### PR TITLE
Added cement mixer

### DIFF
--- a/gm4_cement_mixers/data/cement_mixers/functions/init.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/init.mcfunction
@@ -1,0 +1,15 @@
+#announce module installation
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Installing Cement Mixers..."}]
+execute unless entity @p run say GM4: Installing Cement Mixers...
+
+#declare and initialise scoreboards and settings
+scoreboard players set update_happened gm4_up_check 1
+scoreboard players set cement_mixers gm4_modules 1
+#scoreboard players set cement_mixers gm4_clock_tick 0   ##Module Run by Liquid Tanks Base
+
+#announce success
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Cement Mixers Installed!"}]
+execute unless entity @p run say GM4: Cement Mixers Installed!
+
+#check other modules to make sure they're up to date.
+#$moduleUpdateList

--- a/gm4_cement_mixers/data/cement_mixers/functions/init_check.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/init_check.mcfunction
@@ -1,0 +1,3 @@
+#unless the module is already initialized
+execute unless score cement_mixers gm4_modules matches 1.. run function cement_mixers:init
+scoreboard players add installed_modules gm4_up_check 1

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill.mcfunction
@@ -1,19 +1,4 @@
 #@s = liquid tank with item in first slot
 #run from liquid_tanks:item_process
 
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:black_concrete_powder"}]} run function cement_mixers:item_fill/black_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:blue_concrete_powder"}]} run function cement_mixers:item_fill/blue_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:brown_concrete_powder"}]} run function cement_mixers:item_fill/brown_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:cyan_concrete_powder"}]} run function cement_mixers:item_fill/cyan_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:gray_concrete_powder"}]} run function cement_mixers:item_fill/gray_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:green_concrete_powder"}]} run function cement_mixers:item_fill/green_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_blue_concrete_powder"}]} run function cement_mixers:item_fill/light_blue_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_gray_concrete_powder"}]} run function cement_mixers:item_fill/light_gray_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:lime_concrete_powder"}]} run function cement_mixers:item_fill/lime_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:magenta_concrete_powder"}]} run function cement_mixers:item_fill/magenta_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:orange_concrete_powder"}]} run function cement_mixers:item_fill/orange_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:pink_concrete_powder"}]} run function cement_mixers:item_fill/pink_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:purple_concrete_powder"}]} run function cement_mixers:item_fill/purple_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:red_concrete_powder"}]} run function cement_mixers:item_fill/red_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:white_concrete_powder"}]} run function cement_mixers:item_fill/white_concrete
-execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:yellow_concrete_powder"}]} run function cement_mixers:item_fill/yellow_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. run function cement_mixers:water_concrete

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill.mcfunction
@@ -1,0 +1,19 @@
+#@s = liquid tank with item in first slot
+#run from liquid_tanks:item_process
+
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:black_concrete_powder"}]} run function cement_mixers:item_fill/black_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:blue_concrete_powder"}]} run function cement_mixers:item_fill/blue_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:brown_concrete_powder"}]} run function cement_mixers:item_fill/brown_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:cyan_concrete_powder"}]} run function cement_mixers:item_fill/cyan_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:gray_concrete_powder"}]} run function cement_mixers:item_fill/gray_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:green_concrete_powder"}]} run function cement_mixers:item_fill/green_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_blue_concrete_powder"}]} run function cement_mixers:item_fill/light_blue_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_gray_concrete_powder"}]} run function cement_mixers:item_fill/light_gray_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:lime_concrete_powder"}]} run function cement_mixers:item_fill/lime_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:magenta_concrete_powder"}]} run function cement_mixers:item_fill/magenta_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:orange_concrete_powder"}]} run function cement_mixers:item_fill/orange_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:pink_concrete_powder"}]} run function cement_mixers:item_fill/pink_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:purple_concrete_powder"}]} run function cement_mixers:item_fill/purple_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:red_concrete_powder"}]} run function cement_mixers:item_fill/red_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:white_concrete_powder"}]} run function cement_mixers:item_fill/white_concrete
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:yellow_concrete_powder"}]} run function cement_mixers:item_fill/yellow_concrete

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/black_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/black_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 black_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/blue_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/blue_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 blue_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/brown_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/brown_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 brown_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/cyan_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/cyan_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 cyan_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/gray_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/gray_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 gray_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/green_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/green_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 green_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/light_blue_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/light_blue_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 light_blue_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/light_gray_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/light_gray_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 light_gray_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/lime_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/lime_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 lime_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/magenta_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/magenta_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 magenta_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/orange_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/orange_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 orange_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/pink_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/pink_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 pink_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/purple_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/purple_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 purple_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/red_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/red_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 red_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/white_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/white_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 white_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/item_fill/yellow_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/item_fill/yellow_concrete.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 yellow_concrete 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/cement_mixers/functions/water_concrete.mcfunction
+++ b/gm4_cement_mixers/data/cement_mixers/functions/water_concrete.mcfunction
@@ -1,0 +1,16 @@
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:black_concrete_powder"}]} run function cement_mixers:item_fill/black_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:blue_concrete_powder"}]} run function cement_mixers:item_fill/blue_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:brown_concrete_powder"}]} run function cement_mixers:item_fill/brown_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:cyan_concrete_powder"}]} run function cement_mixers:item_fill/cyan_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:gray_concrete_powder"}]} run function cement_mixers:item_fill/gray_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:green_concrete_powder"}]} run function cement_mixers:item_fill/green_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_blue_concrete_powder"}]} run function cement_mixers:item_fill/light_blue_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:light_gray_concrete_powder"}]} run function cement_mixers:item_fill/light_gray_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:lime_concrete_powder"}]} run function cement_mixers:item_fill/lime_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:magenta_concrete_powder"}]} run function cement_mixers:item_fill/magenta_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:orange_concrete_powder"}]} run function cement_mixers:item_fill/orange_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:pink_concrete_powder"}]} run function cement_mixers:item_fill/pink_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:purple_concrete_powder"}]} run function cement_mixers:item_fill/purple_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:red_concrete_powder"}]} run function cement_mixers:item_fill/red_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:white_concrete_powder"}]} run function cement_mixers:item_fill/white_concrete
+execute if block ~ ~ ~ hopper{CustomName:"{\"text\":\"Water Tank\"}",Items:[{Slot:0b,id:"minecraft:yellow_concrete_powder"}]} run function cement_mixers:item_fill/yellow_concrete

