### PR TITLE
Fix orbis and orbis pre gen not working

### DIFF
--- a/gm4_orbis/data/gm4_orbis/functions/init.mcfunction
+++ b/gm4_orbis/data/gm4_orbis/functions/init.mcfunction
@@ -2,7 +2,7 @@ scoreboard objectives add gm4_count dummy
 scoreboard objectives add gm4_orbis_biome dummy
 scoreboard objectives add gm4_orbis_config dummy
 
-scoreboard players set speed gm4_orbis_config 4
+scoreboard players set speed gm4_orbis_config 2
 scoreboard players add chunk_count gm4_orbis_config 0
 scoreboard players add structure_count gm4_orbis_config 0
 

--- a/gm4_orbis/data/gm4_orbis/functions/main.mcfunction
+++ b/gm4_orbis/data/gm4_orbis/functions/main.mcfunction
@@ -1,5 +1,5 @@
 # reset the orbis clock score
-scoreboard players set orbis_tick gm4_clock_tick 0
+scoreboard players set $orbis_tick gm4_count 0
 # for every player, generate the nearest chunk
 execute at @a[tag=!gm4_orbis_disabled] positioned ~-8 ~ ~-8 as @e[type=area_effect_cloud,tag=gm4_chunk,tag=!gm4_generated,sort=nearest,limit=1] at @s if block ~ ~ ~ bedrock run function gm4_orbis:chunk/generate
 # kill chunk markers that have been generated and have all adjacent chunks generated

--- a/gm4_orbis/data/gm4_orbis/functions/tick.mcfunction
+++ b/gm4_orbis/data/gm4_orbis/functions/tick.mcfunction
@@ -1,4 +1,4 @@
-scoreboard players add orbis_tick gm4_clock_tick 1
-execute if score orbis_tick gm4_clock_tick >= speed gm4_orbis_config run function gm4_orbis:main
+scoreboard players add $orbis_tick gm4_count 1
+execute if score $orbis_tick gm4_count >= speed gm4_orbis_config run function gm4_orbis:main
 
 schedule function gm4_orbis:tick 1t

--- a/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/init.mcfunction
+++ b/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/init.mcfunction
@@ -5,6 +5,7 @@ scoreboard players set x1 gm4_orbis_config -1024
 scoreboard players set z1 gm4_orbis_config -1024
 scoreboard players set x2 gm4_orbis_config 1024
 scoreboard players set z2 gm4_orbis_config 1024
+scoreboard players set structure_debug gm4_orbis_config 1
 
 execute unless score orbis_pre_gen gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Orbis Pre Gen"}
 scoreboard players set orbis_pre_gen gm4_modules 1

--- a/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/main.mcfunction
+++ b/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/main.mcfunction
@@ -1,4 +1,4 @@
-scoreboard players set orbis_pre_gen_tick gm4_clock_tick 0
+scoreboard players set $orbis_pre_gen_tick gm4_count 0
 
 summon area_effect_cloud ~ ~ ~ {Tags:[gm4_orbis_gen_pos]}
 execute as @e[type=area_effect_cloud,tag=gm4_orbis_gen_pos,limit=1] run function gm4_orbis_pre_gen:generate

--- a/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/start.mcfunction
+++ b/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/start.mcfunction
@@ -5,5 +5,4 @@ gamemode spectator @s
 tag @s remove gm4_pre_gen_disabled
 tellraw @a[gamemode=!survival,gamemode=!adventure] [{"text":"Orbis Pre-gen started!","color":"green"}]
 
-scoreboard players set structure_debug gm4_orbis_config 1
 scoreboard players set pre_gen_running gm4_orbis_config 1

--- a/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/tick.mcfunction
+++ b/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/tick.mcfunction
@@ -1,6 +1,6 @@
 tag @a add gm4_orbis_disabled
 
-scoreboard players add orbis_pre_gen_tick gm4_clock_tick 1
-execute if score pre_gen_running gm4_orbis_config matches 1 if score orbis_pre_gen_tick gm4_clock_tick >= speed gm4_orbis_config if entity @a[gamemode=spectator,tag=!gm4_pre_gen_disabled] run function gm4_orbis_pre_gen:main
+scoreboard players add $orbis_pre_gen_tick gm4_count 1
+execute if score $orbis_pre_gen_tick gm4_count >= speed gm4_orbis_config if entity @a[gamemode=spectator,tag=!gm4_pre_gen_disabled] run function gm4_orbis_pre_gen:main
 
 schedule function gm4_orbis_pre_gen:tick 1t

--- a/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/tick.mcfunction
+++ b/gm4_orbis_pre_gen/data/gm4_orbis_pre_gen/functions/tick.mcfunction
@@ -1,6 +1,6 @@
 tag @a add gm4_orbis_disabled
 
-scoreboard players add $orbis_pre_gen_tick gm4_count 1
+execute if score pre_gen_running gm4_orbis_config matches 1 run scoreboard players add $orbis_pre_gen_tick gm4_count 1
 execute if score $orbis_pre_gen_tick gm4_count >= speed gm4_orbis_config if entity @a[gamemode=spectator,tag=!gm4_pre_gen_disabled] run function gm4_orbis_pre_gen:main
 
 schedule function gm4_orbis_pre_gen:tick 1t


### PR DESCRIPTION
The two modules were using the `gm4_clock_tick` scoreboard, but that doesn't exist anymore.