### PR TITLE
Liquid tanks removal of fill and drain

### DIFF
--- a/gm4_liquid_tanks/data/liquid_tanks/functions/init.mcfunction
+++ b/gm4_liquid_tanks/data/liquid_tanks/functions/init.mcfunction
@@ -7,12 +7,15 @@ scoreboard players set update_happened gm4_upCheck 1
 scoreboard players set liquid_tanks gm4_modules 1
 scoreboard players set liquid_tanks gm4_clock_tick 0
 
+# add scoreboards
 scoreboard objectives add gm4_lt_value dummy
 scoreboard objectives add gm4_lt_max dummy
-scoreboard objectives add gm4_lt_buffer dummy
-#scoreboard objectives add gm4_lt_disp_max
+scoreboard objectives add gm4_lt_old_value dummy
 scoreboard objectives add gm4_lt_disp_val dummy
 scoreboard objectives add gm4_lt_util dummy
+
+# remove old scoreboards
+scoreboard objectives remove gm4_lt_buffer
 
 #announce success
 tellraw @a[gamemode=creative] [{"translate":"%1$s","with":["[GM4]: ",{"translate":"text.gm4.prefix"}]},{"translate":"%1$s","with":["Liquid Tanks Installed!",{"translate":"text.gm4.modules.update.installed","with":[{"translate":"module.gm4.liquid_tanks"}]}]}]

--- a/gm4_liquid_tanks/data/liquid_tanks/functions/item_process.mcfunction
+++ b/gm4_liquid_tanks/data/liquid_tanks/functions/item_process.mcfunction
@@ -2,10 +2,14 @@
 #run from liquid_tanks:process
 
 #tank init
-execute if score @s[tag=gm4_lt_empty] gm4_lt_value matches 0 unless entity @s[tag=gm4_lt_fill] run function #liquid_tanks:tank_init
+execute if score @s[tag=gm4_lt_empty] gm4_lt_value matches 0 run function #liquid_tanks:tank_init
 
 #item drain
-execute unless entity @s[tag=gm4_lt_fill] run function #liquid_tanks:item_drain
+function #liquid_tanks:item_drain
 
-#item fill
-execute unless entity @s[tag=gm4_lt_drain] run function #liquid_tanks:item_fill
+#item_fill
+#make sure we don't undo our action
+execute store success score @s gm4_lt_util run data modify entity @s ArmorItems[3].tag.gm4_lt.last_item set from block ~ ~ ~ Items
+execute if score @s gm4_lt_util matches 0 run function #liquid_tanks:item_fill
+#store change
+execute if score @s gm4_lt_util matches 0 run data modify entity @s ArmorItems[3].tag.gm4_lt.last_item set from block ~ ~ ~ Items

--- a/gm4_liquid_tanks/data/liquid_tanks/functions/liquid_value_update.mcfunction
+++ b/gm4_liquid_tanks/data/liquid_tanks/functions/liquid_value_update.mcfunction
@@ -1,10 +1,9 @@
 #@s = liquid tank
 #run from liquid_tanks:process
 
-#apply buffer
-scoreboard players operation @s gm4_lt_value += @s gm4_lt_buffer
-scoreboard players set @s gm4_lt_buffer 0
+# cap value and update old val
 scoreboard players operation @s gm4_lt_value < @s gm4_lt_max
+scoreboard players operation @s gm4_lt_old_value = @s gm4_lt_value
 
 #if value of 0, set to empty
 execute if score @s gm4_lt_value matches ..0 at @s run function liquid_tanks:empty

--- a/gm4_liquid_tanks/data/liquid_tanks/functions/process.mcfunction
+++ b/gm4_liquid_tanks/data/liquid_tanks/functions/process.mcfunction
@@ -11,13 +11,10 @@ execute if block ~ ~ ~ hopper{Items:[{Slot:0b,Count:1b}]} run function liquid_ta
 execute unless block ~ ~ ~ hopper{Items:[{Slot:0b}]} run tag @s remove gm4_lt_drain
 execute unless block ~ ~ ~ hopper{Items:[{Slot:0b}]} run tag @s remove gm4_lt_fill
 
