### PR TITLE
Zauber Cauldrons Vexmas Update

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4/advancements/zauber_cauldrons_wormhole.json
+++ b/gm4_zauber_cauldrons/data/gm4/advancements/zauber_cauldrons_wormhole.json
@@ -1,0 +1,24 @@
+{
+  "display":{
+    "icon":{
+      "item":"chorus_fruit",
+      "nbt":"{display:{Name:\"\\\"zauber_cauldrons logo\\\"\"}}"
+    },
+    "title":"Questionable Ingredients",
+    "description":{
+      "text":"Just like the rabbits!",
+      "color":"gray"
+    }
+  },
+  "parent":"gm4:zauber_cauldrons_create",
+  "criteria":{
+    "use_wormhole_bottle":{
+      "trigger":"minecraft:consume_item",
+      "conditions":{
+        "item":{
+          "nbt":"{gm4_zauber_cauldrons:{item:\"wormhole_bottle\"}}"
+        }
+      }
+    }
+  }
+}

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/advancements/consume_wormhole_bottle.json
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/advancements/consume_wormhole_bottle.json
@@ -1,0 +1,15 @@
+{
+  "criteria":{
+    "consume_wormhole_bottle":{
+      "trigger":"minecraft:consume_item",
+      "conditions":{
+        "item":{
+          "nbt":"{gm4_zauber_cauldrons:{item:\"wormhole_bottle\"}}"
+        }
+      }
+    }
+  },
+ "rewards":{
+   "function":"zauber_cauldrons:cauldron/wormhole_targeting/choose_dimension"
+ }
+}

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
@@ -1,0 +1,18 @@
+#@s=zauber cauldron with overflow items and bottle(s) inside
+#run from prepare_bottle
+#at allign xyz
+
+#summon bottle and remove one from fullness (bottle is used to be bottled into)
+summon item ~ ~.2 ~ {Item:{id:"minecraft:glass_bottle",Count:1b,tag:{gm4_zauber_cauldrons:{item:"bottled_vex"},Enchantments:[{id:"minecraft:protection",lvl:0s}],display:{Name:"{\"text\":\"Magic in a Bottle\",\"italic\":False}"},HideFlags:1}}}
+
+#store amount of excess items in item nbt
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.vex_count int 1 run scoreboard players get @s gm4_zc_fullness
+
+#store coordinates in nbt
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.x int 1 run data get entity @s Pos.[0]
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.y int 1 run data get entity @s Pos.[1]
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.z int 1 run data get entity @s Pos.[2]
+#store dimension in nbt
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run data get entity @s Dimension
+
+scoreboard players set bottled_possessed_items gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
@@ -1,0 +1,8 @@
+#@s=zauber cauldron with overflow items OR bottled_vex item on ground
+#run from use_extra_items AND release_from_bottle
+#at @s
+
+#summons 1 vex for every unused item entity in a cauldron or every vex in bottle (on recipe processing)
+summon vex ~ ~1.5 ~ {CustomName:"\"Possessed Item\"",CustomNameVisible:0,LifeTicks:320,Attributes:[{Name:generic.attackDamage,Base:2}],Health:4.0,Motion:[0.0,0.25,0.0],ActiveEffects:[{Id:11,Amplifier:10,Duration:20,ShowParticles:0b}]}
+scoreboard players remove @s gm4_zc_fullness 1
+execute if score @s gm4_zc_fullness matches 1.. run function zauber_cauldrons:cauldron/extra_items/create_possessed_items

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/failed_catch_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/failed_catch_possessed_items.mcfunction
@@ -1,0 +1,10 @@
+#@s=zauber cauldron with overflow items and bottle(s) inside
+#run from prepare_bottle
+#at allign xyz
+
+#animation
+particle minecraft:block glass ~ ~.3 ~ 0.12 0.12 0.12 0 23
+playsound minecraft:block.glass.break block @a[distance=..8] ~ ~ ~ 1 1.3
+
+#re-add one to fullness (shards of broken bottle)
+scoreboard players add @s gm4_zc_fullness 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/prepare_bottle.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/prepare_bottle.mcfunction
@@ -1,0 +1,15 @@
+#@s=zauber cauldron with overflow items and bottle(s) inside
+#run from use_extra_items
+#at allign xyz
+
+#remove one from fullness (bottle to be bottled into)
+scoreboard players remove @s gm4_zc_fullness 1
+#copy fullness and take mod 3
+scoreboard players operation mod_fullness gm4_zc_fullness = @s gm4_zc_fullness
+scoreboard players operation mod_fullness gm4_zc_fullness %= modulo gm4_zc_fullness
+
+#catch possessed items if
+execute if score mod_fullness gm4_zc_fullness matches 0 run function zauber_cauldrons:cauldron/extra_items/catch_possessed_items
+
+#failed catch
+execute if score mod_fullness gm4_zc_fullness matches 1.. at @s run function zauber_cauldrons:cauldron/extra_items/failed_catch_possessed_items

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/release_from_bottle.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/release_from_bottle.mcfunction
@@ -1,0 +1,12 @@
+#@s=bottled vex item
+#run from main
+#at @s
+
+scoreboard players add @s gm4_zc_data 1
+#moves vex content to score
+execute if score @s gm4_zc_data matches 2.. store result score @s gm4_zc_fullness run data get entity @s Item.tag.gm4_zauber_cauldrons.vex_count 1
+#release the vexes
+execute if score @s gm4_zc_data matches 2.. run particle minecraft:block glass ~ ~ ~ 0.12 0.12 0.12 0 15
+execute if score @s gm4_zc_data matches 2.. run playsound minecraft:block.glass.break block @a[distance=..8] ~ ~ ~ 1 1.3
+execute if score @s gm4_zc_data matches 2.. run function zauber_cauldrons:cauldron/extra_items/create_possessed_items
+execute if score @s gm4_zc_data matches 2.. run kill @s

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/recipe_checks.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/recipe_checks.mcfunction
@@ -7,6 +7,9 @@
 #make items not pickupable when a player is looking at a cauldron
 execute as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^1.448 if block ~ ~ ~ cauldron align xyz positioned ~.5 ~.5 ~.5 if entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,distance=..0.1] align xyz as @e[type=item,dx=0,dy=0,dz=0] run data merge entity @s {PickupDelay:18s}
 
