### PR TITLE
Addition of Zauber Liquids

### DIFF
--- a/gm4_zauber_liquids/data/gm4/tags/functions/init_check.json
+++ b/gm4_zauber_liquids/data/gm4/tags/functions/init_check.json
@@ -1,0 +1,5 @@
+{
+  "values":[
+    "zauber_liquids:init_check"
+  ]
+}

--- a/gm4_zauber_liquids/data/liquid_tanks/tags/functions/item_drain.json
+++ b/gm4_zauber_liquids/data/liquid_tanks/tags/functions/item_drain.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "zauber_liquids:item_drain"
+    ]
+
+}

--- a/gm4_zauber_liquids/data/liquid_tanks/tags/functions/item_fill.json
+++ b/gm4_zauber_liquids/data/liquid_tanks/tags/functions/item_fill.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "zauber_liquids:item_fill"
+    ]
+
+}

--- a/gm4_zauber_liquids/data/liquid_tanks/tags/functions/remove_liquid_tags.json
+++ b/gm4_zauber_liquids/data/liquid_tanks/tags/functions/remove_liquid_tags.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "zauber_liquids:remove_liquid_tags"
+    ]
+
+}

--- a/gm4_zauber_liquids/data/liquid_tanks/tags/functions/tank_init.json
+++ b/gm4_zauber_liquids/data/liquid_tanks/tags/functions/tank_init.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "zauber_liquids:tank_init"
+    ]
+
+}

