### PR TITLE
Update ziprails for liquid minecarts

### DIFF
--- a/gm4_potion_liquids/pack.mcmeta
+++ b/gm4_potion_liquids/pack.mcmeta
@@ -1,0 +1,30 @@
+{
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Potion Liquids",
+  "module_id":"potion_liquids",
+  "site_description":"Adds the ability to store potions in Liquid Tanks",
+  "site_categories":["Liquid Tanks"],
+  "video_link":"https://www.youtube.com/watch?v=qa9lcbii1BE",
+  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Tanks/Potion_Liquids",
+  "required_modules":[
+    "liquid_tanks"
+  ],
+  "recommended_modules":[],
+  "credits":{
+    "Creator":[
+      ["SpecialBuilder32","https://twitter.com/SpecialBuilder"]
+    ],
+    "Updated by":[
+      ["SpecialBuilder32","https://twitter.com/SpecialBuilder"]
+    ],
+    "Icon Design":[
+      ["DuckJr","https://twitter.com/DuckJr94"]
+    ],
+    "Textures by":[
+      ["Vilder50"]
+    ]
+  }
+}

--- a/gm4_ziprails/data/ziprails/functions/main.mcfunction
+++ b/gm4_ziprails/data/ziprails/functions/main.mcfunction
@@ -5,7 +5,7 @@ tag @e[type=hopper_minecart] add gm4_minecart
 tag @e[type=furnace_minecart] add gm4_minecart
 tag @e[type=spawner_minecart] add gm4_minecart
 tag @e[type=tnt_minecart] add gm4_minecart
-
+tag @e[type=command_block_minecart] add gm4_minecart
 
 #advancement
 execute at @e[tag=gm4_minecart,tag=gm4_linked] run advancement grant @p[distance=..1] only gm4:ziprails


### PR DESCRIPTION
added command block minecarts to the list of minecarts that can travel along ziprails in order to support liquid minecarts (which are command block minecarts)