+#check if cauldron has a bottle and ignore bottles when counting items
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:glass_bottle",Count:1b}},nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}}] run scoreboard players add bottle_count gm4_zc_fullness 1
+
 #set recipe_success to 0
 scoreboard players set recipe_success gm4_zc_data 0
 
@@ -25,6 +28,9 @@ execute if score recipe_success gm4_zc_data matches 0 align xyz if entity @e[typ
 #luck from flowers
 execute if score recipe_success gm4_zc_data matches 0 align xyz if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:grass",Count:1b}}] if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"enchanted_prismarine_shard"}},Count:1b}}] run function zauber_cauldrons:recipes/flowers/check_poisonous_flowers
 
+#wormhole in a bottle
+execute if score recipe_success gm4_zc_data matches 0 align xyz if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}},Count:1b}}] if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"enchanted_prismarine_shard"}},Count:1b}}] run function zauber_cauldrons:recipes/chorus/count_chorus
 
 #reset fake players
 scoreboard players reset recipe_success gm4_zc_data
+scoreboard players reset bottle_count gm4_zc_fullness

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/use_extra_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/use_extra_items.mcfunction
@@ -1,7 +1,16 @@
-#@s=zauber cauldron
+#@s=zauber cauldron with overflow items
 #run from recipes
+#at @s
 
