### PR TITLE
Update destroy_liquid_tank.json

### DIFF
--- a/gm4_liquid_tanks/data/liquid_tanks/loot_tables/destroy_liquid_tank.json
+++ b/gm4_liquid_tanks/data/liquid_tanks/loot_tables/destroy_liquid_tank.json
@@ -45,6 +45,15 @@
           "name": "minecraft:iron_trapdoor"
         }
       ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:glass"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add glass to the loot table. Currently, the glass isn't dropped when breaking a liquid tank.