### PR TITLE
Make ores in animation unstackable

### DIFF
--- a/gm4_metallurgy/data/metallurgy/functions/casting/add_metal/initialize.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/casting/add_metal/initialize.mcfunction
@@ -8,5 +8,4 @@ execute if entity @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{ore_type
 execute if entity @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{ore_type:"aluminium"}}},OnGround:1b},tag=gm4_ml_in_animation,dx=0,dz=0] run function metallurgy:casting/add_metal/add_aluminium
 
 #make all ores on top jump
-execute as @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{}}},OnGround:1b},tag=!gm4_ml_in_animation,dx=0,dz=0] run data merge entity @s {Motion:[0.0,0.35,0.0],PickupDelay:30,Tags:["gm4_ml_in_animation"]}
-#,Item:{tag:{gm4_metallurgy:{ore_in_animation:1b}}}
+execute as @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{}}},OnGround:1b},tag=!gm4_ml_in_animation,dx=0,dz=0] run data merge entity @s {Motion:[0.0,0.35,0.0],PickupDelay:30,Tags:["gm4_ml_in_animation"],Item:{tag:{gm4_metallurgy:{ore_in_animation:1b}}}}

--- a/gm4_metallurgy/data/metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/main.mcfunction
@@ -12,6 +12,7 @@ execute at @e[type=item,nbt={Item:{id:"minecraft:obsidian",Count:1b},Motion:[0.0
 
 #manage moulds
 execute as @e[type=vex,tag=gm4_sand_ring] at @s run function metallurgy:casting/sustain_mould
+execute as @e[type=item,tag=gm4_ml_in_animation,nbt=!{PickupDelay:30s}] run data remove entity @s Item.tag.gm4_metallurgy.ore_in_animation
 
 #check for shamir on anvil
 scoreboard players reset found_item_on_anvil gm4_ml_data


### PR DESCRIPTION
These small changes make sure that the item is unstackable in the casting animation.

The current implementation makes ores stack when there is a lag spike or when the clock is misaligned. This new implementation is required if you want to reliably drop ores every clock cycle.