### PR TITLE
Fix issues with metallurgy casting

### DIFF
--- a/gm4_metallurgy/data/metallurgy/functions/casting/add_metal/initialize.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/casting/add_metal/initialize.mcfunction
@@ -8,4 +8,4 @@ execute if entity @e[type=item,tag=gm4_ml_in_animation,dx=0,dz=0,nbt={Item:{Coun
 execute if entity @e[type=item,tag=gm4_ml_in_animation,dx=0,dz=0,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{ore_type:"aluminium"}}},OnGround:1b}] run function metallurgy:casting/add_metal/add_aluminium
 
 #make all ores on top jump
-execute as @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{}}},OnGround:1b},tag=!gm4_ml_in_animation,dx=0,dz=0] run data merge entity @s {Motion:[0.0,0.35,0.0],PickupDelay:30,Tags:["gm4_ml_in_animation"],Item:{tag:{gm4_metallurgy:{ore_in_animation:1b}}}}
+execute as @e[type=item,tag=!gm4_ml_in_animation,dx=0,dz=0,limit=1,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{item:"ore"}}},OnGround:1b}] run data merge entity @s {Motion:[0.0,0.35,0.0],PickupDelay:30,Tags:["gm4_ml_in_animation"],Item:{tag:{gm4_metallurgy:{ore_in_animation:1b}}}}

--- a/gm4_metallurgy/data/metallurgy/functions/casting/check_mould_creation.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/casting/check_mould_creation.mcfunction
@@ -1,0 +1,3 @@
+# @s = obsidian block with count of 1 on top of sand
+# run from main
+execute align xyz unless entity @e[type=vex,tag=gm4_sand_ring,dx=0,dy=-1,dz=0] if entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:clay_ball",Count:1b},OnGround:1b}] run function metallurgy:casting/create_mould

--- a/gm4_metallurgy/data/metallurgy/functions/casting/create_mould.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/casting/create_mould.mcfunction
@@ -1,5 +1,5 @@
 # @s = obsidian block with count of 1 on top of sand next to a clay ball with a count of 1
