### PR TITLE
Fix load order of dependencies

### DIFF
--- a/gm4_ambrosia/data/load/tags/functions/gm4_ambrosia.json
+++ b/gm4_ambrosia/data/load/tags/functions/gm4_ambrosia.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_ambrosia:load"
     ]
 }

--- a/gm4_ambrosia/data/load/tags/functions/load.json
+++ b/gm4_ambrosia/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_ambrosia"
     ]
 }

--- a/gm4_block_compressors/data/load/tags/functions/gm4_block_compressors.json
+++ b/gm4_block_compressors/data/load/tags/functions/gm4_block_compressors.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_block_compressors:load"
     ]
 }

--- a/gm4_block_compressors/data/load/tags/functions/load.json
+++ b/gm4_block_compressors/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_block_compressors"
     ]
 }

--- a/gm4_boots_of_ostara/data/load/tags/functions/gm4_boots_of_ostara.json
+++ b/gm4_boots_of_ostara/data/load/tags/functions/gm4_boots_of_ostara.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_boots_of_ostara:load"
     ]
 }

--- a/gm4_boots_of_ostara/data/load/tags/functions/load.json
+++ b/gm4_boots_of_ostara/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_boots_of_ostara"
     ]
 }

--- a/gm4_cement_mixers/data/load/tags/functions/gm4_cement_mixers.json
+++ b/gm4_cement_mixers/data/load/tags/functions/gm4_cement_mixers.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_cement_mixers:load"
     ]
 }

--- a/gm4_cement_mixers/data/load/tags/functions/load.json
+++ b/gm4_cement_mixers/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_cement_mixers"
     ]
 }

--- a/gm4_cooler_caves/data/load/tags/functions/gm4_cooler_caves.json
+++ b/gm4_cooler_caves/data/load/tags/functions/gm4_cooler_caves.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_orbis",
         "gm4_cooler_caves:load"
     ]
 }

--- a/gm4_cooler_caves/data/load/tags/functions/load.json
+++ b/gm4_cooler_caves/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_orbis",
         "#load:gm4_cooler_caves"
     ]
 }

--- a/gm4_dangerous_dungeons/data/load/tags/functions/gm4_dangerous_dungeons.json
+++ b/gm4_dangerous_dungeons/data/load/tags/functions/gm4_dangerous_dungeons.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_orbis",
         "gm4_dangerous_dungeons:load"
     ]
 }

--- a/gm4_dangerous_dungeons/data/load/tags/functions/load.json
+++ b/gm4_dangerous_dungeons/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_orbis",
         "#load:gm4_dangerous_dungeons"
     ]
 }

--- a/gm4_disassemblers/data/load/tags/functions/gm4_disassemblers.json
+++ b/gm4_disassemblers/data/load/tags/functions/gm4_disassemblers.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_disassemblers:load"
     ]
 }

--- a/gm4_disassemblers/data/load/tags/functions/load.json
+++ b/gm4_disassemblers/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_disassemblers"
     ]
 }

--- a/gm4_heart_canisters/data/load/tags/functions/gm4_heart_canisters.json
+++ b/gm4_heart_canisters/data/load/tags/functions/gm4_heart_canisters.json
@@ -1,3 +1,6 @@
 {
-    "values": []
+    "values": [
+        "#load:gm4_custom_crafters",
+        "gm4_heart_canisters:load"
+    ]
 }

--- a/gm4_heart_canisters/data/load/tags/functions/load.json
+++ b/gm4_heart_canisters/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_heart_canisters"
     ]
 }

--- a/gm4_lightning_rods/data/load/tags/functions/gm4_lightning_rods.json
+++ b/gm4_lightning_rods/data/load/tags/functions/gm4_lightning_rods.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_lightning_rods:load"
     ]
 }

--- a/gm4_lightning_rods/data/load/tags/functions/load.json
+++ b/gm4_lightning_rods/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_lightning_rods"
     ]
 }

--- a/gm4_liquid_minecarts/data/load/tags/functions/gm4_liquid_minecarts.json
+++ b/gm4_liquid_minecarts/data/load/tags/functions/gm4_liquid_minecarts.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_liquid_minecarts:load"
     ]
 }

--- a/gm4_liquid_minecarts/data/load/tags/functions/load.json
+++ b/gm4_liquid_minecarts/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_liquid_minecarts"
     ]
 }

--- a/gm4_master_crafting/data/load/tags/functions/gm4_master_crafting.json
+++ b/gm4_master_crafting/data/load/tags/functions/gm4_master_crafting.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_master_crafting:load"
     ]
 }

--- a/gm4_master_crafting/data/load/tags/functions/load.json
+++ b/gm4_master_crafting/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_master_crafting"
     ]
 }

--- a/gm4_mending_tanks/data/load/tags/functions/gm4_mending_tanks.json
+++ b/gm4_mending_tanks/data/load/tags/functions/gm4_mending_tanks.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_mending_tanks:load"
     ]
 }

--- a/gm4_mending_tanks/data/load/tags/functions/load.json
+++ b/gm4_mending_tanks/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_mending_tanks"
     ]
 }

--- a/gm4_moneo_shamir/data/load/tags/functions/gm4_moneo_shamir.json
+++ b/gm4_moneo_shamir/data/load/tags/functions/gm4_moneo_shamir.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_metallurgy",
         "gm4_moneo_shamir:load"
     ]
 }

--- a/gm4_moneo_shamir/data/load/tags/functions/load.json
+++ b/gm4_moneo_shamir/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_metallurgy",
         "#load:gm4_moneo_shamir"
     ]
 }

