### PR TITLE
Fix phantom scarecrows invalid block tag

### DIFF
--- a/gm4_phantom_scarecrows/data/phantom_scarecrows/tags/blocks/traversable.json
+++ b/gm4_phantom_scarecrows/data/phantom_scarecrows/tags/blocks/traversable.json
@@ -9,8 +9,7 @@
     "minecraft:heavy_weighted_pressure_plate",
     "#minecraft:buttons",
     "minecraft:ladder",
-    "minecraft:sign",
-    "minecraft:wall_sign",
+    "#minecraft:signs",
     "minecraft:tripwire",
     "minecraft:tripwire_hook",
     "#minecraft:banners"


### PR DESCRIPTION
This was a change that I forgot in #183.