### PR TITLE
Fix formatting inconsistency in the template pack

### DIFF
--- a/gm4_template_pack/data/gm4_template/functions/load.mcfunction
+++ b/gm4_template_pack/data/gm4_template/functions/load.mcfunction
@@ -1,5 +1,5 @@
 execute if score gm4 load matches 1 run scoreboard players set gm4_MODULE_ID load 1
-execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"MODULE NAME",require:"Gamemode 4"}
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"MODULE_NAME",require:"Gamemode 4"}
 
 execute if score gm4_MODULE_ID load matches 1 run function gm4_MODULE_ID:init
 execute unless score gm4_MODULE_ID load matches 1 run schedule clear gm4_MODULE_ID:main


### PR DESCRIPTION
load.mcfunction referred to the module name as MODULE NAME instead of MODULE_NAME which was breaking a new tool I'm working on.