--- a/gm4_zauber_liquids/data/liquid_tanks/tags/functions/util_below.json
+++ b/gm4_zauber_liquids/data/liquid_tanks/tags/functions/util_below.json
@@ -1,0 +1,6 @@
+{
+    "values":[
+      "zauber_liquids:util_below"
+    ]
+
+}

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/init.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/init.mcfunction
@@ -1,0 +1,15 @@
+#announce module installation
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Installing Zauber Liquids..."}]
+execute unless entity @p run say GM4: Installing Zauber Liquids...
+
+#declare and initialise scoreboards and settings
+scoreboard players set update_happened gm4_up_check 1
+scoreboard players set zauber_liquids gm4_modules 1
+#scoreboard players set potion_liquids gm4_clock_tick 0   ##Module Run by Liquid Tanks Base
+
+#announce success
+tellraw @a[gamemode=creative] ["",{"text":"[GM4]: Zauber Liquids Installed!"}]
+execute unless entity @p run say GM4: Zauber Liquids Installed!
+
+#check other modules to make sure they're up to date.
+#$moduleUpdateList

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/init_check.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/init_check.mcfunction
@@ -1,0 +1,3 @@
+#unless the module is already initialized
+execute unless score zauber_liquids gm4_modules matches 1.. run function zauber_liquids:init
+scoreboard players add installed_modules gm4_up_check 1

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_drain.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_drain.mcfunction
@@ -1,0 +1,23 @@
+#@s = liquid tank with item in first slot
+#run from liquid_tanks:item_process
+
+#healing
+execute if score @s[tag=gm4_lt_zauber_healing] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"healing"}}}]} run function zauber_liquids:item_drain/potion
+
+#harming
+execute if score @s[tag=gm4_lt_zauber_harming] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"harming"}}}]} run function zauber_liquids:item_drain/potion
+
+#leaping
+execute if score @s[tag=gm4_lt_zauber_leaping] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"leaping"}}}]} run function zauber_liquids:item_drain/potion
+
+#poison
+execute if score @s[tag=gm4_lt_zauber_poison] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"poison"}}}]} run function zauber_liquids:item_drain/potion
+
+#regeneration
+execute if score @s[tag=gm4_lt_zauber_regeneration] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"regeneration"}}}]} run function zauber_liquids:item_drain/potion
+
+#speed
+execute if score @s[tag=gm4_lt_zauber_speed] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"speed"}}}]} run function zauber_liquids:item_drain/potion
+
+#strength
+execute if score @s[tag=gm4_lt_zauber_strength] gm4_lt_value matches ..299 if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"strength"}}}]} run function zauber_liquids:item_drain/potion

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_drain/potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_drain/potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 glass_bottle 1
+scoreboard players add @s gm4_lt_buffer 1
+tag @s add gm4_lt_drain

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill.mcfunction
@@ -1,0 +1,23 @@
+#@s = liquid tank with item in first slot
+#run from liquid_tanks:item_process
+
+#harming
+execute if score @s[tag=gm4_lt_zauber_harming] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_harming_potion
+
+#healing
+execute if score @s[tag=gm4_lt_zauber_healing] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_healing_potion
+
+#leaping
+execute if score @s[tag=gm4_lt_zauber_leaping] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_leaping_potion
+
+#poison
+execute if score @s[tag=gm4_lt_zauber_poison] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_poison_potion
+
+#regeneration
+execute if score @s[tag=gm4_lt_zauber_regeneration] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_regenration_potion
+
+#speed
+execute if score @s[tag=gm4_lt_zauber_speed] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_speed_potion
+
+#strength
+execute if score @s[tag=gm4_lt_zauber_strength] gm4_lt_value matches 1.. if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:glass_bottle"}]} run function zauber_liquids:item_fill/zauber_strength_potion

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_harming_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_harming_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§cInstant Damage IV§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"harming"},HideFlags:32,Potion:harming,CustomPotionEffects:[{Id:7,Amplifier:3,Duration:1}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_healing_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_healing_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§9Instant Health IV§r","§cNausea (0:08)§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"healing"},HideFlags:32,Potion:healing,CustomPotionEffects:[{Id:6,Amplifier:3,Duration:1},{Id:9,Amplifier:0,Duration:160}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_leaping_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_leaping_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§9Jump Boost IV (1:30)§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"leaping"},HideFlags:32,Potion:leaping,CustomPotionEffects:[{Id:8,Amplifier:3,Duration:1800}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_poison_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_poison_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§cPoison IV (0:32)§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"poison"},HideFlags:32,Potion:poison,CustomPotionEffects:[{Id:19,Amplifier:3,Duration:640}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_regeneration_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_regeneration_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§9Regeneration IV (0:22)§r","§9Speed III (0:16)§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"regeneration"},HideFlags:32,Potion:regeneration,CustomPotionEffects:[{Id:10,Amplifier:3,Duration:440},{Id:1,Amplifier:2,Duration:320}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_speed_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_speed_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§9Speed IV (3:20)§r","§cWeakness IV (6:00)§r","","§5When Applied:§r","§9+80% Speed§r","§c-16 Attack Damage§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"speed"},HideFlags:32,Potion:swiftness,CustomPotionEffects:[{Id:1,Amplifier:3,Duration:4000},{Id:18,Amplifier:3,Duration:7200}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_strength_potion.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/item_fill/zauber_strength_potion.mcfunction
@@ -1,0 +1,3 @@
+replaceitem block ~ ~ ~ container.0 potion{display:{Lore:["§9Strength IV (1:30)§r","","§5When Applied:§r","§9+12 Attack Damage§r"]},gm4_zauber_cauldrons:{item:"zauber_potion",potion:"strength"},HideFlags:32,Potion:strength,CustomPotionEffects:[{Id:5,Amplifier:3,Duration:1800}]} 1
+scoreboard players remove @s gm4_lt_buffer 1
+tag @s add gm4_lt_fill

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/harming.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/harming.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Harming Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7EF95B85-BC21-C2FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDcxNjQyNDAsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI2MjkyYmYwNzk0N2IxNjQ3ZmFlNGJjYjc2NzVmOWNhZGJiZDY1MDczMjIzNDM0M2RiZGY2YzA0MTRkYiJ9fX0="}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_harming
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/healing.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/healing.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Healing Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7EF95B85-BC21-C9FF-9FC8-609ECAF80975,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDYzOTQ3MTEsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzliYTZjZjQzODg0YjJjZmMyNDU0NGNmYTVmNmZjNzViY2M3OGE2YWM1NjhmYTE5OGY2NDVkZDkxNWM4Y2FlMzcifX19"}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_healing
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/leaping.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/leaping.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Leaping Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7EF95B85-AC21-C9FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDY5NDYzMjksInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2RjMzE2NmFkZTk1NTA2Y2VmZDhjNTdiMWVlNWY4MTNiNTNhOWZjMTliYTEzNDhjYTE2NmE2YjBjZmEwMzAifX19"}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_leaping
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/poison.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/poison.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Poison Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:3EF95B85-BC21-C9FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDY4ODg4NzIsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzY2MWU3NWExMWEwNzBmNTgyMWMxYmJlOTkxMTJiZGJjYWVjY2IyZDQ3Njg2OWQ3N2ExYzJkZDlmZjY0MDM3In19fQ=="}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_poison
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/regeneration.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/regeneration.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Regeneration Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7EF95B89-BC21-C9FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDYxNzA4MTcsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI2YzljOTNjNjRlZmYzMzE4MzFmNDkyY2E2Nzc1YWJjY2VkM2RjZDhmZWExOWEzMmM0OTM4NjRkYjFlMWMifX19"}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_regeneration
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/speed.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/speed.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Speed Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7EF95BF5-BC21-C9FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDc2MjgyNjQsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU1N2FhOWExMTBmOTEwOGE3MWI2MzI5ODhhMzM4MzQ1OGY0NDVlYjJlYjBmMDM4ZjE3ZDQ5OGU0YmNiYTJhZCJ9fX0="}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_speed
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/strength.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/liquid_init/strength.mcfunction
@@ -1,0 +1,5 @@
+data merge block ~ ~ ~ {CustomName:"\"Zauber Strength Potion Tank\""}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Fire:20000,ArmorItems:[{},{},{},{id:"player_head",Count:1b,tag:{SkullOwner:{Id:7AF95B85-BC21-C9FF-9FC8-609ECAF80973,Properties:{textures:[{Value:"eyJ0aW1lc3RhbXAiOjE0MjkzNDY3NTE4NTAsInByb2ZpbGVJZCI6IjZjZjU0M2E2MGVlOTQzN2NiNjE0YzdiOTRkZTVjNWI3IiwicHJvZmlsZU5hbWUiOiJNcnNNYWtpc3RlaW4iLCJpc1B1YmxpYyI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2Y5NGE3YjJmZDc5MzYxNzdjNjI2ZDllYWQwZWY0MzRmMjNmNmViNmQyYzAzNDgwZGE2MDRlZWIyMWRjZiJ9fX0="}]}}}}]}
+scoreboard players set @s gm4_lt_max 300
+tag @s add gm4_lt_zauber_strength
+tag @s remove gm4_lt_empty

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/remove_liquid_tags.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/remove_liquid_tags.mcfunction
@@ -1,0 +1,10 @@
+#@s = liquid tank stand
+# removes all liquid tags from the stand. Used for emptying tank and reassigning liquid type
+
+tag @s remove gm4_lt_zauber_harming
+tag @s remove gm4_lt_zauber_healing
+tag @s remove gm4_lt_zauber_leaping
+tag @s remove gm4_lt_zauber_poison
+tag @s remove gm4_lt_zauber_regeneration
+tag @s remove gm4_lt_zauber_speed
+tag @s remove gm4_lt_zauber_strength

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/tank_init.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/tank_init.mcfunction
@@ -1,0 +1,23 @@
+#@s = empty liquid tank with item in first slot or entity on top
+#run from liquid_tanks:item_process
+
+#zauber leaping
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"leaping"}}}]} run function zauber_liquids:liquid_init/leaping
+
+#zauber speed
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"speed"}}}]} run function zauber_liquids:liquid_init/speed
+
+#zauber healing
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"healing"}}}]} run function zauber_liquids:liquid_init/healing
+
+#zauber harming
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"harming"}}}]} run function zauber_liquids:liquid_init/harming
+
+#zauber poison
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"poison"}}}]} run function zauber_liquids:liquid_init/poison
+
+#zauber regeneration
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"regeneration"}}}]} run function zauber_liquids:liquid_init/regeneration
+
+#zauber strength
+execute if block ~ ~ ~ hopper{Items:[{Slot:0b,id:"minecraft:potion",tag:{gm4_zauber_cauldrons:{item:"zauber_potion",potion:"strength"}}}]} run function zauber_liquids:liquid_init/strength

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/harming.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/harming.mcfunction
@@ -1,0 +1,6 @@
+#@s = living-base entity below zauber harming potion tank
+#run from zauber_liquids:util_below
+
+effect give @s instant_damage 1 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/healing.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/healing.mcfunction
@@ -1,0 +1,7 @@
+#@s = living-base entity below zauber healing potion tank
+#run from zauber_liquids:util_below
+
+effect give @s instant_health 1 3
+effect give @s nausea 8 0
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/leaping.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/leaping.mcfunction
@@ -1,0 +1,6 @@
+#@s = living-base entity below zauber leaping potion tank
+#run from zauber_liquids:util_below
+
+effect give @s jump_boost 90 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/poison.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/poison.mcfunction
@@ -1,0 +1,6 @@
+#@s = living-base entity below zauber poison potion tank
+#run from zauber_liquids:util_below
+
+effect give @s poison 32 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/regeneration.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/regeneration.mcfunction
@@ -1,0 +1,7 @@
+#@s = living-base entity below zauber regeneration potion tank
+#run from zauber_liquids:util_below
+
+effect give @s regeneration 22 3
+effect give @s speed 16 2
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/speed.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/speed.mcfunction
@@ -1,0 +1,7 @@
+#@s = living-base entity below zauber speed potion tank
+#run from zauber_liquids:util_below
+
+effect give @s speed 200 3
+effect give @s weakness 360 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util/strength.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util/strength.mcfunction
@@ -1,0 +1,6 @@
+#@s = living-base entity below zauber strength potion tank
+#run from zauber_liquids:util_below
+
+effect give @s strength 90 3
+scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_buffer 1
+playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5

