### PR TITLE
Change data merge to setblock

### DIFF
--- a/gm4_custom_crafters/data/custom_crafters/functions/create.mcfunction
+++ b/gm4_custom_crafters/data/custom_crafters/functions/create.mcfunction
@@ -1,6 +1,7 @@
 #@s = @e[type=item,nbt=CRAFTING_TABLE] at @s if block ~ ~-1 ~ dropper{CC RECIPE} align xyz positioned ~.5 ~-1 ~.5
 
 summon armor_stand ~ ~.1 ~ {Small:1,NoGravity:1,Marker:1,Invulnerable:1,Invisible:1,DisabledSlots:2039552,Tags:["gm4_no_edit","gm4_custom_crafter"],Fire:200000,CustomName:"\"gm4_custom_crafter\"",ArmorItems:[{},{},{},{id:"crafting_table",Count:1}]}
-data merge block ~ ~ ~ {Items:[],CustomName:"\"Custom Crafter\""}
+setblock ~ ~ ~ minecraft:air
+setblock ~ ~ ~ dropper[facing=up]{Items:[],CustomName:"\"Custom Crafter\""}
 advancement grant @a[distance=..4] only gm4:custom_crafters
 kill @s


### PR DESCRIPTION
Having the block set to air then back to a dropper kicks the player out of the menu in case s/he was inside of it while the custom crafter was being created. This prevents a bug which I have seen many times where the block is renamed to 'Custom Crafter', but you need to go out and back into the dropper to see the renamed block. Until you re-open the menu, it will still just say 'Dropper' as your block entity name.