### PR TITLE
Saddle item motion

### DIFF
--- a/gm4_chairs/data/chairs/functions/kill.mcfunction
+++ b/gm4_chairs/data/chairs/functions/kill.mcfunction
@@ -1,3 +1,4 @@
 # @s = @e[tag=gm4_chairs] and NOT inside stair blocks
-summon minecraft:item ~ ~.4 ~ {Item:{id:"minecraft:saddle",Count:1b}} 
+summon fox ~ ~.6 ~ {Age:-1000,NoAI:1,NoGravity:1,Silent:1,Invulnerable:1,Tags:["gm4_chairs_item"],DeathTime:19,ActiveEffects:[{Id:14,Amplifier:0,Duration:2147483647,ShowParticles:0b}],HandItems:[{id:"minecraft:saddle",Count:1b}]}
+kill @e[type=fox,tag=gm4_chairs_item,distance=..2]
 data merge entity @s {Health:0b}


### PR DESCRIPTION
When breaking the chair, the saddle item no longer spawns without a motion (a fox is spawned holding the item and is killed)