-#summons 1 vex for every unused item entity in a cauldron (on recipe processing)
-summon vex ~ ~1.5 ~ {CustomName:"\"Possessed Item\"",CustomNameVisible:0,LifeTicks:320,Attributes:[{Name:generic.attackDamage,Base:2}],Health:4.0,Motion:[0.0,0.25,0.0]}
-scoreboard players remove @s gm4_zc_fullness 1
-execute if score @s gm4_zc_fullness > expected_item_amount gm4_zc_fullness run function zauber_cauldrons:cauldron/use_extra_items
+#calculate how many excess items are in the recipe
+scoreboard players operation @s gm4_zc_fullness -= expected_item_amount gm4_zc_fullness
+
+#absorb possessed items into a bottle if present
+scoreboard players set bottled_possessed_items gm4_zc_data 0
+execute if score bottle_count gm4_zc_fullness matches 1.. if score @s gm4_zc_fullness matches 2.. align xyz run function zauber_cauldrons:cauldron/extra_items/prepare_bottle
+
+#summon possessed items if no bottle present
+execute if score bottled_possessed_items gm4_zc_data matches 0 run function zauber_cauldrons:cauldron/extra_items/create_possessed_items
+
+#reset fake players
+scoreboard players reset bottled_possessed_items gm4_zc_data

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/arrival_animation.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/arrival_animation.mcfunction
@@ -1,0 +1,11 @@
+# @s player consuming wormhole_bottle
+# at @s in depending on call
+# run from cauldron/wormhole_targeting/teleport_to_dimension
+
+#particles and sound
+particle minecraft:portal ~ ~.6 ~ .25 .25 .25 0 100
+playsound minecraft:entity.enderman.teleport player @a[distance=..8] ~ ~ ~ 1 .3
+
+#explosion if no cauldron in target block
+execute align xyz unless entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,dx=0,dy=0,dz=0] run summon tnt
+execute align xyz unless entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,dx=0,dy=0,dz=0] run playsound minecraft:entity.generic.explode block @s

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/choose_dimension.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/choose_dimension.mcfunction
@@ -1,0 +1,19 @@
+# @s player consuming wormhole_bottle
+# at @s
+# run from advancement zauber_cauldrons:consume_wormhole_bottle
+
+#effect player with resistance
+execute unless entity @s[nbt={ActiveEffects:[{Id:11b,Ambient:0b}]}] run effect give @s minecraft:resistance 1 12 true
+#particles and sound for depart
+particle minecraft:portal ~ ~.6 ~ .25 .25 .25 0 100
+playsound minecraft:entity.enderman.teleport player @a[distance=1..8] ~ ~ ~ 1 .3
+#summon marker for teleportation
+summon area_effect_cloud ~ ~ ~ {Tags:["gm4_zc_wormhole_target","gm4_zc_new_wormhole_target"],Duration:1}
+
+#chose dimension
+execute if score @s gm4_zc_warp_d matches 0 in minecraft:overworld run function zauber_cauldrons:cauldron/wormhole_targeting/teleport_to_dimension
+execute if score @s gm4_zc_warp_d matches 1 in minecraft:the_end run function zauber_cauldrons:cauldron/wormhole_targeting/teleport_to_dimension
+execute if score @s gm4_zc_warp_d matches -1 in minecraft:the_nether run function zauber_cauldrons:cauldron/wormhole_targeting/teleport_to_dimension
+
+#revoke advancement for next teleport
+advancement revoke @s only zauber_cauldrons:consume_wormhole_bottle

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/teleport_to_dimension.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/wormhole_targeting/teleport_to_dimension.mcfunction
@@ -1,0 +1,19 @@
+# @s player consuming wormhole_bottle
+# at @s in depending on call
+# run from cauldron/wormhole_targeting/choose_dimension
+
+#warp marker to the chosen dimension
+tp @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target,tag=gm4_zc_new_wormhole_target,limit=1] ~ ~ ~
+
+#teleport marker
+execute store result entity @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target,tag=gm4_zc_new_wormhole_target,limit=1] Pos.[0] double 1 run scoreboard players get @s gm4_zc_warp_x
+execute store result entity @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target,tag=gm4_zc_new_wormhole_target,limit=1] Pos.[1] double 1 run scoreboard players get @s gm4_zc_warp_y
+execute store result entity @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target,tag=gm4_zc_new_wormhole_target,limit=1] Pos.[2] double 1 run scoreboard players get @s gm4_zc_warp_z
+
+#teleport player
+execute at @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target,tag=gm4_zc_new_wormhole_target,limit=1] run tp @s ~.5 ~.7 ~.5
+execute at @s run function zauber_cauldrons:cauldron/wormhole_targeting/arrival_animation
+#check for cauldron at destination
+
+
+tag @e[type=area_effect_cloud,tag=gm4_zc_wormhole_target] remove gm4_zc_new_wormhole_target

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/init.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/init.mcfunction
@@ -4,15 +4,22 @@ execute unless entity @p run say GM4: Installing Zauber Cauldrons...
 
 #declare and initialise scoreboards and settings
 scoreboard players set update_happened gm4_up_check 1
-scoreboard players set zauber_cauldrons gm4_modules 1
+scoreboard players set zauber_cauldrons gm4_modules 2
 scoreboard players set zauber_cauldrons gm4_clock_tick 0
 
 #create needed scoreboards
 scoreboard objectives add gm4_zc_data dummy "gm4_zauber_cauldrons_data"
 scoreboard objectives add gm4_zc_flowers dummy "gm4_zauber_cauldrons_flowers"
+scoreboard objectives add gm4_zc_chorus dummy "gm4_zauber_cauldrons_chorus"
 scoreboard objectives add gm4_zc_fullness dummy "gm4_zauber_cauldrons_fullness"
 scoreboard objectives add gm4_zc_deaths deathCount "gm4_zauber_cauldrons_deaths"
+scoreboard objectives add gm4_zc_warp_x dummy "gm4_zauber_cauldrons_warp_x"
+scoreboard objectives add gm4_zc_warp_y dummy "gm4_zauber_cauldrons_warp_y"
+scoreboard objectives add gm4_zc_warp_z dummy "gm4_zauber_cauldrons_warp_z"
+scoreboard objectives add gm4_zc_warp_d dummy "gm4_zauber_cauldrons_warp_d"
 function zauber_cauldrons:recipes/flowers/initiate_flower_types
+function zauber_cauldrons:recipes/chorus/initiate_chorus_amounts
+scoreboard players set modulo gm4_zc_fullness 3
 
 #announce success
 tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Zauber Cauldrons Installed!"}]

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/init_check.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/init_check.mcfunction
@@ -1,3 +1,3 @@
 #unless the module is already initialized
-execute unless score zauber_cauldrons gm4_modules matches 1.. run function zauber_cauldrons:init
+execute unless score zauber_cauldrons gm4_modules matches 2 run function zauber_cauldrons:init
 scoreboard players add installed_modules gm4_up_check 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/main.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/main.mcfunction
