### PR TITLE
Change order of checks in decompress functions to fix NBT loss

### DIFF
--- a/gm4_block_compressors/data/block_compressors/functions/decompress/16.mcfunction
+++ b/gm4_block_compressors/data/block_compressors/functions/decompress/16.mcfunction
@@ -4,13 +4,13 @@
 #set item count
 data merge entity @s {Item:{Count:16b}}
 
-#restore original item tag, overwriting tags from compression
-data modify entity @s Item.tag set from entity @s Item.tag.gm4_precompression_tag
-
 #grandfather previously compressed items in older formats without gm4_precompression_tag
 execute unless data entity @s Item.tag.gm4_precompression_tag run data remove entity @s Item.tag
 
 #if original had no data, remove tag entirely
 execute if entity @s[nbt={Item:{tag:{gm4_precompression_tag:"no_tag_data_to_preserve"}}}] run data remove entity @s Item.tag
+
+#restore original item tag, overwriting tags from compression
+data modify entity @s Item.tag set from entity @s Item.tag.gm4_precompression_tag
 
 playsound entity.firework_rocket.blast block @a ~ ~ ~ 1 .1

--- a/gm4_block_compressors/data/block_compressors/functions/decompress/64.mcfunction
+++ b/gm4_block_compressors/data/block_compressors/functions/decompress/64.mcfunction
@@ -4,13 +4,13 @@
 #set item count
 data merge entity @s {Item:{Count:64b}}
 
-#restore original item tag, overwriting tags from compression
-data modify entity @s Item.tag set from entity @s Item.tag.gm4_precompression_tag
-
 #grandfather previously compressed items in older formats without gm4_precompression_tag
 execute unless data entity @s Item.tag.gm4_precompression_tag run data remove entity @s Item.tag
 
 #if original had no data, remove tag entirely
 execute if entity @s[nbt={Item:{tag:{gm4_precompression_tag:"no_tag_data_to_preserve"}}}] run data remove entity @s Item.tag
+
+#restore original item tag, overwriting tags from compression
+data modify entity @s Item.tag set from entity @s Item.tag.gm4_precompression_tag
 
 playsound entity.firework_rocket.blast block @a ~ ~ ~ 1 .1


### PR DESCRIPTION
Previously, the NBT restore would happen before the grandfathered check.
This would cause the `unless data entity @s Item.tag.gm4_precompression_tag` to always succeed, as the precompression tag would be removed by the restore. 
Changing the order allows all checks to work as intended, fixing the loss of NBT