### PR TITLE
Fixed advancement for speed paths

### DIFF
--- a/gm4_speed_paths/data/gm4/advancements/speed_paths.json
+++ b/gm4_speed_paths/data/gm4/advancements/speed_paths.json
@@ -1,7 +1,7 @@
 {
   "display":{
     "icon":{
-      "item":"path_block",
+      "item":"grass_path",
       "nbt":"{display:{Name:\"\\\"speed_paths logo\\\"\"}}"
     },
     "title":"Plain Ol' Advancement Title",


### PR DESCRIPTION
`path_block` was used instead of `grass_path`