### PR TITLE
Added Liquid Minecarts

### DIFF
--- a/gm4_liquid_minecarts/data/gm4/advancements/root.json
+++ b/gm4_liquid_minecarts/data/gm4/advancements/root.json
@@ -1,0 +1,20 @@
+{
+  "display":{
+    "icon":{
+      "item":"command_block",
+      "nbt":"{display:{Name:\"\\\"GM4 Logo\\\"\"}}"
+    },
+    "title":"Gamemode 4",
+    "description":{
+      "text":"Semi-funny blurb about gm4",
+      "color":"gray"
+    },
+    "background":"textures/block/light_blue_concrete_powder.png",
+    "announce_to_chat": false
+  },
+  "criteria":{
+    "automatic":{
+      "trigger":"minecraft:tick"
+    }
+  }
+}

--- a/gm4_liquid_minecarts/data/gm4/tags/functions/init_check.json
+++ b/gm4_liquid_minecarts/data/gm4/tags/functions/init_check.json
@@ -1,0 +1,5 @@
+{
+  "values":[
+    "liquid_minecarts:init_check"
+  ]
+}

--- a/gm4_liquid_minecarts/data/gm4/tags/functions/pulse_check.json
+++ b/gm4_liquid_minecarts/data/gm4/tags/functions/pulse_check.json
@@ -1,0 +1,5 @@
+{
+    "values":[
+        "liquid_minecarts:pulse_check"
+    ]
+}

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_load_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_load_liquid.mcfunction
@@ -1,0 +1,7 @@
+#run from try_to_load
+#@s = liquid minecart containing a liquid with a liquid tank containing liquid pointed at it
+
+summon area_effect_cloud ~ ~ ~ {Tags:["gm4_liquid_minecart_compare"],Duration:1}
+data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from block ~ ~ ~ CustomName
+execute if score @s gm4_lt_value < @s gm4_lt_max store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
+execute if score @s gm4_lt_value < @s gm4_lt_max if score @s gm4_lm_data matches 0 run function liquid_minecarts:load_liquid

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_load_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_load_liquid.mcfunction
@@ -3,5 +3,6 @@
 
 summon area_effect_cloud ~ ~ ~ {Tags:["gm4_liquid_minecart_compare"],Duration:1}
 data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from block ~ ~ ~ CustomName
-execute if score @s gm4_lt_value < @s gm4_lt_max store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
-execute if score @s gm4_lt_value < @s gm4_lt_max if score @s gm4_lm_data matches 0 run function liquid_minecarts:load_liquid
+execute store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
+execute if score @s gm4_lm_data matches 0 run function liquid_minecarts:load_liquid
+kill @e[type=area_effect_cloud,tag=g4m_liquid_minecart_compare]

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_unload_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_unload_liquid.mcfunction
@@ -2,5 +2,6 @@
 #@s = liquid minecart containing a liquid with a liquid tank containing liquid below it
 summon area_effect_cloud ~ ~ ~ {Tags:["gm4_liquid_minecart_compare"],Duration:1}
 data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from block ~ ~ ~ CustomName
-execute if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_value < @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
-execute if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_value < @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max if score @s gm4_lm_data matches 0 run function liquid_minecarts:unload_liquid
+execute store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
+execute if score @s gm4_lm_data matches 0 run function liquid_minecarts:unload_liquid
+kill @e[type=area_effect_cloud,tag=g4m_liquid_minecart_compare]

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_unload_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/compare_unload_liquid.mcfunction
@@ -1,0 +1,6 @@
+#run from try_to_unload
+#@s = liquid minecart containing a liquid with a liquid tank containing liquid below it
+summon area_effect_cloud ~ ~ ~ {Tags:["gm4_liquid_minecart_compare"],Duration:1}
+data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from block ~ ~ ~ CustomName
+execute if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_value < @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max store success score @s gm4_lm_data run data modify entity @e[type=area_effect_cloud,limit=1,sort=nearest,tag=gm4_liquid_minecart_compare] CustomName set from entity @s CustomName
+execute if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_value < @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max if score @s gm4_lm_data matches 0 run function liquid_minecarts:unload_liquid

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
@@ -1,9 +1,6 @@
 #run from main
 #@s = hopper minecart with upgrade recipe inside
-summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisabledSlots:2039583,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f]}}]}
+summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisabledSlots:2039583,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f],RightArm:[0.0f,-90.0f,0.0f]}}]}
 execute as @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] run function liquid_minecarts:liquid_value_update
-scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_value 0
-scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_max 40
-scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_disp_val 0
 data merge entity @s {Items:[]}
 kill @s

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
@@ -1,0 +1,9 @@
+#run from main
+#@s = hopper minecart with upgrade recipe inside
+summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisabledSlots:2039583,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f]}}]}
+execute as @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] run function liquid_minecarts:liquid_value_update
+scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_value 0
+scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_max 40
+scoreboard players set @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] gm4_lt_disp_val 0
+data merge entity @s {Items:[]}
+kill @s

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/destroy.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/destroy.mcfunction
@@ -1,0 +1,4 @@
+#run from main
+#@s = display armor_stand without a liquid minecart
+loot spawn ~ ~ ~ loot liquid_minecarts:destroy_liquid_minecart
+kill @s

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/drain_minecart.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/drain_minecart.mcfunction
@@ -1,0 +1,6 @@
+#run from command_block_minecart (liquid minecart)
+#@s = liquid minecart going over active activator rail
+scoreboard players set @s gm4_lt_value 0
+data merge entity @s {Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"]}
+function liquid_minecarts:liquid_value_update
+playsound minecraft:block.brewing_stand.brew block @a ~ ~ ~ 1.0 0.0

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init.mcfunction
@@ -1,0 +1,20 @@
+#announce module installation
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Installing Liquid Minecarts..."}]
+execute unless entity @p run say GM4: Installing Liquid Minecarts...
+
+#declare and initialise scoreboards and settings
+scoreboard players set update_happened gm4_up_check 1
+scoreboard players set liquid_minecarts gm4_modules 1
+scoreboard players set liquid_minecarts gm4_clock_tick 0
+
+scoreboard objectives add gm4_lm_data dummy
+scoreboard players set 5 gm4_lm_data 5
+scoreboard players set 2 gm4_lm_data 2
+scoreboard players set 100 gm4_lm_data 100
+
+#announce success
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Liquid Minecarts Installed!"}]
+execute unless entity @p run say GM4: Liquid Minecarts Installed!
+
+#check other modules to make sure they're up to date.
+#$moduleUpdateList

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_check.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_check.mcfunction
@@ -1,0 +1,3 @@
+#unless the module is already initialized
+execute unless score liquid_minecarts gm4_modules matches 1.. run function liquid_minecarts:init
+scoreboard players add installed_modules gm4_up_check 1

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_liquid.mcfunction
@@ -1,0 +1,16 @@
+#run from try_to_unload
+#@s = empty liquid minecart next to a liquid tank pointed at it containing liquid
+data modify entity @s CustomName set from block ~ ~ ~ CustomName
+data modify entity @e[type=minecraft:armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] HandItems[0] set from entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest] ArmorItems[3]
+data modify entity @s Tags set from entity @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] Tags
+tag @s remove gm4_lt_idle
+tag @s remove gm4_lt_drain
+tag @s remove gm4_lt_fill
+tag @s remove gm4_liquid_tank
+tag @s add gm4_liquid_minecart
+#set tank max based on 40% of hopper max
+scoreboard players operation @s gm4_lt_max = @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max
+scoreboard players operation @s gm4_lt_max /= 5 gm4_lm_data
+scoreboard players operation @s gm4_lt_max *= 2 gm4_lm_data
+#fill the tank
+function liquid_minecarts:load_liquid

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
@@ -1,0 +1,21 @@
+#run from try_to_unload
+#@s = liquid minecart
+data modify block ~ ~ ~ CustomName set from entity @s CustomName
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display","gm4_lm_needs_texture"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000}
+data modify entity @e[type=armor_stand,tag=gm4_lm_needs_texture,limit=1,sort=nearest] ArmorItems[3] set from entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] HandItems[0]
+tag @e[type=armor_stand] remove gm4_lm_needs_texture
+scoreboard players operation @s gm4_lm_data = @s gm4_lt_max
+scoreboard players operation @s gm4_lm_data *= 5 gm4_lm_data
+scoreboard players operation @s gm4_lm_data /= 2 gm4_lm_data
+scoreboard players operation @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest,distance=..0.5] gm4_lt_max = @s gm4_lm_data
+scoreboard players operation @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest,distance=..0.5] gm4_lt_value = @s gm4_lt_value
+scoreboard players set @s gm4_lt_value 0
+
+#apply liquid tag
+tag @s remove gm4_liquid_minecart
+tag @s add gm4_lm_to_lt
+data modify entity @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest,distance=..0.5] Tags set from entity @s Tags
+data merge entity @s {Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"]}
+playsound minecraft:block.brewing_stand.brew block @a ~ ~ ~ 1.0 1.5
+execute as @e[type=armor_stand,tag=gm4_lm_to_lt,limit=1,sort=nearest,distance=..0.5] run function liquid_minecarts:minecart_to_tank_init
+function liquid_minecarts:liquid_value_update

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/item_fill.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/item_fill.mcfunction
@@ -1,0 +1,4 @@
+#@s = liquid tank with item in first slot
+#run from liquid_tanks:item_process
+
+execute if score @s[tag=gm4_lt_water] gm4_lt_value matches 1.. run function cement_mixers:water_concrete

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report.mcfunction
@@ -1,5 +1,5 @@
 #run from level_report_ray
 #@s = players looking at liquid minecart
 execute as @e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..1,limit=1,sort=nearest] run function liquid_minecarts:liquid_value_update