-#apply buffer and display level update
-execute unless score @s gm4_lt_buffer matches 0 run function liquid_tanks:liquid_value_update
-
 
 #entity processing
 execute align xyz positioned ~ ~1 ~ if entity @e[type=!armor_stand,dx=0] run function #liquid_tanks:util_above
 execute align xyz positioned ~ ~-1 ~ if entity @e[type=!armor_stand,dx=0] run function #liquid_tanks:util_below
 
-#apply buffer and display level update
-execute unless score @s gm4_lt_buffer matches 0 run function liquid_tanks:liquid_value_update
+# if value changed update display level
+execute unless score @s gm4_lt_old_value = @s gm4_lt_value run function liquid_tanks:liquid_value_update

--- a/gm4_liquid_tanks/data/liquid_tanks/functions/process.mcfunction
+++ b/gm4_liquid_tanks/data/liquid_tanks/functions/process.mcfunction
@@ -4,17 +4,16 @@
 #tank destruction
 execute unless block ~ ~ ~ hopper run function liquid_tanks:destroy
 
-#item processing
-execute if block ~ ~ ~ hopper{Items:[{Slot:0b,Count:1b}]} run function liquid_tanks:item_process
-
-#last action resetting
-execute unless block ~ ~ ~ hopper{Items:[{Slot:0b}]} run tag @s remove gm4_lt_drain
-execute unless block ~ ~ ~ hopper{Items:[{Slot:0b}]} run tag @s remove gm4_lt_fill
-
-
 #entity processing
 execute align xyz positioned ~ ~1 ~ if entity @e[type=!armor_stand,dx=0] run function #liquid_tanks:util_above
 execute align xyz positioned ~ ~-1 ~ if entity @e[type=!armor_stand,dx=0] run function #liquid_tanks:util_below
+
+#last action resetting iff value changed
+execute unless score @s gm4_lt_old_value = @s gm4_lt_value run data remove entity @s ArmorItems[3].tag.gm4_lt.last_item
+
+#item processing
+execute store success score @s gm4_lt_util run data modify entity @s ArmorItems[3].tag.gm4_lt.last_item set from block ~ ~ ~ Items
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,Count:1b}]} if score @s gm4_lt_util matches 1.. run function liquid_tanks:item_process
 
 # if value changed update display level
 execute unless score @s gm4_lt_old_value = @s gm4_lt_value run function liquid_tanks:liquid_value_update

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/beetroot.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/beetroot.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 air 1
-scoreboard players add @s gm4_lt_buffer 1
+scoreboard players add @s gm4_lt_value 1
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/beetroot.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/beetroot.mcfunction
@@ -1,3 +1,2 @@
 replaceitem block ~ ~ ~ container.0 air 1
 scoreboard players add @s gm4_lt_value 1
-tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bottle.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
-scoreboard players add @s gm4_lt_buffer 1
+scoreboard players add @s gm4_lt_value 1
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bottle.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
 scoreboard players add @s gm4_lt_value 1
-tag @s add gm4_lt_drain
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bowl.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bowl.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 bowl 1
 scoreboard players add @s gm4_lt_value 1
-tag @s add gm4_lt_drain
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bowl.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bowl.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 bowl 1
-scoreboard players add @s gm4_lt_buffer 1
+scoreboard players add @s gm4_lt_value 1
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 bucket 1
-scoreboard players add @s gm4_lt_buffer 3
+scoreboard players add @s gm4_lt_value 3
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 bucket 1
 scoreboard players add @s gm4_lt_value 3
-tag @s add gm4_lt_drain
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/enchanted_book.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/enchanted_book.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 book 1
-scoreboard players add @s gm4_lt_buffer 4
+scoreboard players add @s gm4_lt_value 4
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/enchanted_book.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/enchanted_book.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 book 1
 scoreboard players add @s gm4_lt_value 4
-tag @s add gm4_lt_drain
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/experience_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/experience_bottle.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
-scoreboard players add @s gm4_lt_buffer 9
+scoreboard players add @s gm4_lt_value 9
 tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/experience_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_drain/experience_bottle.mcfunction
@@ -1,3 +1,2 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
 scoreboard players add @s gm4_lt_value 9