--- a/gm4_zauber_liquids/data/zauber_liquids/functions/util_below.mcfunction
+++ b/gm4_zauber_liquids/data/zauber_liquids/functions/util_below.mcfunction
@@ -1,0 +1,27 @@
+#@s = tank with entity above it positioned ~ ~-1 ~
+#run from liquid_tanks:process via #liquid_tanks:util_below
+
+tag @s add gm4_processing_tank
+
+#harming
+execute if score @s[tag=gm4_lt_zauber_harming] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] run function zauber_liquids:util/harming
+
+#healing
+execute if score @s[tag=gm4_lt_zauber_healing] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] run function zauber_liquids:util/healing
+
+#leaping
+execute if score @s[tag=gm4_lt_zauber_leaping] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] if entity @s[nbt=!{ActiveEffects:[{Id:8b}]}] run function zauber_liquids:util/leaping
+
+#poison
+execute if score @s[tag=gm4_lt_zauber_poison] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] if entity @s[nbt=!{ActiveEffects:[{Id:19b}]}] run function zauber_liquids:util/poison
+
+#regeneration
+execute if score @s[tag=gm4_lt_zauber_regeneration] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] if entity @s[nbt=!{ActiveEffects:[{Id:10b}]}] run function zauber_liquids:util/regeneration
+
+#speed
+execute if score @s[tag=gm4_lt_zauber_speed] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] if entity @s[nbt=!{ActiveEffects:[{Id:1b}]}] run function zauber_liquids:util/speed
+
+#strength
+execute if score @s[tag=gm4_lt_zauber_strength] gm4_lt_value matches 1.. as @e[team=!invalid_team,type=!armor_stand,limit=1,dx=0] unless entity @s[gamemode=spectator] if entity @s[nbt=!{ActiveEffects:[{Id:5b}]}] run function zauber_liquids:util/strength
+
+tag @s remove gm4_processing_tank

