### PR TITLE
Revert Liquid Minecarts Wiki Link

### DIFF
--- a/gm4_liquid_minecarts/pack.mcmeta
+++ b/gm4_liquid_minecarts/pack.mcmeta
@@ -8,7 +8,7 @@
   "site_description":"Allows Minecarts to move fluids between Liquid Tanks",
   "site_categories":["Liquid Tanks"],
   "video_link":"",
-  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Minecarts",
+  "wiki_link":"https://wiki.gm4.co/wiki/Liquid_Tanks/Liquid_Minecarts",
   "required_modules":[
     "liquid_tanks"
   ],


### PR DESCRIPTION
The wiki page was created with the wrong standard. The page has now been moved to a subpage of Liquid Tanks, as the original pack.mcmeta displayed.