-tag @s add gm4_lt_drain

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/beetroot_soup.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/beetroot_soup.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 beetroot_soup 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/beetroot_soup.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/beetroot_soup.mcfunction
@@ -1,3 +1,2 @@
 replaceitem block ~ ~ ~ container.0 beetroot_soup 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/experience_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/experience_bottle.mcfunction
@@ -1,5 +1,5 @@
 replaceitem block ~ ~ ~ container.0 experience_bottle 1
-scoreboard players remove @s gm4_lt_buffer 9
+scoreboard players remove @s gm4_lt_value 9
 tag @s add gm4_lt_fill
 
 advancement grant @a[distance=..4,gamemode=!spectator] only gm4:standard_liquids

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/experience_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/experience_bottle.mcfunction
@@ -1,5 +1,5 @@
 replaceitem block ~ ~ ~ container.0 experience_bottle 1
 scoreboard players remove @s gm4_lt_value 9
-tag @s add gm4_lt_fill
+
 
 advancement grant @a[distance=..4,gamemode=!spectator] only gm4:standard_liquids

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/lava_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/lava_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 lava_bucket 1
 scoreboard players remove @s gm4_lt_value 3
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/lava_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/lava_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 lava_bucket 1
-scoreboard players remove @s gm4_lt_buffer 3
+scoreboard players remove @s gm4_lt_value 3
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/milk_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/milk_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 milk_bucket 1
 scoreboard players remove @s gm4_lt_value 3
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/milk_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/milk_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 milk_bucket 1
-scoreboard players remove @s gm4_lt_buffer 3
+scoreboard players remove @s gm4_lt_value 3
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/mushroom_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/mushroom_stew.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 mushroom_stew 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/mushroom_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/mushroom_stew.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 mushroom_stew 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/rabbit_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/rabbit_stew.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 rabbit_stew 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/rabbit_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/rabbit_stew.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 rabbit_stew 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bottle.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:water"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bottle.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bottle.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:water"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 water_bucket 1
-scoreboard players remove @s gm4_lt_buffer 3
+scoreboard players remove @s gm4_lt_value 3
 tag @s add gm4_lt_fill

--- a/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bucket.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/item_fill/water_bucket.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 water_bucket 1
 scoreboard players remove @s gm4_lt_value 3
-tag @s add gm4_lt_fill
+

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/beetroot_soup.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/beetroot_soup.mcfunction
@@ -2,5 +2,5 @@
 #run from standard_liquids:util_below
 
 effect give @s saturation 1 5
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/cauldron.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/cauldron.mcfunction
@@ -1,7 +1,7 @@
 #@s = liquid tank, positioned at empty cauldron
 #run from standard_liquids:util_above
 
-execute if score @s gm4_lt_util matches 3.. run scoreboard players remove @s gm4_lt_buffer 3
+execute if score @s gm4_lt_util matches 3.. run scoreboard players remove @s gm4_lt_value 3
 execute if score @s gm4_lt_util matches 3.. run setblock ~ ~ ~ cauldron[level=3]
 execute if score @s gm4_lt_util matches 3.. run playsound item.bucket.empty block @a[distance=..10]
 execute if score @s gm4_lt_util matches 3.. run scoreboard players remove @s gm4_lt_util 3

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/cow.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/cow.mcfunction
@@ -7,7 +7,7 @@ scoreboard players add @s gm4_lt_util 1
 execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_empty,distance=..8] if score @s gm4_lt_value matches 0 at @s run function standard_liquids:liquid_init/milk
 
 #add milk to tank
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_milk,distance=..8] if score @s gm4_lt_value matches ..297 run scoreboard players add @s gm4_lt_buffer 3
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_milk,distance=..8] if score @s gm4_lt_value matches ..297 run scoreboard players add @s gm4_lt_value 3
 
 #reset score after 5 mins
 execute if score @s gm4_lt_util matches 375.. run scoreboard players reset @s gm4_lt_util

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/deposit_experience.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/deposit_experience.mcfunction
@@ -7,9 +7,9 @@ execute if score @s gm4_lt_util matches 0 if entity @s[level=1..] run scoreboard
 
 execute if score @s gm4_lt_util matches 5.. if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_value matches ..1390 run experience add @s -4 points
 
