### PR TITLE
fix translation for undead player

### DIFF
--- a/gm4_undead_players/data/undead_players/functions/main.mcfunction
+++ b/gm4_undead_players/data/undead_players/functions/main.mcfunction
@@ -1,5 +1,5 @@
 #@s = @a[scores={gm4_undead=1..},gamemode=!creative,gamemode=!spectator] at @s
 
-execute if entity @s[gamemode=!creative,gamemode=!spectator] run summon zombie ~ ~1 ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Undead Player",{"translate":"block.gm4.block_compressor"}]}',CustomNameVisible:1,CanPickUpLoot:1b,PersistenceRequired:1,IsBaby:0,HandItems:{},ArmorItems:{},Tags:["gm4_undead_player"]}
+execute if entity @s[gamemode=!creative,gamemode=!spectator] run summon zombie ~ ~1 ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Undead Player",{"translate":"entity.gm4.undead_player"}]}',CustomNameVisible:1,CanPickUpLoot:1b,PersistenceRequired:1,IsBaby:0,HandItems:{},ArmorItems:{},Tags:["gm4_undead_player"]}
 execute if entity @s[gamemode=!creative,gamemode=!spectator] run advancement grant @s only gm4:undead_players
 scoreboard players reset @s gm4_undead


### PR DESCRIPTION
The undead player had a translate value of "block.gm4.block_compressor" that i changed to "entity.gm4.undead_player" as in "[GM4_Resources/base/assets/gm4/lang/en_us.json](https://github.com/Gamemode4Dev/GM4_Resources/blob/master/base/assets/gm4/lang/en_us.json)"