-title @s actionbar ["",{"score":{"name":"@e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..1,limit=1,sort=nearest]","objective":"gm4_lt_disp_val"},"color":"dark_green"},{"text":"% Full","color":"dark_green"}]
+title @s actionbar ["",{"score":{"name":"@e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..1,limit=1,sort=nearest]","objective":"gm4_lm_data"},"color":"dark_green"},{"text":"% Full","color":"dark_green"}]
 tag @s add gm4_lt_found_tank

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report.mcfunction
@@ -1,0 +1,5 @@
+#run from level_report_ray
+#@s = players looking at liquid minecart
+execute as @e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..1,limit=1,sort=nearest] run function liquid_minecarts:liquid_value_update
+title @s actionbar ["",{"score":{"name":"@e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..1,limit=1,sort=nearest]","objective":"gm4_lt_disp_val"},"color":"dark_green"},{"text":"% Full","color":"dark_green"}]
+tag @s add gm4_lt_found_tank

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report_ray.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/level_report_ray.mcfunction
@@ -1,0 +1,8 @@
+#@s = all players at @s
+#run from main
+execute anchored eyes positioned ^ ^ ^.5 if entity @e[distance=..1,type=command_block_minecart,tag=gm4_liquid_minecart,limit=1,sort=nearest] run function liquid_minecarts:level_report
+execute unless entity @s[tag=gm4_lt_found_tank] anchored eyes positioned ^ ^ ^1.5 if entity @e[distance=..1,type=command_block_minecart,tag=gm4_liquid_minecart,limit=1,sort=nearest] run function liquid_minecarts:level_report
+execute unless entity @s[tag=gm4_lt_found_tank] anchored eyes positioned ^ ^ ^2.5 if entity @e[distance=..1,type=command_block_minecart,tag=gm4_liquid_minecart,limit=1,sort=nearest] run function liquid_minecarts:level_report
+execute unless entity @s[tag=gm4_lt_found_tank] anchored eyes positioned ^ ^ ^3.5 if entity @e[distance=..1,type=command_block_minecart,tag=gm4_liquid_minecart,limit=1,sort=nearest] run function liquid_minecarts:level_report
+
+tag @s remove gm4_lt_found_tank

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/liquid_value_update.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/liquid_value_update.mcfunction
@@ -1,0 +1,20 @@
+#run from load_liquid, unload_liquid and create
+#@s = liquid minecart
+
+#calculate tank fullness percentage
+scoreboard players operation @s gm4_lm_data = @s gm4_lt_value
+scoreboard players operation @s gm4_lm_data *= 100 gm4_lm_data
+scoreboard players operation @s gm4_lm_data /= @s gm4_lt_max
+
+scoreboard players operation @s gm4_lt_disp_val = @s gm4_lm_data
+
+#1%-50%
+execute if score @s gm4_lt_value matches 1.. if score @s gm4_lm_data matches 0..50 run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"42ceac16-1b02-4889-8d85-f8b7a167b0b3",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTEzNjg2ZjIxMDY1YTRiZTZjYzU3MDYxZDhlNzM2MDQ3MzQ2YzU4NmEzYTU1OWMwMzdhMDMxNGJjNDUyOTA4MSJ9fX0="}]}}}}]}
+#51%-99%
+execute unless score @s gm4_lt_value = @s gm4_lt_max if score @s gm4_lm_data matches 51..100 run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"ec98f0b8-97a1-47a0-9786-7071ed229a0e",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmFjOTBjM2ZmNWI5NzBhNTIyNTliNTdhNDlmMjFmOGE1NTdmZmIxYTM2ZmNjNDkwMDQyMTQzNDZkOWViN2RmZCJ9fX0="}]}}}}]}
+#100%
+execute if score @s gm4_lt_value = @s gm4_lt_max run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"ff983ce0-57a7-4ec6-9cdf-6090de1adc6d",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2M5OTI4ODgxNGY1ODVjN2JjMmU1NWQ0NDY0ZDUzOGQwZDlkOWM4YjE4NzRiZTA5ZDc4Yjk3YzA3YzAwYWIxYSJ9fX0="}]}}}}]}
+#0%
+execute if score @s gm4_lt_value matches 0 run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"0720bc21-0c53-4856-bd45-d8d5e0f96f78",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjhiMjU1MjJjMzFiZmU0Y2VhMTAxMDA4MGQ1YTFiOWIwOGU3NWJhZTUzOGRhODk3MmNiZGQ2YTk0Mzk5MjEyYSJ9fX0="}]}}}}]}
+
+scoreboard players set @s gm4_lm_data 0

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/liquid_value_update.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/liquid_value_update.mcfunction
@@ -6,8 +6,6 @@ scoreboard players operation @s gm4_lm_data = @s gm4_lt_value
 scoreboard players operation @s gm4_lm_data *= 100 gm4_lm_data
 scoreboard players operation @s gm4_lm_data /= @s gm4_lt_max
 