-execute if score @s gm4_lt_util matches 5.. if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_value matches ..1390 run scoreboard players add @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_buffer 4
+execute if score @s gm4_lt_util matches 5.. if score @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_value matches ..1390 run scoreboard players add @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_value 4
 
 execute if score @s gm4_lt_util matches 1.. run experience add @s -1 points
-execute if score @s gm4_lt_util matches 1.. run scoreboard players add @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_buffer 1
+execute if score @s gm4_lt_util matches 1.. run scoreboard players add @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] gm4_lt_value 1
 
-execute as @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] unless score @s gm4_lt_buffer matches 0 run function liquid_tanks:liquid_value_update
+execute as @e[type=armor_stand,tag=gm4_liquid_tank,limit=1,distance=..0.5] unless score @s gm4_lt_old_value = @s gm4_lt_value run function liquid_tanks:liquid_value_update

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/experience_orb.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/experience_orb.mcfunction
@@ -4,6 +4,6 @@
 #get xp orb's value
 execute store result score experience_value gm4_lt_util run data get entity @s Value
 
-scoreboard players operation @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer += experience_value gm4_lt_util
+scoreboard players operation @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_value += experience_value gm4_lt_util
 
 kill @s

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/furnace_fuel.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/furnace_fuel.mcfunction
@@ -6,9 +6,7 @@ execute if block ~ ~ ~ furnace[lit=false]{Items:[{Slot:1b,tag:{tankhoe:1b}}]} ru
 
 #adjust burntime and remove lava
 execute store success score lava_fueling gm4_lt_util if block ~ ~ ~ furnace[lit=true]{CookTime:1s,BurnTime:200s} run data merge block ~ ~ ~ {BurnTime:6600s}
-execute if score lava_fueling gm4_lt_util matches 1.. run scoreboard players remove @s gm4_lt_buffer 1
+execute if score lava_fueling gm4_lt_util matches 1.. run scoreboard players remove @s gm4_lt_value 1
 scoreboard players reset lava_fueling gm4_lt_util
 
 tag @s remove gm4_lt_furnace_start
-
-execute unless score @s gm4_lt_buffer matches 0 run function liquid_tanks:liquid_value_update

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/milk.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/milk.mcfunction
@@ -2,6 +2,6 @@
 #run from standard_liquids:util_below
 
 effect clear @s
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 3
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5
 #particle?

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/mooshroom.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/mooshroom.mcfunction
@@ -7,7 +7,7 @@ scoreboard players add @s gm4_lt_util 1
 execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_empty,distance=..8] if score @s gm4_lt_value matches 0 at @s run function standard_liquids:liquid_init/mushroom_stew
 
 #add mushroom stew to tank
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_mushroom_stew,distance=..8] if score @s gm4_lt_value matches ..299 run scoreboard players add @s gm4_lt_buffer 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_mushroom_stew,distance=..8] if score @s gm4_lt_value matches ..299 run scoreboard players add @s gm4_lt_value 1
 
 #reset score after 5 mins
 execute if score @s gm4_lt_util matches 375.. run scoreboard players reset @s gm4_lt_util

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/mushroom_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/mushroom_stew.mcfunction
@@ -2,5 +2,5 @@
 #run from standard_liquids:util_below
 
 effect give @s saturation 1 5
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/rabbit_stew.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/rabbit_stew.mcfunction
@@ -2,5 +2,5 @@
 #run from standard_liquids:util_below
 
 effect give @s saturation 1 9
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_liquid_tanks/data/standard_liquids/functions/util/withdraw_experience.mcfunction
+++ b/gm4_liquid_tanks/data/standard_liquids/functions/util/withdraw_experience.mcfunction
@@ -3,11 +3,9 @@
 
 
 execute if score @s gm4_lt_value matches 5.. run experience add @a[distance=..0.5,limit=1,gamemode=!spectator] 4
-execute if score @s gm4_lt_value matches 5.. run scoreboard players remove @s gm4_lt_buffer 4
+execute if score @s gm4_lt_value matches 5.. run scoreboard players remove @s gm4_lt_value 4
 
 execute if score @s gm4_lt_value matches 1.. run experience add @a[distance=..0.5,limit=1,gamemode=!spectator] 1
