### PR TITLE
Bats now no longer explode when they are defused

### DIFF
--- a/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
+++ b/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
@@ -1,2 +1,2 @@
 execute at @e[type=bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
-execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] unless entity @s[tag=gm4_defused_bat] run function bat_grenades:explode
+execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[tag=gm4_defused_bat] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode

--- a/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
+++ b/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
@@ -1,2 +1,2 @@
-execute at @e[type=bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
-execute as @e[type=bat,tag=gm4_defused_bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode
+execute at @e[type=bat,tag=!gm4_defused_bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
+execute as @e[type=bat,tag=!gm4_defused_bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode

--- a/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
+++ b/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
@@ -1,2 +1,2 @@
 execute at @e[type=bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
-execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[tag=gm4_defused_bat] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode
+execute as @e[type=bat,tag=gm4_defused_bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode

--- a/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
+++ b/gm4_bat_grenades/data/bat_grenades/functions/main.mcfunction
@@ -1,2 +1,2 @@
 execute at @e[type=bat] run playsound minecraft:entity.bat.ambient hostile @a[gamemode=!creative,gamemode=!spectator,distance=..7]
-execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] run function bat_grenades:explode
+execute as @e[type=bat] at @s if entity @a[gamemode=!creative,gamemode=!spectator,distance=..3] unless entity @s[nbt={NoAI:1b}] unless entity @s[tag=gm4_defused_bat] run function bat_grenades:explode


### PR DESCRIPTION
Added a check for the defused tag before the explode function is called so now bats do not explode when they are defused. ( Needs #236 to be able to defuse bats )