### PR TITLE
Improved lag in detecting if a player has boots of ostara

### DIFF
--- a/gm4_boots_of_ostara/data/boots_of_ostara/advancements/enable_boots.json
+++ b/gm4_boots_of_ostara/data/boots_of_ostara/advancements/enable_boots.json
@@ -1,0 +1,18 @@
+{
+  "criteria": {
+    "boots_of_ostara": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:leather_boots",
+            "nbt": "{gm4_boots_of_ostara:1b}"
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "boots_of_ostara:enable_boots"
+  }
+}

--- a/gm4_boots_of_ostara/data/boots_of_ostara/functions/active.mcfunction
+++ b/gm4_boots_of_ostara/data/boots_of_ostara/functions/active.mcfunction
@@ -2,3 +2,5 @@ execute if block ~ ~-0.5 ~ dirt if entity @s[nbt={Inventory:[{Slot:-106b,id:"min
 execute if block ~ ~-0.5 ~ soul_sand if block ~ ~0.5 ~ air positioned ~ ~0.5 ~ if entity @s[nbt={Inventory:[{Slot:-106b,id:"minecraft:nether_wart"}]}] run function boots_of_ostara:plant/nether_wart
 execute if block ~ ~-0.5 ~ farmland if block ~ ~0.5 ~ air positioned ~ ~0.5 ~ run function boots_of_ostara:plant
 advancement grant @s only gm4:boots_of_ostara
+
+execute as @s[nbt=!{Inventory:[{Slot:100b,id:"minecraft:leather_boots",tag:{gm4_boots_of_ostara:1b}}]}] run advancement revoke @s only boots_of_ostara:enable_boots

--- a/gm4_boots_of_ostara/data/boots_of_ostara/functions/enable_boots.mcfunction
+++ b/gm4_boots_of_ostara/data/boots_of_ostara/functions/enable_boots.mcfunction
@@ -1,0 +1,2 @@
+#called by the advancement boots_of_ostara:enable_boots when they enable a pair of boots
+execute as @s[nbt=!{Inventory:[{Slot:100b,id:"minecraft:leather_boots",tag:{gm4_boots_of_ostara:1b}}]}] run advancement revoke @s only boots_of_ostara:enable_boots

--- a/gm4_boots_of_ostara/data/boots_of_ostara/functions/main.mcfunction
+++ b/gm4_boots_of_ostara/data/boots_of_ostara/functions/main.mcfunction
@@ -1,2 +1,2 @@
-execute as @a[gamemode=!spectator,nbt={Inventory:[{Slot:100b,id:"minecraft:leather_boots",tag:{gm4_boots_of_ostara:1b}}]}] at @s run function boots_of_ostara:active
+execute as @a[advancements={boots_of_ostara:enable_boots=true}] at @s run function boots_of_ostara:active
 execute as @e[type=armor_stand,nbt={HandItems:[{id:"minecraft:grass_block"}],ArmorItems:[{id:"minecraft:leather_boots",tag:{gm4_boots_of_ostara:1b}}]}] at @s if block ~ ~-0.5 ~ dirt run setblock ~ ~-0.5 ~ grass_block


### PR DESCRIPTION
It had been noticed on gm4 when debugs were ran the command that check players to see if they had boots of ostara in there inventory by quite a bit.

To fix this i have replaced the nbt check command with an advancement that is granted if they player has boots of ostara in there inv (it was not possible to check if it was in boot slot). From there this runs a functions that checks if it is in there boots slot, if they are it will then allow them to keep the advancement, if not it will remove the advancement. Then in the main function it just runs on players with the advancement and will check to see if they have removed them.