-scoreboard players operation @s gm4_lt_disp_val = @s gm4_lm_data
-
 #1%-50%
 execute if score @s gm4_lt_value matches 1.. if score @s gm4_lm_data matches 0..50 run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"42ceac16-1b02-4889-8d85-f8b7a167b0b3",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTEzNjg2ZjIxMDY1YTRiZTZjYzU3MDYxZDhlNzM2MDQ3MzQ2YzU4NmEzYTU1OWMwMzdhMDMxNGJjNDUyOTA4MSJ9fX0="}]}}}}]}
 #51%-99%
@@ -16,5 +14,3 @@ execute unless score @s gm4_lt_value = @s gm4_lt_max if score @s gm4_lm_data mat
 execute if score @s gm4_lt_value = @s gm4_lt_max run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"ff983ce0-57a7-4ec6-9cdf-6090de1adc6d",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2M5OTI4ODgxNGY1ODVjN2JjMmU1NWQ0NDY0ZDUzOGQwZDlkOWM4YjE4NzRiZTA5ZDc4Yjk3YzA3YzAwYWIxYSJ9fX0="}]}}}}]}
 #0%
 execute if score @s gm4_lt_value matches 0 run data merge entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1b,tag:{SkullOwner:{Id:"0720bc21-0c53-4856-bd45-d8d5e0f96f78",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjhiMjU1MjJjMzFiZmU0Y2VhMTAxMDA4MGQ1YTFiOWIwOGU3NWJhZTUzOGRhODk3MmNiZGQ2YTk0Mzk5MjEyYSJ9fX0="}]}}}}]}
-
-scoreboard players set @s gm4_lm_data 0

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_check.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_check.mcfunction
@@ -1,0 +1,12 @@
+#run from main
+#@s = liquid minecart
+
+#load
+execute if block ~1 ~ ~ hopper[facing=west] positioned ~1 ~ ~ run function liquid_minecarts:try_to_load
+execute if block ~-1 ~ ~ hopper[facing=east] positioned ~-1 ~ ~ run function liquid_minecarts:try_to_load
+execute if block ~ ~ ~1 hopper[facing=north] positioned ~-1 ~ ~ run function liquid_minecarts:try_to_load
+execute if block ~ ~ ~-1 hopper[facing=south] positioned ~-1 ~ ~ run function liquid_minecarts:try_to_load
+execute if block ~ ~1 ~ hopper[facing=down] positioned ~ ~1 ~ run function liquid_minecarts:try_to_load
+
+#unload
+execute if block ~ ~-1 ~ hopper positioned ~ ~-1 ~ run function liquid_minecarts:try_to_unload

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_liquid.mcfunction
@@ -1,0 +1,17 @@
+#run from compare_load_liquid and init_liquid
+#@s liquid minecart that can accept the current tank's liquid
+
+#take all the liquid in the tank (or as much as the minecart can hold) (amount of liquid to take stored in gm4_lm_data)
+#get remaining space in minecart
+scoreboard players operation @s gm4_lm_data = @s gm4_lt_max
+scoreboard players operation @s gm4_lm_data -= @s gm4_lt_value
+#lower lm_data if tank has less liquid than the remaining space
+execute if score @s gm4_lm_data > @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value run scoreboard players operation @s gm4_lm_data = @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value
+
+#add liquid to minecart
+scoreboard players operation @s gm4_lt_value += @s gm4_lm_data
+#take liquid from tank
+scoreboard players operation @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_buffer -= @s gm4_lm_data
+#update display
+function liquid_minecarts:liquid_value_update
+playsound minecraft:block.brewing_stand.brew block @a

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_liquid.mcfunction
@@ -6,7 +6,7 @@
 scoreboard players operation @s gm4_lm_data = @s gm4_lt_max
 scoreboard players operation @s gm4_lm_data -= @s gm4_lt_value
 #lower lm_data if tank has less liquid than the remaining space
-execute if score @s gm4_lm_data > @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value run scoreboard players operation @s gm4_lm_data = @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value
+scoreboard players operation @s gm4_lm_data < @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value
 
 #add liquid to minecart
 scoreboard players operation @s gm4_lt_value += @s gm4_lm_data

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/main.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/main.mcfunction
@@ -1,0 +1,13 @@
+
+#create liquid minecarts from hopper minecart
+execute as @e[type=hopper_minecart,tag=!gm4_liquid_minecart,nbt={Items:[{id:"minecraft:hopper",Count:1b},{id:"minecraft:iron_trapdoor",Count:1b},{id:"minecraft:comparator",Count:1b},{id:"minecraft:dispenser",Count:1b},{id:"minecraft:bucket",Count:1b}]}] at @s run function liquid_minecarts:create
+
+#detect destroyed liquid minecarts
+execute as @e[type=armor_stand,tag=gm4_liquid_minecart_display] at @s unless entity @e[type=command_block_minecart,tag=gm4_liquid_minecart,distance=..0.5] run function liquid_minecarts:destroy
+
+
+#look for hoppers pointing into or below the liquid minecart
+execute as @e[type=command_block_minecart,tag=gm4_liquid_minecart] at @s run function liquid_minecarts:load_check
+
+#minecart level report
+execute as @a[gamemode=!spectator] at @s run function liquid_minecarts:level_report_ray

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/minecart_to_tank_init.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/minecart_to_tank_init.mcfunction
@@ -1,0 +1,5 @@
+tag @s add gm4_liquid_tank
+tag @s add gm4_lt_idle
+tag @s add gm4_no_edit
+tag @s remove gm4_lt_empty
+tag @s remove gm4_lm_to_lt

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/minecart_to_tank_init.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/minecart_to_tank_init.mcfunction
@@ -1,3 +1,5 @@
+#run from init_tank
+#@s = liquid tank that a minecart is putting a new liquid into
 tag @s add gm4_liquid_tank
 tag @s add gm4_lt_idle
 tag @s add gm4_no_edit

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/pulse_check.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/pulse_check.mcfunction
@@ -1,0 +1,3 @@
+#compares assigned run tick to current tick and calls main
+function #liquid_minecarts:tick
+execute if score current_tick gm4_clock_tick = liquid_minecarts gm4_clock_tick run function liquid_minecarts:main

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_load.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_load.mcfunction
@@ -2,6 +2,6 @@
 #@s = liquid minecart with a hopper pointing at it
 
 #if the minecart has a liquid in it and the tank does too
-execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] run function liquid_minecarts:compare_load_liquid
+execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] if score @s gm4_lt_value < @s gm4_lt_max run function liquid_minecarts:compare_load_liquid
 #if the minecart is empty and the tank has contents
 execute if entity @s[tag=gm4_liquid_minecart_empty] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] run function liquid_minecarts:init_liquid

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_load.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_load.mcfunction
@@ -1,0 +1,7 @@
+#run from load_check
+#@s = liquid minecart with a hopper pointing at it
+
+#if the minecart has a liquid in it and the tank does too
+execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] run function liquid_minecarts:compare_load_liquid
+#if the minecart is empty and the tank has contents
+execute if entity @s[tag=gm4_liquid_minecart_empty] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] run function liquid_minecarts:init_liquid

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_unload.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_unload.mcfunction
@@ -2,6 +2,6 @@
 #@s = liquid minecart with a hopper below it
 
 #if the minecart has a liquid in it and the tank does too
-execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] align xyz positioned ~.5 ~ ~.5 run function liquid_minecarts:compare_unload_liquid
+execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] align xyz positioned ~.5 ~ ~.5 if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_value < @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,sort=nearest] gm4_lt_max run function liquid_minecarts:compare_unload_liquid
 #if the minecart has liquid but the tank is empty
 execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=0}] align xyz positioned ~.5 ~ ~.5 run function liquid_minecarts:init_tank

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_unload.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/try_to_unload.mcfunction
@@ -1,0 +1,7 @@
+#run from load_check
+#@s = liquid minecart with a hopper below it
+
+#if the minecart has a liquid in it and the tank does too
+execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=1..}] align xyz positioned ~.5 ~ ~.5 run function liquid_minecarts:compare_unload_liquid
+#if the minecart has liquid but the tank is empty
+execute if entity @s[scores={gm4_lt_value=1..}] if entity @e[type=armor_stand,distance=..0.1,tag=gm4_liquid_tank,scores={gm4_lt_value=0}] align xyz positioned ~.5 ~ ~.5 run function liquid_minecarts:init_tank

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/unload_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/unload_liquid.mcfunction
@@ -1,0 +1,19 @@
+#run from compare_unload_liquid and
+#@s liquid minecart above a liquid tank that can accept the liquid
+
+#take all the liquid in the tank (or as much as the minecart can hold) (amount of liquid to take stored in gm4_lm_data)
+#get remaining space in minecart
+scoreboard players operation @s gm4_lm_data = @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_max
+scoreboard players operation @s gm4_lm_data -= @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value
+#lower lm_data if tank has less space than minecart's liquid level
+execute if score @s gm4_lt_value < @s gm4_lm_data run scoreboard players operation @s gm4_lm_data = @s gm4_lt_value
+
+#remove liquid from minecart
+scoreboard players operation @s gm4_lt_value -= @s gm4_lm_data
+#give liquid to tank
+scoreboard players operation @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_buffer += @s gm4_lm_data
+#update display
+function liquid_minecarts:liquid_value_update
+playsound minecraft:block.brewing_stand.brew block @a ~ ~ ~ 1.0 1.5
+#clear liquid tags
+execute if score @s gm4_lt_value matches 0 run data merge entity @s {Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"]}

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/unload_liquid.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/unload_liquid.mcfunction
@@ -6,7 +6,7 @@
 scoreboard players operation @s gm4_lm_data = @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_max
 scoreboard players operation @s gm4_lm_data -= @e[type=armor_stand,limit=1,sort=nearest,tag=gm4_liquid_tank] gm4_lt_value
 #lower lm_data if tank has less space than minecart's liquid level
-execute if score @s gm4_lt_value < @s gm4_lm_data run scoreboard players operation @s gm4_lm_data = @s gm4_lt_value
+scoreboard players operation @s gm4_lm_data < @s gm4_lt_value
 
 #remove liquid from minecart
 scoreboard players operation @s gm4_lt_value -= @s gm4_lm_data

--- a/gm4_liquid_minecarts/data/liquid_minecarts/loot_tables/destroy_liquid_minecart.json
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/loot_tables/destroy_liquid_minecart.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:generic",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:comparator"
+        }
+      ]
+    },
+    {
+      "rolls": 2,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:hopper"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:bucket"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dispenser"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:iron_trapdoor"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_liquid_minecarts/pack.mcmeta
+++ b/gm4_liquid_minecarts/pack.mcmeta
@@ -1,0 +1,24 @@
+{
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Liquid Minecarts",
+  "module_id":"liquid_minecarts",
+  "site_description":"Allows Minecarts to move fluids between Liquid Tanks",
+  "site_categories":["Liquid Tanks"],
+  "video_link":"",
+  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Tanks/Liquid_Minecarts",
+  "required_modules":[
+    "liquid_tanks"
+  ],
+  "recommended_modules":["potion_liquids"],
+  "credits":{
+    "Creator":[
+      ["Sparks","https://twitter.com/SparksTheGamer"]
+    ],
+    "Icon Design":[
+      ["DuckJr","https://twitter.com/DuckJr94"]
+    ]
+  }
+}


### PR DESCRIPTION
Liquid Minecarts first draft. I threw this together in a few days so I'm sure there are errors or places where performance can be improved.

Video: https://www.youtube.com/watch?v=qQctcD3WvWw

Liquid Minecarts are used to move liquids between tanks. This module needs feedback and testing. The goal in its design is to support any new liquids automatically. Instead of hard-coded values, liquid minecarts copy the scores, tags and textures from the tank they load from.

Minecarts can hold 40% of the capacity of the tank from which they got their liquid from (usually 120 bottles).
Minecarts are created by placing down a hopper minecart and entering the same recipe as a liquid tank.
Minecarts will fill if there is a liquid tank pointed at them and they are empty or the liquid in the tank matches their own.
Minecarts will empty their contents into an empty tank or a tank with matching liquid if they are on top of the tank.
Minecarts will empty completely if they drive over a powered activator rail. This is so automated systems can assure tanks have no residual contents.
Minecarts have no GUI for survival players and have no functionality outside of being able to interface with tanks. Think of them as pipes.


A note on why liquid minecarts are command_block_minecart entities. Originally I used regular minecarts  but this caused the passenger tank armour stand to be ejected when going over an activator rail. Minecarts themselves don't support skulls as a custom display block. I didn't want the minecarts to have a GUI because they have no GUI functionality and seeing a hopper interface on a mobile liquid tank will cause players to expect it to be able to bottle and unbottle. Furthermore a GUI will cause the tank to suck items out of hoppers or place them in, potentially messing up auto-filler systems if it picks something up while travelling down a track. Furnace minecarts drive weird as we all know so command block minecart it is! There's an added advantage that the "drain" feature is entered as a command in the minecart itself meaning there's no 20hz clock needed to check for activator rails. As far as I can tell, in survival it acts like a normal minecart. You can't view the command GUI and breaking it doesn't drop a command block.