@@ -13,11 +13,18 @@ scoreboard players reset @a[scores={gm4_zc_deaths=1..}] gm4_zc_deaths
 effect give @a[gamemode=!spectator,tag=gm4_zc_luck] minecraft:luck 8 0 true
 
 #apply crystal effects
-scoreboard players add crystals_clock gm4_zc_data 1
-execute if score crystals_clock gm4_zc_data matches 3.. as @a[gamemode=!spectator,tag=gm4_zc_luck,nbt={Inventory:[{Slot:-106b,id:"minecraft:player_head",tag:{gm4_zauber_cauldrons:{item:"crystal"}}}]}] run function zauber_cauldrons:recipes/crystals/apply_effects
+scoreboard players add slow_clock gm4_zc_data 1
+execute if score slow_clock gm4_zc_data matches 3.. as @a[gamemode=!spectator,tag=gm4_zc_luck,nbt={Inventory:[{Slot:-106b,id:"minecraft:player_head",tag:{gm4_zauber_cauldrons:{item:"crystal"}}}]}] run function zauber_cauldrons:recipes/crystals/apply_effects
 #grant full zauber armor advancement
-execute if score crystals_clock gm4_zc_data matches 3.. run advancement grant @a[gamemode=!spectator,nbt={Inventory:[{Slot:100b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:101b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:102b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:103b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}]}] only gm4:zauber_cauldrons_full_armor
-execute if score crystals_clock gm4_zc_data matches 3.. run scoreboard players set crystals_clock gm4_zc_data 0
+execute if score slow_clock gm4_zc_data matches 3.. run advancement grant @a[gamemode=!spectator,nbt={Inventory:[{Slot:100b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:101b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:102b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}},{Slot:103b,tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}]}] only gm4:zauber_cauldrons_full_armor
+
+#release vexes from bottled vexes
+execute if score slow_clock gm4_zc_data matches 3.. as @e[type=item,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}}] at @s run function zauber_cauldrons:cauldron/extra_items/release_from_bottle
+execute if score slow_clock gm4_zc_data matches 3.. run scoreboard players set slow_clock gm4_zc_data 0
+
+#wormhole in a bottle consumption
+execute as @a[gamemode=!spectator,nbt={SelectedItem:{id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}}] run function zauber_cauldrons:recipes/chorus/store_mainhand_coordinates
+execute as @a[gamemode=!spectator,nbt={Inventory:[{Slot:-106b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}]},nbt=!{SelectedItem:{id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}}] run function zauber_cauldrons:recipes/chorus/store_offhand_coordinates
 
 #restore broken crystals
 data merge entity @e[type=item,limit=1,nbt={Item:{tag:{SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab419a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODc4ODY4MjcsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS83MmRkMTkxZDgxYzg4NDUzYzVlM2JjMWJlMjFkYjVhMTkyZDUyNmI3MTg2YjJmNjk0ZjI4Y2JkZmNjYzYyYzNhIn19fQ=="}]}}}}}] {Item:{tag:{gm4_zauber_cauldrons:{item:"crystal",type:"resistance"},HideFlags:1,display:{Name:"\"§eCrystal of Resistance§r\""}}}}

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/blurry_wormhole.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/blurry_wormhole.mcfunction
@@ -1,0 +1,50 @@
+#@s=boiling zauber cauldron with recipe inside
+#at @s align xyz
+#run from count_chorus
+
+#generate random coordinate offset from UUID of items in cauldron
+execute store result score dx gm4_zc_data run data get entity @e[type=item,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] UUIDMost -.000000000000000001
+execute store result score dy gm4_zc_data run data get entity @e[type=item,nbt={Item:{id:"minecraft:chorus_fruit"}},limit=1] UUIDMost -.000000000000000001
+execute store result score dz gm4_zc_data run data get entity @e[type=item,nbt={Item:{id:"minecraft:popped_chorus_fruit"}},limit=1] UUIDMost -.000000000000000001
+
+#get bottled_vex cauldron pos
+execute store result score x gm4_zc_data run data get entity @e[type=item,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.x
+execute store result score y gm4_zc_data run data get entity @e[type=item,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.y
+execute store result score z gm4_zc_data run data get entity @e[type=item,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.z
+
+#add random offset (target coordinates)
+scoreboard players operation x gm4_zc_data += dx gm4_zc_data
+scoreboard players operation y gm4_zc_data += dy gm4_zc_data
+scoreboard players operation z gm4_zc_data += dz gm4_zc_data
+
+#summon resulting item marked with no kill tag
+execute at @s run summon item ~ ~.2 ~ {Tags:["gm4_zc_new_wormhole_bottle"],Item:{id:potion,Count:1b,tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"},Potion:"minecraft:thick",CustomPotionColor:6358357,Enchantments:[{id:"minecraft:protection",lvl:0s}],HideFlags:33,display:{Name:"{\"text\":\"Wormhole in a Bottle\",\"italic\":False,\"color:\":\"aqua\"}"}}}}
+
+#copy target coordinates to new item
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.x int 1 run scoreboard players get x gm4_zc_data
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.y int 1 run scoreboard players get y gm4_zc_data
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.z int 1 run scoreboard players get z gm4_zc_data
+#copy target dimension to new item
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.dimension
+
+#kill remaining items
+kill @e[type=item,tag=!gm4_zc_new_wormhole_bottle,dx=0,dy=0,dz=0]
+tag @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] remove gm4_zc_new_wormhole_bottle
+
+#if one, popped or raw chorus, was more than required, turn those into vexes
+execute if score raw_chorus_fullness gm4_zc_chorus matches 1.. run scoreboard players operation @s gm4_zc_fullness += raw_chorus_fullness gm4_zc_chorus
+execute if score popped_chorus_fullness gm4_zc_chorus matches 1.. run scoreboard players operation @s gm4_zc_fullness += popped_chorus_fullness gm4_zc_chorus
+
+#cosmetics
+execute at @s run particle minecraft:witch ~ ~.3 ~ .1 .1 .1 1 7
+execute at @s run playsound minecraft:entity.ender_eye.death master @a[distance=..8] ~ ~ ~ 1 .6
+
+scoreboard players set recipe_success gm4_zc_data 1
+
+#reset fake players
+scoreboard players reset dx gm4_zc_data
+scoreboard players reset dy gm4_zc_data
+scoreboard players reset dz gm4_zc_data
+scoreboard players reset x gm4_zc_data
+scoreboard players reset y gm4_zc_data
+scoreboard players reset z gm4_zc_data

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/count_chorus.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/count_chorus.mcfunction
@@ -1,0 +1,36 @@
+#@s=boiling zauber cauldron with bottled vex and enchanted_prismarine_shard inside.
+#at align xyz
+#run from cauldron/recipe_checks NOWHERE RN
+
+#initialise fake players
+scoreboard players set cancel_recipe gm4_zc_data 0
+
+#set expected fullness for these recipes (stack chorus+stack popped chorus+enchanted_prismarine_shard+bottled vex)
+scoreboard players set expected_item_amount gm4_zc_fullness 4
+
+#read count from chorus fruit stacks
+execute store result score raw_chorus_fullness gm4_zc_chorus run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:chorus_fruit"}},limit=1] Item.Count 1
+execute store result score popped_chorus_fullness gm4_zc_chorus run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:popped_chorus_fruit"}},limit=1] Item.Count 1
+
+#cancel recipe if one of the ingredients is missing
+execute if score raw_chorus_fullness gm4_zc_chorus matches 0 run scoreboard players set cancel_recipe gm4_zc_data 2
+execute if score popped_chorus_fullness gm4_zc_chorus matches 0 run scoreboard players set cancel_recipe gm4_zc_data 2
+
+#check count against seed based count
+execute unless score cancel_recipe gm4_zc_data matches 2 run scoreboard players operation raw_chorus_fullness gm4_zc_chorus -= required_chorus_fruit gm4_zc_chorus
+execute unless score cancel_recipe gm4_zc_data matches 2 run scoreboard players operation popped_chorus_fullness gm4_zc_chorus -= required_popped_chorus_fruit gm4_zc_chorus
+
+#start incomplete recipe
+execute unless score cancel_recipe gm4_zc_data matches 2 if score raw_chorus_fullness gm4_zc_chorus matches ..-1 run scoreboard players set cancel_recipe gm4_zc_data 1
+execute unless score cancel_recipe gm4_zc_data matches 2 if score popped_chorus_fullness gm4_zc_chorus matches ..-1 run scoreboard players set cancel_recipe gm4_zc_data 1
+execute if score cancel_recipe gm4_zc_data matches 1 run function zauber_cauldrons:recipes/chorus/blurry_wormhole
+
+#start complete recipe
+execute if score cancel_recipe gm4_zc_data matches 0 run function zauber_cauldrons:recipes/chorus/precise_wormhole
+
+#use water and play sound once a recipe ran
+execute if score recipe_success gm4_zc_data matches 1 at @s if score @s gm4_zc_fullness > expected_item_amount gm4_zc_fullness run function zauber_cauldrons:cauldron/use_extra_items
+execute if score recipe_success gm4_zc_data matches 1 at @s run function zauber_cauldrons:cauldron/use_water
+
+#reset fake players
+scoreboard players reset cancel_recipe gm4_zc_data

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/initiate_chorus_amounts.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/initiate_chorus_amounts.mcfunction
@@ -1,0 +1,28 @@
+#no @s.
+#at world spawn
+#called by init
+
+#randomly marks flower types as poisonous on module installation
+
+#initialise fixed values
+scoreboard players set modulo gm4_zc_chorus 64
+scoreboard players set divider gm4_zc_chorus 10
+
+#copy seed to scoreboard
+execute store result score seed gm4_zc_chorus run seed
+
+#set chorus and popped chorus to a digit of the seed
+scoreboard players operation required_chorus_fruit gm4_zc_chorus = seed gm4_zc_chorus
+scoreboard players operation required_chorus_fruit gm4_zc_chorus /= divider gm4_zc_chorus
+scoreboard players operation required_popped_chorus_fruit gm4_zc_chorus = required_chorus_fruit gm4_zc_chorus
+scoreboard players operation required_popped_chorus_fruit gm4_zc_chorus /= divider gm4_zc_chorus
+
+#scale down to 1-64 (mod64):
+scoreboard players operation required_chorus_fruit gm4_zc_chorus %= modulo gm4_zc_chorus
+scoreboard players operation required_popped_chorus_fruit gm4_zc_chorus %= modulo gm4_zc_chorus
+scoreboard players add required_chorus_fruit gm4_zc_chorus 1
+scoreboard players add required_popped_chorus_fruit gm4_zc_chorus 1
+
+#count total
+scoreboard players operation required_total gm4_zc_chorus = required_chorus_fruit gm4_zc_chorus
+scoreboard players operation required_total gm4_zc_chorus += required_popped_chorus_fruit gm4_zc_chorus

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/precise_wormhole.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/precise_wormhole.mcfunction
@@ -1,0 +1,27 @@
+#@s=boiling zauber cauldron with recipe inside
+#at @s align xyz
+#run from count_chorus
+
+#summon resulting item marked with no kill tag
+execute at @s run summon item ~ ~.2 ~ {Tags:["gm4_zc_new_wormhole_bottle"],Item:{id:potion,Count:1b,tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"},Potion:"minecraft:thick",CustomPotionColor:8587123,Enchantments:[{id:"minecraft:protection",lvl:0s}],HideFlags:33,display:{Name:"{\"text\":\"Wormhole in a Bottle\",\"italic\":False,\"color:\":\"aqua\"}"}}}}
+
+#copy target coordinates to new item
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.x int 1 run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.x
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.y int 1 run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.y
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.z int 1 run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.z
+#copy taget dimension to new item
+execute store result entity @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run data get entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.cauldron_pos.dimension
+
+#kill remaining items
+kill @e[type=item,tag=!gm4_zc_new_wormhole_bottle,dx=0,dy=0,dz=0]
+tag @e[type=item,dx=0,dy=0,dz=0,tag=gm4_zc_new_wormhole_bottle,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"wormhole_bottle"}}}},limit=1] remove gm4_zc_new_wormhole_bottle
+
+#cosmetics
+execute at @s run particle minecraft:witch ~ ~.3 ~ .1 .1 .1 1 17
+execute at @s run playsound minecraft:entity.ender_eye.death master @a[distance=..8] ~ ~ ~ 1 .2
+
+#add oversized stacks to cauldron fullness to summon vexes
+scoreboard players operation @s gm4_zc_fullness += raw_chorus_fullness gm4_zc_chorus
+scoreboard players operation @s gm4_zc_fullness += popped_chorus_fullness gm4_zc_chorus
+
+scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/store_mainhand_coordinates.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/store_mainhand_coordinates.mcfunction
@@ -1,0 +1,8 @@
+# @s = player holding a wormhole_bottle either in the offhand OR (exclusive) in the mainhand
+# at world spawn
+
+#store coordinates from item into scoreboard
+execute store result score @s gm4_zc_warp_x run data get entity @s SelectedItem.tag.gm4_zauber_cauldrons.cauldron_pos.x
+execute store result score @s gm4_zc_warp_y run data get entity @s SelectedItem.tag.gm4_zauber_cauldrons.cauldron_pos.y
+execute store result score @s gm4_zc_warp_z run data get entity @s SelectedItem.tag.gm4_zauber_cauldrons.cauldron_pos.z
+execute store result score @s gm4_zc_warp_d run data get entity @s SelectedItem.tag.gm4_zauber_cauldrons.cauldron_pos.dimension

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/store_offhand_coordinates.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/chorus/store_offhand_coordinates.mcfunction
@@ -1,0 +1,5 @@
+# @s = player holding a wormhole_bottle either in the offhand OR (exclusive) in the mainhand
+# at world spawn
+
+#NOT SUPPORTED TIL 1.14
+title @s actionbar ["",{"text":"offhand not supported in versions below 1.14!","color":"red"}]

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/blast_protection.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/blast_protection.mcfunction
@@ -3,5 +3,5 @@
 #run from zauber_potions
 
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
-summon item ~ ~.2 ~ {Item:{id:"player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"resistance"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab419a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODc4ODY4MjcsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS83MmRkMTkxZDgxYzg4NDUzYzVlM2JjMWJlMjFkYjVhMTkyZDUyNmI3MTg2YjJmNjk0ZjI4Y2JkZmNjYzYyYzNhIn19fQ=="}]}},HideFlags:1,display:{Name:"\"§eCrystal of Resistance§r\""}}}}
+summon item ~ ~.2 ~ {Item:{id:"player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"resistance"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab419a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODc4ODY4MjcsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS83MmRkMTkxZDgxYzg4NDUzYzVlM2JjMWJlMjFkYjVhMTkyZDUyNmI3MTg2YjJmNjk0ZjI4Y2JkZmNjYzYyYzNhIn19fQ=="}]}},HideFlags:1,display:{Name:"{\"text\":\"Crystal of Resistance\",\"italic\":False,\"color:\":\"yellow\"}"}}}}
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/fire_protection.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/fire_protection.mcfunction
@@ -3,5 +3,5 @@
 #run from zauber_potions
 
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
-summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"fire_resistance"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab429a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODgyNDc2MDMsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS81OGQ4ZWZjODJlMzQyYmI4MTRmYTc3YTZlNzFmMzNiMGU1YTVkOGI1ZmJiOTI0N2YxOTQ2ZjBmZWI0ODMzNyJ9fX0="}]}},HideFlags:1,display:{Name:"\"§eCrystal of Fire Resistance§r\""}}}}
+summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"fire_resistance"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab429a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODgyNDc2MDMsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS81OGQ4ZWZjODJlMzQyYmI4MTRmYTc3YTZlNzFmMzNiMGU1YTVkOGI1ZmJiOTI0N2YxOTQ2ZjBmZWI0ODMzNyJ9fX0="}]}},HideFlags:1,display:{Name:"{\"text\":\"Crystal of Fire Resistance\",\"italic\":False,\"color:\":\"yellow\"}"}}}}
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/projectile_protection.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/projectile_protection.mcfunction
@@ -3,5 +3,5 @@
 #run from zauber_potions
 
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
-summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"speed"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab439a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODg0MTI0MTksInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zNDY0MTcxY2Y2ZTJiOWMwYTI1MjRhZGYzZGI0MjdmNWQ1NzdiM2E2YWFmOTIyNDlmZTI4MWM3YzMwNDdmZSJ9fX0="}]}},HideFlags:1,display:{Name:"\"§eCrystal of Speed§r\""}}}}
+summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"speed"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab439a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODg0MTI0MTksInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zNDY0MTcxY2Y2ZTJiOWMwYTI1MjRhZGYzZGI0MjdmNWQ1NzdiM2E2YWFmOTIyNDlmZTI4MWM3YzMwNDdmZSJ9fX0="}]}},HideFlags:1,display:{Name:"{\"text\":\"Crystal of Speed\",\"italic\":False,\"color:\":\"yellow\"}"}}}}
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/protection.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/crystals/protection.mcfunction
@@ -3,5 +3,5 @@
 #run from zauber_potions
 
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
-summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"regeneration"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab449a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODYzMDA0MTcsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9lNzZmNDQ5MTI2MjQxOTM2ZDE3ODZhNDAyZGY2ZjQ2NWU1ZTdiMjhlZWQzNWFiNzY3MWYwZDI2YjJjZTZlMyJ9fX0="}]}},HideFlags:1,display:{Name:"\"§eCrystal of Regeneration§r\""}}}}
+summon item ~ ~.2 ~ {Item:{id:"minecraft:player_head",Count:1b,tag:{gm4_zauber_cauldrons:{item:"crystal",type:"regeneration"},SkullOwner:{Id:"d15e515a-2058-459a-bfe9-ab449a0d2e7c",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0NzY4ODYzMDA0MTcsInByb2ZpbGVJZCI6ImQxNWU1MTVhMjA1ODQ1OWFiZmU5ZmY1NzlhMGQyZTdjIiwicHJvZmlsZU5hbWUiOiJCbHVlZmlyZTYxMCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9lNzZmNDQ5MTI2MjQxOTM2ZDE3ODZhNDAyZGY2ZjQ2NWU1ZTdiMjhlZWQzNWFiNzY3MWYwZDI2YjJjZTZlMyJ9fX0="}]}},HideFlags:1,display:{Name:"{\"text\":\"Crystal of Regeneration\",\"italic\":False,\"color:\":\"yellow\"}"}}}}
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/flowers/check_poisonous_flowers.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/flowers/check_poisonous_flowers.mcfunction
@@ -7,7 +7,7 @@ scoreboard players set cancel_recipe gm4_zc_data 0
 #set expected fullness for these recipes
 scoreboard players operation expected_item_amount gm4_zc_fullness = required_flowers gm4_zc_flowers
 #add two to expected items (grass and enchanted_prismarine_shard)
-scoreboard players operation expected_item_amount gm4_zc_fullness += modulo gm4_zc_flowers
+scoreboard players add expected_item_amount gm4_zc_fullness 2
 
 #poisonous flowers set flag to abort recipe checks
 execute if score red_tulip gm4_zc_flowers matches 1 if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:red_tulip"}}] run scoreboard players set cancel_recipe gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/precursors/prismarine_shard.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/recipes/precursors/prismarine_shard.mcfunction
@@ -6,7 +6,7 @@
 scoreboard players set expected_item_amount gm4_zc_fullness 1
 #recipe
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
-summon item ~ ~.2 ~ {Item:{id:"minecraft:prismarine_shard",Count:1b,tag:{Enchantments:[{lvl:1s,id:"minecraft:unbreaking"}],gm4_zauber_cauldrons:{item:"enchanted_prismarine_shard"},HideFlags:1,display:{Name:"\"§bEnchanted Prismarine Shard§r\""}}}}
+summon item ~ ~.2 ~ {Item:{id:"minecraft:prismarine_shard",Count:1b,tag:{Enchantments:[{lvl:1s,id:"minecraft:unbreaking"}],gm4_zauber_cauldrons:{item:"enchanted_prismarine_shard"},HideFlags:1,display:{Name:"{\"text\":\"Enchanted Prismarine Shard\",\"italic\":False,\"color:\":\"aqua\"}"}}}}
 experience add @a[level=30..,distance=..2,limit=1,sort=nearest] -30 levels
 playsound block.portal.travel block @a[distance=..16] ~ ~ ~ .2 1.2
 particle enchanted_hit ~ ~.4 ~ .1 .1 .1 .15 10

--- a/gm4_zauber_cauldrons/pack.mcmeta
+++ b/gm4_zauber_cauldrons/pack.mcmeta
@@ -1,25 +1,6 @@
 {
-  "pack":{
-    "pack_format":0,
-    "description":"A Gamemode 4 Module"
-  },
-  "module_name":"Zauber Cauldrons",
-  "module_id":"zauber_cauldrons",
-  "site_description":"Brew potions, special armour and attribute crystals in any cauldron!",
-  "site_categories":[],
-  "video_link":"https://www.youtube.com/watch?v=Io1JTFUzyrc",
-  "wiki_link":"https://wiki.gm4.co/wiki/Zauber_Cauldrons",
-  "required_modules":[],
-  "recommended_modules":[],
-  "credits":{
-    "Creator":[
-      ["Bluefire610","https://www.twitter.com/Bluefire610"]
-    ],
-    "Updated by":[
-      ["Bluefire610","https://www.twitter.com/bluefire610"]
-    ],
-    "Icon Design":[
-      ["DuckJr","https://twitter.com/DuckJr94"]
-    ]
-  }
+    "pack":{
+        "pack_format":0,
+        "description":"A Gamemode 4 Module"
+    }
 }

--- a/gm4_zauber_cauldrons/pack.mcmeta
+++ b/gm4_zauber_cauldrons/pack.mcmeta
@@ -1,6 +1,25 @@
 {
-    "pack":{
-        "pack_format":0,
-        "description":"A Gamemode 4 Module"
-    }
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Zauber Cauldrons",
+  "module_id":"zauber_cauldrons",
+  "site_description":"Brew potions, special armour and attribute crystals in any cauldron!",
+  "site_categories":[],
+  "video_link":"https://www.youtube.com/watch?v=Io1JTFUzyrc",
+  "wiki_link":"https://wiki.gm4.co/wiki/Zauber_Cauldrons",
+  "required_modules":[],
+  "recommended_modules":[],
+  "credits":{
+    "Creator":[
+      ["Bluefire610","https://www.twitter.com/Bluefire610"]
+    ],
+    "Updated by":[
+      ["Bluefire610","https://www.twitter.com/bluefire610"]
+    ],
+    "Icon Design":[
+      ["DuckJr","https://twitter.com/DuckJr94"]
+    ]
+  }
 }


### PR DESCRIPTION
**Feature Changes**

- Added _Magic in a Bottle_:
        - Created by adding an empty bottle to any recipe with items that are not required for the recipe 
           (spawns vexes). Only works when the amount of Possessed Items that would be created is a 
           multiple of 3.
        - Stores Possessed Items inside that can be released by letting the bottle sit on the ground.
- Added _Wormhole in a Bottle_:
        - Made using a bottle of _Magic in a Bottle_, an Enchanted Prismarine Shard and 1-64 raw as well 
           as popped chorus, the latter being dependent on the seed.
        - Teleports to the location the _Magic in a Bottle_ was made at upon consumption, even across 
          dimensions.
        - Safe if the cauldron still exists, explosive if it doesn't
        - Not supplying enough chorus makes to teleport blurry

**Technical Changes**

- Item names now use proper JSON components