### PR TITLE
Removed needless @s change in Bat Grenades

### DIFF
--- a/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
+++ b/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
@@ -1,3 +1,3 @@
-execute as @e[type=bat] at @s run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
-execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] run summon creeper ~ ~ ~ {CustomName:"\"Bat\"",ExplosionRadius:1b,ignited:1b,Fuse:0s,Tags:["GM4_batGrenade"]}
+execute at @e[type=bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
+execute at @e[type=bat] if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] run summon creeper ~ ~ ~ {CustomName:"\"Bat\"",ExplosionRadius:1b,ignited:1b,Fuse:0s,Tags:["GM4_batGrenade"]}
 execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] run data merge entity @s {DeathTime:19,Health:0.0f}


### PR DESCRIPTION
The main function in Bat Grenades changes executioner even though `@s` is only used to change position later. This pull request changes the single `@s` into the `@e[type=bat]` originally used for the `as`