### PR TITLE
Fix #67 - inconsistent ziprails behavior

### DIFF
--- a/gm4_ziprails/data/ziprails/functions/zipping.mcfunction
+++ b/gm4_ziprails/data/ziprails/functions/zipping.mcfunction
@@ -7,11 +7,13 @@ execute if entity @s[tag=!gm4_linked] if block ~ ~1 ~ tripwire_hook[attached=tru
 
 #teleport carts to rail-trigger height
 execute if entity @s[tag=!gm4_taut_link,tag=gm4_linked] unless block ~ ~ ~ #minecraft:rails align y run teleport @s ~ ~.36250001192093 ~
-execute if entity @s[tag=gm4_linked,tag=gm4_linked] unless block ~ ~ ~ #minecraft:rails run tag @s add gm4_taut_link
+execute if entity @s[tag=gm4_linked] unless block ~ ~ ~ #minecraft:rails run tag @s add gm4_taut_link
 execute if block ~ ~ ~ #minecraft:rails run tag @s remove gm4_taut_link
 
+execute if entity @s[tag=!gm4_taut_link] if block ~ ~1 ~ tripwire_hook[attached=true] run function ziprails:link
+
 #move docked minecarts along their string
-data merge entity @s[tag=gm4_zipping_north] {Motion:[0.0,0.04,-0.3]}
-data merge entity @s[tag=gm4_zipping_south] {Motion:[0.0,0.04,0.3]}
-data merge entity @s[tag=gm4_zipping_east] {Motion:[0.3,0.04,0.0]}
-data merge entity @s[tag=gm4_zipping_west] {Motion:[-0.3,0.04,0.0]}
+data merge entity @s[tag=gm4_taut_link,tag=gm4_zipping_north] {Motion:[0.0,0.04,-0.3]}
+data merge entity @s[tag=gm4_taut_link,tag=gm4_zipping_south] {Motion:[0.0,0.04,0.3]}
+data merge entity @s[tag=gm4_taut_link,tag=gm4_zipping_east] {Motion:[0.3,0.04,0.0]}
+data merge entity @s[tag=gm4_taut_link,tag=gm4_zipping_west] {Motion:[-0.3,0.04,0.0]}


### PR DESCRIPTION
This adds two extra checks which result in more consistent behavior.
1. It only applies the motion if the minecart has the `gm4_taut_link` tag
2. It re-links the minecart if it doesn't have the `gm4_taut_link` and if there's a tripwire above it