-execute if score @s gm4_lt_value matches 1.. run scoreboard players remove @s gm4_lt_buffer 1
+execute if score @s gm4_lt_value matches 1.. run scoreboard players remove @s gm4_lt_value 1
 
 execute if score @s gm4_lt_value matches 1.. run summon experience_orb ~ ~1.8 ~ {Age:5995,Value:0}
-
-execute unless score @s gm4_lt_buffer matches 0 run function liquid_tanks:liquid_value_update

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_drain/long_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_drain/long_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
 scoreboard players add @s gm4_lt_value 3
-tag @s add gm4_lt_drain
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_drain/long_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_drain/long_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
-scoreboard players add @s gm4_lt_buffer 3
+scoreboard players add @s gm4_lt_value 3
 tag @s add gm4_lt_drain

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_drain/potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_drain/potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
-scoreboard players add @s gm4_lt_buffer 1
+scoreboard players add @s gm4_lt_value 1
 tag @s add gm4_lt_drain

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_drain/potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_drain/potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 glass_bottle 1
 scoreboard players add @s gm4_lt_value 1
-tag @s add gm4_lt_drain
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/fire_resistance_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/fire_resistance_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:fire_resistance"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/fire_resistance_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/fire_resistance_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:fire_resistance"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/floating_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/floating_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"potion_liquids:floating",display:{Name:'{"translate":"%1$s","with":["Potion of Floating",{"translate":"item.gm4.floating_potion"}],"italic":false}'},CustomPotionEffects:[{Id:25b,Amplifier:0b,Duration:300}],CustomPotionColor:13631487} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/floating_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/floating_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"potion_liquids:floating",display:{Name:'{"translate":"%1$s","with":["Potion of Floating",{"translate":"item.gm4.floating_potion"}],"italic":false}'},CustomPotionEffects:[{Id:25b,Amplifier:0b,Duration:300}],CustomPotionColor:13631487} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/harming_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/harming_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:harming"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/harming_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/harming_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:harming"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/healing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/healing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:healing"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/healing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/healing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:healing"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/invisibility_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/invisibility_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:invisibility"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/invisibility_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/invisibility_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:invisibility"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/leaping_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/leaping_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:leaping"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/leaping_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/leaping_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:leaping"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/luck_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/luck_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:luck"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/luck_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/luck_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:luck"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/night_vision_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/night_vision_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:night_vision"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/night_vision_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/night_vision_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:night_vision"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/poison_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/poison_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:poison"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/poison_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/poison_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:poison"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/regeneration_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/regeneration_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:regeneration"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/regeneration_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/regeneration_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:regeneration"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slow_falling_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slow_falling_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:slow_falling"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slow_falling_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slow_falling_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:slow_falling"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slowness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slowness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:slowness"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slowness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/slowness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:slowness"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strength_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strength_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strength"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strength_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strength_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strength"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_harming_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_harming_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_harming"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_harming_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_harming_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_harming"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_healing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_healing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_healing"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_healing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_healing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_healing"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_leaping_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_leaping_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_leaping"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_leaping_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_leaping_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_leaping"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_regeneration_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_regeneration_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_regeneration"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_regeneration_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_regeneration_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_regeneration"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_slowness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_slowness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_slowness"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_slowness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_slowness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_slowness"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_strength_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_strength_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_strength"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_strength_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_strength_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_strength"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_swiftness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_swiftness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_swiftness"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_swiftness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_swiftness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_swiftness"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_turtle_master_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_turtle_master_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_turtle_master"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_turtle_master_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/strong_turtle_master_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:strong_turtle_master"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/swiftness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/swiftness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:swiftness"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/swiftness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/swiftness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:swiftness"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/turtle_master_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/turtle_master_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:turtle_master"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/turtle_master_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/turtle_master_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:turtle_master"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/water_breathing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/water_breathing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:water_breathing"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/water_breathing_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/water_breathing_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:water_breathing"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/weakness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/weakness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:weakness"} 1
-scoreboard players remove @s gm4_lt_buffer 1
+scoreboard players remove @s gm4_lt_value 1
 tag @s add gm4_lt_fill