-# run from main
+# run from check_mould_creation
 
 summon vex ~.45 ~-0.845 ~.65 {CustomName:"\"gm4_sand_ring\"",Tags:["gm4_sand_ring","gm4_new_sand_ring"],Attributes:[{Name:"generic.maxHealth",Base:0.25}],ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1,Damage:3,tag:{SkullOwner:{Id:"085b275e-bb5a-4344-b437-568271065014",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0Nzk4NTI1MDM5MzksInByb2ZpbGVJZCI6Ijk4NWIyNzVlYmI1YTQzNDRiNDM3Njg5NTI4NjNhNjNmIiwicHJvZmlsZU5hbWUiOiJTcGFya3MiLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWZhYmExYzg3NTFjYWIzZjEyZjJlODgwMTRjZjRlYmY2N2ZjNWQ3NGNmY2U5YmUyNTI1YWQ0OWE5MjFkY2YyIn0sIkNBUEUiOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS81YzNjYTdlZTJhNDk4ZjFiNWQyNThkNWZhOTI3ZTYzZTQzMzE0M2FkZDU1MzhjZjYzYjZhOWI3OGFlNzM1In19fQ=="}]}}}}],NoAI:1,Silent:1,ActiveEffects:[{Id:14b,Amplifier:1b,Duration:2147483647,ShowParticles:0b}],Invunerable:1,PersistenceRequired:1}
 
@@ -11,5 +11,5 @@ scoreboard players add @e[type=vex,tag=gm4_new_sand_ring] gm4_ml_ore_th 0
 scoreboard players set @e[type=vex,tag=gm4_new_sand_ring] gm4_ml_heat 30
 tag @e[type=vex,tag=gm4_new_sand_ring] remove gm4_new_sand_ring
 
-kill @e[type=item,nbt={Item:{id:"minecraft:clay_ball",Count:1b}},limit=1,dx=0,dy=0,dz=0]
-kill @e[type=item,nbt={Item:{id:"minecraft:obsidian",Count:1b}},limit=1,dx=0,dy=0,dz=0]
+kill @e[type=item,limit=1,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:clay_ball",Count:1b},OnGround:1b}]
+kill @e[type=item,limit=1,dx=0,dy=0,dz=0,nbt={Item:{id:"minecraft:obsidian",Count:1b},OnGround:1b}]

--- a/gm4_metallurgy/data/metallurgy/functions/casting/sustain_mould.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/casting/sustain_mould.mcfunction
@@ -11,7 +11,7 @@ execute unless score @s gm4_ml_heat matches 1..89 run function metallurgy:castin
 
 #add metals if player desires to do so
 
-execute if score @s gm4_ml_heat matches 50..89 align xyz positioned ~ ~1 ~ if entity @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{}}},OnGround:1b},dx=0,dy=0,dz=0] run function metallurgy:casting/add_metal/initialize
+execute if score @s gm4_ml_heat matches 50..89 align xyz positioned ~ ~1 ~ if entity @e[type=item,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{item:"ore"}}},OnGround:1b},dx=0,dy=0,dz=0] run function metallurgy:casting/add_metal/initialize
 
 #hot ring without metal
 execute if score @s[tag=!gm4_contains_metal] gm4_ml_heat matches 50..51 run data merge entity @s {ArmorItems:[{},{},{},{id:"minecraft:player_head",Count:1,tag:{SkullOwner:{Id:"085b275e-bb5a-4344-b437-720437904580",Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0ODE0MTE3MjM4MDYsInByb2ZpbGVJZCI6Ijk4NWIyNzVlYmI1YTQzNDRiNDM3Njg5NTI4NjNhNjNmIiwicHJvZmlsZU5hbWUiOiJTcGFya3MiLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTc0NTVkNjg3MjJkOTU3ZmI1ZGVjZGNjY2NjMWI2MWU4NzlhOTY3ZjFiZGM3YzJhMmZkMTlhYTI3OWU4ODUifSwiQ0FQRSI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzVjM2NhN2VlMmE0OThmMWI1ZDI1OGQ1ZmE5MjdlNjNlNDMzMTQzYWRkNTUzOGNmNjNiNmE5Yjc4YWU3MzUifX19"}]}}}}]}

--- a/gm4_metallurgy/data/metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/data/metallurgy/functions/main.mcfunction
@@ -8,7 +8,7 @@ effect give @a[nbt={Inventory:[{id:"minecraft:player_head",tag:{gm4_metallurgy:{
 execute as @e[type=tnt] run scoreboard players set found_primed_tnt gm4_ml_data 1
 
 #check for moulds waiting to be created
-execute at @e[type=item,nbt={Item:{id:"minecraft:obsidian",Count:1b},Motion:[0.0,0.0,0.0]},limit=1] if block ~ ~-1 ~ #minecraft:sand align xyz unless entity @e[type=vex,tag=gm4_sand_ring,dx=0,dy=-1,dz=0] if entity @e[type=item,nbt={Item:{id:"minecraft:clay_ball",Count:1b},Motion:[0.0,0.0,0.0]},dx=0,dy=0,dz=0] run function metallurgy:casting/create_mould
+execute as @e[type=item,nbt={Item:{id:"minecraft:obsidian",Count:1b},OnGround:1b}] at @s if block ~ ~-0.1 ~ #minecraft:sand run function metallurgy:casting/check_mould_creation
 
 #manage moulds
 execute as @e[type=vex,tag=gm4_sand_ring] at @s run function metallurgy:casting/sustain_mould


### PR DESCRIPTION
This pull request fixes a few issues that were found while trying to make an automated caster.

* Obsidian casts (Shamirs!) could jump and be absorbed by a mould
* Two ore items could jump on the same mould in one clock pulse
* Only one obsidian item globally was being checked to create a mould
* A mould could be formed with the items not directly on the sand, but for example on a slab

I tested these changes thoroughly to make sure that no items could be deleted or duplicated.