### PR TITLE
fix ability to get free protection 1 book (honey beetroot)

### DIFF
--- a/gm4_ambrosia/data/gm4_ambrosia/functions/honey_tanks/item_fill_beet.mcfunction
+++ b/gm4_ambrosia/data/gm4_ambrosia/functions/honey_tanks/item_fill_beet.mcfunction
@@ -1,3 +1,3 @@
-replaceitem block ~ ~ ~ container.0 beetroot{gm4_ambrosia:{item:"honey_beetroot"},HideFlags:3,Enchantments:[{id:"minecraft:protection",lvl:0}],display:{Name:'{"translate":"%1$s","with":["Honey-Glazed Beetroot","TRANSLATION.KEY.FOR.MISODE"],"italic":"false","color":"white"}',Lore:['{"text":"Regeneration (0:03)","color":"blue","italic":"false"}']}} 1
+replaceitem block ~ ~ ~ container.0 beetroot{gm4_ambrosia:{item:"honey_beetroot"},HideFlags:3,Enchantments:[{}],display:{Name:'{"translate":"%1$s","with":["Honey-Glazed Beetroot","TRANSLATION.KEY.FOR.MISODE"],"italic":"false","color":"white"}',Lore:['{"text":"Regeneration (0:03)","color":"blue","italic":"false"}']}} 1
 scoreboard players remove @s gm4_lt_buffer 1
 tag @s add gm4_lt_fill

--- a/gm4_ambrosia/data/gm4_ambrosia/functions/honey_tanks/item_fill_beet.mcfunction
+++ b/gm4_ambrosia/data/gm4_ambrosia/functions/honey_tanks/item_fill_beet.mcfunction
@@ -1,3 +1,3 @@
-replaceitem block ~ ~ ~ container.0 beetroot{gm4_ambrosia:{item:"honey_beetroot"},HideFlags:3,Enchantments:[{id:"minecraft:protection",lvl:1}],display:{Name:'{"translate":"%1$s","with":["Honey-Glazed Beetroot","TRANSLATION.KEY.FOR.MISODE"],"italic":"false","color":"white"}',Lore:['{"text":"Regeneration (0:03)","color":"blue","italic":"false"}']}} 1
+replaceitem block ~ ~ ~ container.0 beetroot{gm4_ambrosia:{item:"honey_beetroot"},HideFlags:3,Enchantments:[{id:"minecraft:protection",lvl:0}],display:{Name:'{"translate":"%1$s","with":["Honey-Glazed Beetroot","TRANSLATION.KEY.FOR.MISODE"],"italic":"false","color":"white"}',Lore:['{"text":"Regeneration (0:03)","color":"blue","italic":"false"}']}} 1
 scoreboard players remove @s gm4_lt_buffer 1
 tag @s add gm4_lt_fill


### PR DESCRIPTION
You could get a "free" protection 1 book by throwing a honey beetroot on an enchantment extractor (the beetroot still works), this was caused by the enchantment level being 1 instead of 0.