### PR TITLE
Create Squids by Dropping a lightning rod on Dried Kelp Block

### DIFF
--- a/gm4_lightning_rods/data/lightning_rods/functions/boom.mcfunction
+++ b/gm4_lightning_rods/data/lightning_rods/functions/boom.mcfunction
@@ -2,6 +2,7 @@
 
 execute if block ~ ~-1 ~ spawner{SpawnData:{id:"minecraft:creeper"}} run data merge block ~ ~-1 ~ {MaxSpawnDelay:801s,SpawnData:{id:"minecraft:creeper",powered:true},SpawnPotentials:[{Entity:{id:"minecraft:creeper",powered:true},Weight:1}]}
 execute if block ~ ~-1 ~ purpur_block run function lightning_rods:create_shulker
+execute if block ~ ~-1 ~ dried_kelp_block run function lightning_rods:create_squid
 
 summon lightning_bolt
 kill @s

--- a/gm4_lightning_rods/data/lightning_rods/functions/create_squid.mcfunction
+++ b/gm4_lightning_rods/data/lightning_rods/functions/create_squid.mcfunction
@@ -1,3 +1,3 @@
 setblock ~ ~-1 ~ air
-summon squid ~ ~-1 ~ {ActiveEffects:[{Id:10b,Amplifier:3b,Duration:100,ShowParticles:1b}]}
+summon squid ~ ~-1 ~ {ActiveEffects:[{Id:10b,Amplifier:3b,Duration:100,ShowParticles:0b}]}
 

--- a/gm4_lightning_rods/data/lightning_rods/functions/create_squid.mcfunction
+++ b/gm4_lightning_rods/data/lightning_rods/functions/create_squid.mcfunction
@@ -1,0 +1,3 @@
+setblock ~ ~-1 ~ air
+summon squid ~ ~-1 ~ {ActiveEffects:[{Id:10b,Amplifier:3b,Duration:100,ShowParticles:1b}]}
+


### PR DESCRIPTION
Gamemode 4 Public Server V has an issue where due to the player count, spawning of squids in oceans is limited, which led to wanting a way to create them that was not just a spawner. Building on the idea that shocking a purpur block give a shulker, the most logical thing to create a squid that was sea related was the  dried kelp block.

Notes:
- Checks for Dried Kelp Block below, like purpur
- Squid is spawned with a few seconds of resistance so it does not die from suffocation or fire caused by lightning rods