### PR TITLE
Fixed disabled slots and added support for sloped rail loading (liquid Minecarts)

### DIFF
--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
@@ -1,7 +1,7 @@
 #@s = hopper minecart with upgrade recipe inside
 #run from main
 
-summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,DisabledSlots:4144959,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f],RightArm:[0.0f,-90.0f,0.0f]}}]}
+summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,DisabledSlots:2039583,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f],RightArm:[0.0f,-90.0f,0.0f]}}]}
 execute as @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] run function liquid_minecarts:liquid_value_update
 data merge entity @s {Items:[]}
 kill @s

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/create.mcfunction
@@ -1,7 +1,7 @@
 #@s = hopper minecart with upgrade recipe inside
 #run from main
 
-summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisabledSlots:2039583,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f],RightArm:[0.0f,-90.0f,0.0f]}}]}
+summon command_block_minecart ~ ~ ~ {Command:"execute if score @s gm4_lt_value matches 1.. run function liquid_minecarts:drain_minecart",Tags:["gm4_liquid_minecart","gm4_liquid_minecart_empty"],CustomDisplayTile:1,DisplayState:{"Name":"minecraft:hopper"},Passengers:[{id:"minecraft:armor_stand",Tags:["gm4_liquid_minecart_display","gm4_no_edit"],Invisible:1b,DisabledSlots:4144959,Small:1b,ArmorItems:[{},{},{},{}],Pose:{Head:[180.0f,0.0f,0.0f],RightArm:[0.0f,-90.0f,0.0f]}}]}
 execute as @e[type=command_block_minecart,distance=..0,tag=gm4_liquid_minecart_empty] run function liquid_minecarts:liquid_value_update
 data merge entity @s {Items:[]}
 kill @s

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
@@ -2,7 +2,7 @@
 #run from try_to_unload
 
 data modify block ~ ~ ~ CustomName set from entity @s CustomName
-summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display","gm4_lm_needs_texture"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039583,Fire:20000}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display","gm4_lm_needs_texture"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:4144959,Fire:20000}
 data modify entity @e[type=armor_stand,tag=gm4_lm_needs_texture,limit=1,sort=nearest] ArmorItems[3] set from entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] HandItems[0]
 tag @e[type=armor_stand] remove gm4_lm_needs_texture
 scoreboard players operation @s gm4_lm_data = @s gm4_lt_max

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/init_tank.mcfunction
@@ -2,7 +2,7 @@
 #run from try_to_unload
 
 data modify block ~ ~ ~ CustomName set from entity @s CustomName
-summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display","gm4_lm_needs_texture"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:4144959,Fire:20000}
+summon armor_stand ~ ~-.45 ~ {CustomName:"\"gm4_liquid_tank_display\"",Tags:["gm4_no_edit","gm4_liquid_tank_display","gm4_lm_needs_texture"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039583,Fire:20000}
 data modify entity @e[type=armor_stand,tag=gm4_lm_needs_texture,limit=1,sort=nearest] ArmorItems[3] set from entity @e[type=armor_stand,tag=gm4_liquid_minecart_display,limit=1,sort=nearest] HandItems[0]
 tag @e[type=armor_stand] remove gm4_lm_needs_texture
 scoreboard players operation @s gm4_lm_data = @s gm4_lt_max

--- a/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_check.mcfunction
+++ b/gm4_liquid_minecarts/data/liquid_minecarts/functions/load_check.mcfunction
@@ -2,10 +2,10 @@
 #run from main
 
 #load
-execute if block ~1 ~ ~ hopper[facing=west] positioned ~1 ~ ~ run function liquid_minecarts:try_to_load
-execute if block ~-1 ~ ~ hopper[facing=east] positioned ~-1 ~ ~ run function liquid_minecarts:try_to_load
-execute if block ~ ~ ~1 hopper[facing=north] positioned ~ ~ ~1 run function liquid_minecarts:try_to_load
-execute if block ~ ~ ~-1 hopper[facing=south] positioned ~ ~ ~-1 run function liquid_minecarts:try_to_load
+execute if block ~1 ~ ~ hopper[facing=west] align xyz positioned ~1.5 ~ ~0.5 run function liquid_minecarts:try_to_load
+execute if block ~-1 ~ ~ hopper[facing=east] align xyz positioned ~-0.5 ~ ~0.5 run function liquid_minecarts:try_to_load
+execute if block ~ ~ ~1 hopper[facing=north] align xyz positioned ~0.5 ~ ~1.5 run function liquid_minecarts:try_to_load
+execute if block ~ ~ ~-1 hopper[facing=south] align xyz positioned ~0.5 ~ ~-0.5 run function liquid_minecarts:try_to_load
 execute if block ~ ~1 ~ hopper[facing=down] positioned ~ ~1 ~ run function liquid_minecarts:try_to_load
 
 #unload


### PR DESCRIPTION
I fixed the disabled slots NBT (updated values from bloo's patch and moved it from the minecart NBT to armour stand NBT in the create function.

The load check commands were modified to support them being aligned to allow for support for sloped rails when the cart is being loaded from the North, South, East or West directions.