### PR TITLE
Remove liquid tanks check in orbis load

### DIFF
--- a/gm4_orbis/data/gm4_orbis/functions/load.mcfunction
+++ b/gm4_orbis/data/gm4_orbis/functions/load.mcfunction
@@ -1,4 +1,4 @@
-execute if score gm4 load matches 1 if score gm4_liquid_tanks load matches 1 run scoreboard players set gm4_orbis load 1
+execute if score gm4 load matches 1 run scoreboard players set gm4_orbis load 1
 execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Orbis",require:"Gamemode 4"}
 
 execute if score gm4_orbis load matches 1 run function gm4_orbis:init


### PR DESCRIPTION
This prevented Orbis from loading when liquid tanks was not installed.