--- a/gm4_potion_liquids/data/potion_liquids/functions/item_fill/weakness_potion.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/item_fill/weakness_potion.mcfunction
@@ -1,3 +1,3 @@
 replaceitem block ~ ~ ~ container.0 potion{Potion:"minecraft:weakness"} 1
 scoreboard players remove @s gm4_lt_value 1
-tag @s add gm4_lt_fill
+

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/fire_resistance.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/fire_resistance.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s fire_resistance 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/floating.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/floating.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s levitation 15 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/harming.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/harming.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s instant_damage 1 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/healing.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/healing.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s instant_health 1 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/invisibility.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/invisibility.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s invisibility 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/leaping.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/leaping.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s jump_boost 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/luck.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/luck.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s luck 300 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/night_vision.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/night_vision.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s night_vision 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/poison.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/poison.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s poison 45 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/regeneration.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/regeneration.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s regeneration 45 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/shulker.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/shulker.mcfunction
@@ -7,7 +7,7 @@ scoreboard players add @s gm4_lt_util 1
 execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_empty,distance=..8] if score @s gm4_lt_value matches 0 at @s run function potion_liquids:liquid_init/floating
 
 #add potion to tank
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_floating,distance=..8] if score @s gm4_lt_value matches ..299 run scoreboard players add @s gm4_lt_buffer 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_floating,distance=..8] if score @s gm4_lt_value matches ..299 run scoreboard players add @s gm4_lt_value 1
 
 #reset score after 5 mins
 execute if score @s gm4_lt_util matches 375.. run scoreboard players reset @s gm4_lt_util

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/slow_falling.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/slow_falling.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s slow_falling 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/slowness.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/slowness.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s slowness 90 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strength.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strength.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s strength 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_harming.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_harming.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s instant_damage 1 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_healing.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_healing.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s instant_health 1 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_leaping.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_leaping.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s jump_boost 90 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_poison.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_poison.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s poison 21 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_regeneration.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_regeneration.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s regeneration 22 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_slowness.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_slowness.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s slowness 20 3
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_strength.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_strength.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s strength 90 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_swiftness.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_swiftness.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s speed 90 1
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/strong_turtle_master.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/strong_turtle_master.mcfunction
@@ -3,5 +3,5 @@
 
 effect give @s slowness 20 5
 effect give @s resistance 20 3
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/swiftness.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/swiftness.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s speed 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/turtle_master.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/turtle_master.mcfunction
@@ -3,5 +3,5 @@
 
 effect give @s slowness 20 3
 effect give @s resistance 20 2
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/water_breathing.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/water_breathing.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s water_breathing 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/weakness.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/weakness.mcfunction
@@ -2,5 +2,5 @@
 #run from potion_liquids:util_below
 
 effect give @s weakness 180 0
-scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_buffer 1
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,distance=..8] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_potion_liquids/data/potion_liquids/functions/util/witch.mcfunction
+++ b/gm4_potion_liquids/data/potion_liquids/functions/util/witch.mcfunction
@@ -7,10 +7,10 @@ scoreboard players add @s gm4_lt_util 1
 execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_empty,distance=..8] if score @s gm4_lt_value matches 0 at @s run function potion_liquids:util/random_witch_init
 
 #add potion to tank
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_regeneration,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_buffer 1
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_swiftness,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_buffer 1
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_fire_resistance,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_buffer 1
-execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_harming,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_buffer 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_regeneration,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_value 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_swiftness,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_value 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_fire_resistance,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_value 1
+execute if score @s gm4_lt_util matches 1 as @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank,tag=gm4_lt_harming,distance=..8] if score @s gm4_lt_value matches ..29 run scoreboard players add @s gm4_lt_value 1
 
 #reset score after 5 mins
 execute if score @s gm4_lt_util matches 375.. run scoreboard players reset @s gm4_lt_util


### PR DESCRIPTION
This builds on #237

Comes with following features:
* Removes the need of adding the fill and drain tag to the tank. 
* Allows a drain operation immediately after a full operation unless that would undo the first. (and vica versa)