### PR TITLE
[Bat Grenades] Remove `Bat Droppings` from bat loot tables

### DIFF
--- a/gm4_bat_grenades/data/minecraft/loot_tables/entities/bat.json
+++ b/gm4_bat_grenades/data/minecraft/loot_tables/entities/bat.json
@@ -37,31 +37,6 @@
           "weight":5
         }
       ]
-    },
-    {
-      "conditions":[
-        {
-          "condition":"killed_by_player"
-        }
-      ],
-      "rolls":1,
-      "entries":[
-        {
-          "type":"item",
-          "name":"minecraft:phantom_membrane",
-          "functions":[
-            {
-              "function":"set_nbt",
-              "tag":"{display:{Name:'{\"text\":\"Bat Droppings\",\"italic\":false}',Lore:['\"A bat dropped this\"']}}"
-            }
-          ],
-          "weight":1
-        },
-        {
-          "type":"empty",
-          "weight":7
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Removed `Bat Droppings` from the bat loot tables, as requested multiple times