--- a/gm4_cement_mixers/data/gm4/advancements/root.json
+++ b/gm4_cement_mixers/data/gm4/advancements/root.json
@@ -1,0 +1,20 @@
+{
+  "display":{
+    "icon":{
+      "item":"command_block",
+      "nbt":"{display:{Name:\"\\\"GM4 Logo\\\"\"}}"
+    },
+    "title":"Gamemode 4",
+    "description":{
+      "text":"Semi-funny blurb about gm4",
+      "color":"gray"
+    },
+    "background":"textures/block/light_blue_concrete_powder.png",
+    "announce_to_chat": false
+  },
+  "criteria":{
+    "automatic":{
+      "trigger":"minecraft:tick"
+    }
+  }
+}

--- a/gm4_cement_mixers/data/gm4/tags/functions/init_check.json
+++ b/gm4_cement_mixers/data/gm4/tags/functions/init_check.json
@@ -1,0 +1,5 @@
+{
+  "values":[
+    "cement_mixers:init_check"
+  ]
+}

--- a/gm4_cement_mixers/data/liquid_tanks/tags/functions/item_fill.json
+++ b/gm4_cement_mixers/data/liquid_tanks/tags/functions/item_fill.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "cement_mixers:item_fill"
+    ]
+
+}

--- a/gm4_cement_mixers/pack.mcmeta
+++ b/gm4_cement_mixers/pack.mcmeta
@@ -1,0 +1,24 @@
+{
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Cement Mixers",
+  "module_id":"cement_mixers",
+  "site_description":"Adds the ability to turn powder into concrete in Liquid Tanks",
+  "site_categories":[],
+  "video_link":"https://www.youtube.com/watch?v=qa9lcbii1BE",
+  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Tanks/Cement_Mixer",
+  "required_modules":[
+    "liquid_tanks"
+  ],
+  "recommended_modules":[],
+  "credits":{
+    "Creator":[
+      ["Sparks","https://twitter.com/SparksTheGamer"]
+    ],
+    "Icon Design":[
+      ["DuckJr","https://twitter.com/DuckJr94"]
+    ]
+  }
+}


### PR DESCRIPTION
This is a liquid tanks expansion which allows water tanks to turn single concrete powder blocks into concrete at the cost of 1 third of a water bucket per block.

The aim of this module is to allow players to create an automatic way to convert powder to concrete but to make them work for it first by creating a redstone contraption that feeds the concrete powder in steadily (and optionally tops up the water too)