### PR TITLE
1.14 compatibility

### DIFF
--- a/gm4_orbis/data/orbis/loot_tables/chests/dungeon_20.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/dungeon_20.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/dungeon_20"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/dungeon_30.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/dungeon_30.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/dungeon_30"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/dungeon_40.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/dungeon_40.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/dungeon_40"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/tower_110.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/tower_110.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/tower_110"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/tower_130.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/tower_130.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/tower_130"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/tower_150.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/tower_150.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/tower_150"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/tower_70.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/tower_70.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/tower_70"
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_orbis/data/orbis/loot_tables/chests/tower_90.json
+++ b/gm4_orbis/data/orbis/loot_tables/chests/tower_90.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_orbis:chests/tower_90"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Improves 1.14 compatibility.
- chests generated by Orbis in 1.14 will still give loot in 1.15