--- a/gm4_orbis_pre_gen/data/load/tags/functions/gm4_orbis_pre_gen.json
+++ b/gm4_orbis_pre_gen/data/load/tags/functions/gm4_orbis_pre_gen.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_orbis",
         "gm4_orbis_pre_gen:load"
     ]
 }

--- a/gm4_orbis_pre_gen/data/load/tags/functions/load.json
+++ b/gm4_orbis_pre_gen/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_orbis",
         "#load:gm4_orbis_pre_gen"
     ]
 }

--- a/gm4_particles_pack/data/load/tags/functions/gm4_particles_pack.json
+++ b/gm4_particles_pack/data/load/tags/functions/gm4_particles_pack.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_better_armour_stands",
         "gm4_particles_pack:load"
     ]
 }

--- a/gm4_particles_pack/data/load/tags/functions/load.json
+++ b/gm4_particles_pack/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_better_armour_stands",
         "#load:gm4_particles_pack"
     ]
 }

--- a/gm4_poses_pack/data/load/tags/functions/gm4_poses_pack.json
+++ b/gm4_poses_pack/data/load/tags/functions/gm4_poses_pack.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_better_armour_stands",
         "gm4_poses_pack:load"
     ]
 }

--- a/gm4_poses_pack/data/load/tags/functions/load.json
+++ b/gm4_poses_pack/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_better_armour_stands",
         "#load:gm4_poses_pack"
     ]
 }

--- a/gm4_potion_liquids/data/load/tags/functions/gm4_potion_liquids.json
+++ b/gm4_potion_liquids/data/load/tags/functions/gm4_potion_liquids.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_potion_liquids:load"
     ]
 }

--- a/gm4_potion_liquids/data/load/tags/functions/load.json
+++ b/gm4_potion_liquids/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_potion_liquids"
     ]
 }

--- a/gm4_record_crafting/data/load/tags/functions/gm4_record_crafting.json
+++ b/gm4_record_crafting/data/load/tags/functions/gm4_record_crafting.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_record_crafting:load"
     ]
 }

--- a/gm4_record_crafting/data/load/tags/functions/load.json
+++ b/gm4_record_crafting/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_record_crafting"
     ]
 }

--- a/gm4_relocators/data/load/tags/functions/gm4_relocators.json
+++ b/gm4_relocators/data/load/tags/functions/gm4_relocators.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_relocators:load"
     ]
 }

--- a/gm4_relocators/data/load/tags/functions/load.json
+++ b/gm4_relocators/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_relocators"
     ]
 }

--- a/gm4_scuba_gear/data/load/tags/functions/gm4_scuba_gear.json
+++ b/gm4_scuba_gear/data/load/tags/functions/gm4_scuba_gear.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_scuba_gear:load"
     ]
 }

--- a/gm4_scuba_gear/data/load/tags/functions/load.json
+++ b/gm4_scuba_gear/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_scuba_gear"
     ]
 }

--- a/gm4_standard_crafting/data/load/tags/functions/gm4_standard_crafting.json
+++ b/gm4_standard_crafting/data/load/tags/functions/gm4_standard_crafting.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_standard_crafting:load"
     ]
 }

--- a/gm4_standard_crafting/data/load/tags/functions/load.json
+++ b/gm4_standard_crafting/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_standard_crafting"
     ]
 }

--- a/gm4_template_pack/data/gm4_template/functions/load.mcfunction
+++ b/gm4_template_pack/data/gm4_template/functions/load.mcfunction
@@ -2,4 +2,4 @@ execute if score gm4 load matches 1 run scoreboard players set gm4_MODULE_ID loa
 execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"MODULE NAME",require:"Gamemode 4"}
 
 execute if score gm4_MODULE_ID load matches 1 run function gm4_MODULE_ID:init
-execute unless score gm4_MODULE_ID load matches 1 run schedule clear MODULE_ID:main
+execute unless score gm4_MODULE_ID load matches 1 run schedule clear gm4_MODULE_ID:main

--- a/gm4_tower_structures/data/load/tags/functions/gm4_tower_structures.json
+++ b/gm4_tower_structures/data/load/tags/functions/gm4_tower_structures.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_orbis",
         "gm4_tower_structures:load"
     ]
 }

--- a/gm4_tower_structures/data/load/tags/functions/load.json
+++ b/gm4_tower_structures/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_orbis",
         "#load:gm4_tower_structures"
     ]
 }

--- a/gm4_trapped_signs/data/load/tags/functions/gm4_trapped_signs.json
+++ b/gm4_trapped_signs/data/load/tags/functions/gm4_trapped_signs.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_custom_crafters",
         "gm4_trapped_signs:load"
     ]
 }

--- a/gm4_trapped_signs/data/load/tags/functions/load.json
+++ b/gm4_trapped_signs/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_custom_crafters",
         "#load:gm4_trapped_signs"
     ]
 }

--- a/gm4_zauber_liquids/data/load/tags/functions/gm4_zauber_liquids.json
+++ b/gm4_zauber_liquids/data/load/tags/functions/gm4_zauber_liquids.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "#load:gm4_liquid_tanks",
         "gm4_zauber_liquids:load"
     ]
 }

--- a/gm4_zauber_liquids/data/load/tags/functions/load.json
+++ b/gm4_zauber_liquids/data/load/tags/functions/load.json
@@ -1,6 +1,5 @@
 {
     "values": [
-        "#load:gm4_liquid_tanks",
         "#load:gm4_zauber_liquids"
     ]
 }


### PR DESCRIPTION
This fix makes sure that dependencies of dependencies are loaded in the correct order. So for example while custom crafters is not a direct dependency of tinkering compressors, it is a dependency of a dependency.