### PR TITLE
Change site category of Relocators to "Custom Crafting"

### DIFF
--- a/gm4_relocators/pack.mcmeta
+++ b/gm4_relocators/pack.mcmeta
@@ -7,7 +7,7 @@
   "module_id":"relocators",
   "site_description":"Craft relocators to move your custom crafters, liquid tanks, and other machines",
   "site_categories":[
-    "Custom Crafters"
+    "Custom Crafting"
   ],
   "video_link":"",
   "wiki_link":"https://wiki.gm4.co/wiki/Relocators",
@@ -22,9 +22,6 @@
   "credits":{
     "Creator":[
       ["BluePsychoRanger","https://www.twitter.com/BluPsychoRanger"]
-    ],
-    "Icon Design":[
-      ["DuckJr","https://www.twitter.com/DuckJr94"]
     ]
   }
 }


### PR DESCRIPTION
Relocators is currently categorized under "Custom Crafters," on the website which is incorrect. I also removed Duck from the Icon Design credits as it seems that he's taking a break from GM4 Module Icon design