### PR TITLE
Fix typo in particles pack

### DIFF
--- a/gm4_particles_pack/data/gm4_particles_pack/functions/main.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/main.mcfunction
@@ -1,4 +1,4 @@
 execute as @e[type=armor_stand,scores={gm4_particle=1..}] at @s run function gm4_particles_pack:particle
 execute as @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud] at @s unless entity @e[type=armor_stand,scores={gm4_particle=1..},distance=..1] run kill @s
 
-schedule function gm4_particles_pack:main
+schedule function gm4_particles_pack:main 16t


### PR DESCRIPTION
The main loop was only running on reload because the schedule command had a typo.