--- a/gm4_zauber_liquids/pack.mcmeta
+++ b/gm4_zauber_liquids/pack.mcmeta
@@ -1,0 +1,28 @@
+{
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Zauber Liquids",
+  "module_id":"zauber_liquids",
+  "site_description":"Adds the ability to store potions in Liquid Tanks",
+  "site_categories":["Liquid Tanks"],
+  "video_link":"https://www.youtube.com/watch?v=qa9lcbii1BE",
+  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Tanks/Zauber_Liquids",
+  "required_modules":[
+    "liquid_tanks"
+  ],
+  "recommended_modules":[],
+  "credits":{
+    "Creator":[
+      ["SpecialBuilder32","https://twitter.com/SpecialBuilder"],
+      ["Bluefire610","https://twitter.com/Bluefire610"]
+    ],
+    "Icon Design":[
+      ["DuckJr","https://twitter.com/DuckJr94"]
+    ],
+    "Textures by":[
+      ["Vilder50"]
+    ]
+  }
+}


### PR DESCRIPTION
This liquid tanks expansion was done in a stream. 

Requires some more work to be compatible with zauber cauldrons and resource pack preparations.

- [ ] Zauber Cauldron module requires potion items to have identifying custom nbt
- [ ] Potion Item Lore in this module needs to be moved to json formatting
- [ ] Testing
- [ ] Probably a wiki page and icon.