### PR TITLE
Increase Likelyhood of Mysterious Midnights

### DIFF
--- a/gm4_mysterious_midnights/data/mysterious_midnights/functions/expansion_selection/calculate_midnight_difficulty.mcfunction
+++ b/gm4_mysterious_midnights/data/mysterious_midnights/functions/expansion_selection/calculate_midnight_difficulty.mcfunction
@@ -7,10 +7,10 @@ execute store result score random gm4_nights_data run data get entity @e[limit=1
 scoreboard players operation random gm4_nights_data %= 16 gm4_nights_data
 
 #manipulate moon_phase to cancel 53% of mysterious_midnights
-execute if score random gm4_nights_data matches 0..8 run scoreboard players set moon_phase gm4_nights_data 1
+execute if score random gm4_nights_data matches 0..5 run scoreboard players set moon_phase gm4_nights_data 1
 
 #remember that a mysterious midnight was attempted
 scoreboard players set send_night_end_pulse gm4_nights_data 1
 
 #select expansion depending on rarity, in case a mysterious midnight occured
-execute if score random gm4_nights_data matches 9.. run function mysterious_midnights:expansion_selection/start_expansion
+execute if score random gm4_nights_data matches 6.. run function mysterious_midnights:expansion_selection/start_expansion

--- a/gm4_mysterious_midnights/data/mysterious_midnights/functions/expansion_selection/start_expansion.mcfunction
+++ b/gm4_mysterious_midnights/data/mysterious_midnights/functions/expansion_selection/start_expansion.mcfunction
@@ -6,11 +6,11 @@
 playsound entity.wolf.howl weather @a ~ ~10000 ~ 0 1 1
 
 #common
-execute if score random gm4_nights_data matches 9..12 run function #mysterious_midnights:common_expansion
+execute if score random gm4_nights_data matches 6..10 run function #mysterious_midnights:common_expansion
 #uncommon
-execute if score random gm4_nights_data matches 13..14 run function #mysterious_midnights:uncommon_expansion
+execute if score random gm4_nights_data matches 11..13 run function #mysterious_midnights:uncommon_expansion
 #rare
-execute if score random gm4_nights_data matches 15.. run function #mysterious_midnights:rare_expansion
+execute if score random gm4_nights_data matches 14.. run function #mysterious_midnights:rare_expansion
 
 #chose one expansion
 tag @e[type=area_effect_cloud,tag=gm4_mysterious_midnights_expansion,limit=1,sort=random] add gm4_mysterious_midnights_active

--- a/gm4_mysterious_midnights/data/mysterious_midnights/functions/send_night_end_pulse.mcfunction
+++ b/gm4_mysterious_midnights/data/mysterious_midnights/functions/send_night_end_pulse.mcfunction
@@ -9,7 +9,7 @@ scoreboard players set send_night_end_pulse gm4_nights_data 0
 scoreboard players set moon_phase gm4_nights_data -1
 
 #send night end pulse to expansions
-execute if score random gm4_nights_data matches 9.. run function #mysterious_midnights:dawn_event
+execute if score random gm4_nights_data matches 6.. run function #mysterious_midnights:dawn_event
 
 #end expansion activity
 kill @e[type=area_effect_cloud,tag=gm4_mysterious_midnights_expansion,tag=gm4_mysterious_midnights_active]


### PR DESCRIPTION
Makes Mysterious Midnights 40% more likely. Instead of 46% of full moons being affected, 86% are. Previously a common Mysterious Midnight occurred roughly every 17 in-game days (5hrs 36min). This is a long time for singleplayer. With this patch a Mysterious Midnight occurs roughly every 12 in-game days (4hrs0min). See this image for a full chart:
![image](https://user-images.githubusercontent.com/41843855/55683410-c84fde80-593f-11e9-999b-cd687cd43f50.png)
