### PR TITLE
Fix bug with Tier 2 Heart Canister counting

### DIFF
--- a/gm4_heart_canisters/data/heart_canisters/functions/check_heart_canisters.mcfunction
+++ b/gm4_heart_canisters/data/heart_canisters/functions/check_heart_canisters.mcfunction
@@ -7,8 +7,8 @@ scoreboard players set @s[nbt={Inventory:[{Count:3b,tag:{gm4_heart_canister_tier
 scoreboard players set @s[nbt={Inventory:[{Count:4b,tag:{gm4_heart_canister_tier:1b}}]}] gm4_heart_can 4
 scoreboard players set @s[nbt={Inventory:[{Count:5b,tag:{gm4_heart_canister_tier:1b}}]}] gm4_heart_can 5
 
-scoreboard players add @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:1b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 1
-scoreboard players add @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:2b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 2
-scoreboard players add @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:3b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 3
-scoreboard players add @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:4b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 4
-scoreboard players add @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:5b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 5
+scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:1b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 6
+scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:2b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 7
+scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:3b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 8
+scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:4b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 9
+scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{Count:5b,tag:{gm4_heart_canister_tier:2b}}]}] gm4_heart_can 10


### PR DESCRIPTION
Using "add" means it can go beyond 10 and up to 20 if you have multiple stacks of canisters with possible values 1, 2, 3, 4, and 5. I've fixed it so Tier 2 counting works in the same way as Tier 1 counting, thus avoiding this issue.