### PR TITLE
Add 1.15 Book Binders

### DIFF
--- a/gm4_book_binders/data/gm4/advancements/book_binders.json
+++ b/gm4_book_binders/data/gm4/advancements/book_binders.json
@@ -1,0 +1,32 @@
+{
+  "display": {
+    "icon": {
+      "item": "lectern",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Ain't Got Rhythm",
+        {"translate": "advancement.gm4.book_binders.place"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Set up a Book Binder",
+        {"translate": "advancement.gm4.book_binders.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+    "gm4_place_book_binder": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "block": "minecraft:lectern"
+      }
+    }
+  }
+}

--- a/gm4_book_binders/data/gm4/advancements/book_binders_bind.json
+++ b/gm4_book_binders/data/gm4/advancements/book_binders_bind.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "enchanted_book",
+      "nbt": "{CustomModelData:1,Enchantments:[{id:\"minecraft:mending\",lvl:1}]}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Curse of Binding",
+        {"translate": "advancement.gm4.book_binders.bind"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Publish your first Enchanted Book",
+        {"translate": "advancement.gm4.book_binders_bind.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:book_binders",
+  "criteria": {
+    "gm4_book_binders_bind": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_book_binders/data/gm4/advancements/book_binders_debind.json
+++ b/gm4_book_binders/data/gm4/advancements/book_binders_debind.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "paper",
+      "nbt": "{CustomModelData:1,Enchantments:[{id:\"minecraft:mending\",lvl:1}]}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Tearing Up!",
+        {"translate": "advancement.gm4.book_binders.debind"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Get your first enchanted page",
+        {"translate": "advancement.gm4.book_binders_debind.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:book_binders",
+  "criteria": {
+    "gm4_book_binders_debind": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_book_binders/data/gm4/advancements/root.json
+++ b/gm4_book_binders/data/gm4/advancements/root.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "icon": {
+      "item": "command_block",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Gamemode 4",
+        {"translate": "advancement.gm4.root.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Semi-funny blurb about GM4",
+        {"translate": "advancement.gm4.root.description"}
+      ],
+      "color": "gray"
+    },
+    "background": "textures/block/light_blue_concrete_powder.png",
+    "announce_to_chat": false
+  },
+  "criteria": {
+    "automatic": {
+      "trigger": "minecraft:tick"
+    }
+  }
+}

--- a/gm4_book_binders/data/gm4_book_binders/advancements/place_new_lectern.json
+++ b/gm4_book_binders/data/gm4_book_binders/advancements/place_new_lectern.json
@@ -1,0 +1,13 @@
+{
+  "criteria": {
+    "place_lectern": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "block": "minecraft:lectern"
+      }
+    }
+  },
+  "rewards": {
+    "function": "gm4_book_binders:binder/placement/revoke_advancement"
+  }
+}

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/hopper/found_item.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/hopper/found_item.mcfunction
@@ -1,0 +1,16 @@
+# @s an active book binder with active hopper in the back
+# at location of hopper
+# run from gm4_book_binders:binder/hopper/grab
+
+# give item into armor stand's hand (done before count is reduced)
+data modify entity @s HandItems[0] set from storage gm4_book_binders:binder_container Items[0]
+data modify entity @s HandItems[0].Count set value 1
+
+# remove one item from hopper's first (filled) slot
+execute store result storage gm4_book_binders:binder_container Items[0].Count byte 1 run data get storage gm4_book_binders:binder_container Items[0].Count 0.99
+
+# return items into hopper
+data modify block ~ ~ ~ Items append from storage gm4_book_binders:binder_container Items[0]
+
+# clean up storage
+data remove storage gm4_book_binders:binder_container Items

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/hopper/grab.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/hopper/grab.mcfunction
@@ -1,0 +1,9 @@
+# @s an active book binder with active hopper in the back
+# at location of hopper
+# run from gm4_book_binders:binder/tick
+
+# copy the last stone slot to a temp array
+execute store success score found_item gm4_binder_data run data modify storage gm4_book_binders:binder_container Items set from block ~ ~ ~ Items
+
+# move item out of hopper if an item was found
+execute if score found_item gm4_binder_data matches 1.. run function gm4_book_binders:binder/hopper/found_item

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/detect_facing.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/detect_facing.mcfunction
@@ -1,0 +1,7 @@
+# @s = book binder AEC
+# at most negative corner of lectern
+# run from binder/placement/place_lectern
+execute if block ~ ~ ~ lectern[facing=north] run function gm4_book_binders:binder/placement/facing/north
+execute if block ~ ~ ~ lectern[facing=south] run function gm4_book_binders:binder/placement/facing/south
+execute if block ~ ~ ~ lectern[facing=east] run function gm4_book_binders:binder/placement/facing/east
+execute if block ~ ~ ~ lectern[facing=west] run function gm4_book_binders:binder/placement/facing/west

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/disable.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/disable.mcfunction
@@ -1,0 +1,9 @@
+# @s any book binder armor stand in lectern with book on actual lectern
+# at @s
+# run from gm4_book_binders:process_binder
+
+data merge entity @s {DisabledSlots:2039583,Marker:1b}
+tag @s remove gm4_book_binder_active
+
+# kill armor stands that are no longer in a lectern
+execute unless block ~ ~ ~ lectern run function gm4_book_binders:binder/placement/kill

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/drop_hand_item.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/drop_hand_item.mcfunction
@@ -1,0 +1,7 @@
+# @s a book binder NOT inside a lectern, with items in the hand slot
+# at @s
+# run from gm4_book_binders:binder/placement/kill
+
+# summon hand item as item entity
+summon item ~ ~ ~ {Tags:["gm4_empty_hand_item"],PickupDelay:0s,Item:{id:"minecraft:wooden_hoe",Count:1b}}
+data modify entity @e[type=item,limit=1,sort=nearest,tag=gm4_empty_hand_item,dx=0] Item set from entity @s HandItems[0]

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/drop_stored_item.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/drop_stored_item.mcfunction
@@ -1,0 +1,7 @@
+# @s a book binder NOT inside a lectern, with items in the foot slot
+# at @s
+# run from gm4_book_binders:binder/placement/kill
+
+#move the foot item with the lectern's inventory to the hand slot and then run the debinder to drop it all as pages
+data modify entity @s HandItems[0] set from entity @s ArmorItems[0]
+function gm4_book_binders:binder/recipes/enchanted_book

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/enable.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/enable.mcfunction
@@ -1,0 +1,6 @@
+# @s any book binder armor stand in lectern with book on actual lectern
+# at @s
+# run from gm4_book_binders:process_binder
+
+data merge entity @s {DisabledSlots:1973790,Marker:0b}
+tag @s add gm4_book_binder_active

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/east.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/east.mcfunction
@@ -1,0 +1,5 @@
+# @s = book binder AEC
+# at most negative corner of lectern
+# run from binder/placement/place_lectern
+
+summon minecraft:armor_stand ~.6 ~.01 ~.5 {Rotation:[90f,0f],NoGravity:1b,Small:1b,ShowArms:1b,Invisible:1b,Pose:{RightArm:[25.0f,0.0f,180.0f]},CustomName:'"gm4_book_binder"',Tags:["gm4_book_binder","gm4_book_binder_east","gm4_no_edit"],DeathLootTable:"minecraft:empty",ArmorItems:[{id:"minecraft:enchanted_book",Count:1b,tag:{StoredEnchantments:[]}},{},{},{}]}

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/north.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/north.mcfunction
@@ -1,0 +1,5 @@
+# @s = book binder AEC
+# at most negative corner of lectern
+# run from binder/placement/place_lectern
+
+summon minecraft:armor_stand ~.5 ~.01 ~.38 {NoGravity:1b,Small:1b,ShowArms:1b,Invisible:1b,Pose:{RightArm:[25.0f,0.0f,180.0f]},CustomName:'"gm4_book_binder"',Tags:["gm4_book_binder","gm4_book_binder_north","gm4_no_edit"],DeathLootTable:"minecraft:empty",ArmorItems:[{id:"minecraft:enchanted_book",Count:1b,tag:{StoredEnchantments:[]}},{},{},{}]}

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/south.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/south.mcfunction
@@ -1,0 +1,5 @@
+# @s = book binder AEC
+# at most negative corner of lectern
+# run from binder/placement/place_lectern
+
+summon minecraft:armor_stand ~.5 ~.01 ~.6 {Rotation:[180f,0f],NoGravity:1b,Small:1b,ShowArms:1b,Invisible:1b,Pose:{RightArm:[25.0f,0.0f,180.0f]},CustomName:'"gm4_book_binder"',Tags:["gm4_book_binder","gm4_book_binder_south","gm4_no_edit"],DeathLootTable:"minecraft:empty",ArmorItems:[{id:"minecraft:enchanted_book",Count:1b,tag:{StoredEnchantments:[]}},{},{},{}]}

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/west.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/facing/west.mcfunction
@@ -1,0 +1,5 @@
+# @s = book binder AEC
+# at most negative corner of lectern
+# run from binder/placement/place_lectern
+
+summon minecraft:armor_stand ~.38 ~.01 ~.5 {Rotation:[-90f,0f],NoGravity:1b,Small:1b,ShowArms:1b,Invisible:1b,Pose:{RightArm:[25.0f,0.0f,180.0f]},CustomName:'"gm4_book_binder"',Tags:["gm4_book_binder","gm4_book_binder_west","gm4_no_edit"],DeathLootTable:"minecraft:empty",ArmorItems:[{id:"minecraft:enchanted_book",Count:1b,tag:{StoredEnchantments:[]}},{},{},{}]}

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/kill.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/kill.mcfunction
@@ -1,0 +1,20 @@
+# @s a book binder NOT inside a lectern
+# at @s
+# run from gm4_book_binders:binder/placement/disable
+
+# check for the existence of an hand item
+scoreboard players reset has_hand_item gm4_binder_data
+execute store success score has_hand_item gm4_binder_data if entity @s[nbt={HandItems:[{Count:1b}]}]
+
+# drop hand items if necessary
+execute if score has_hand_item gm4_binder_data matches 1.. run function gm4_book_binders:binder/placement/drop_hand_item
+
+# check for the existence of an hand item
+scoreboard players reset has_stored_item gm4_binder_data
+execute store success score has_stored_item gm4_binder_data unless entity @s[nbt={ArmorItems:[{tag:{StoredEnchantments:[]}}]}]
+
+# drop internally stored pages if necessary
+execute if score has_stored_item gm4_binder_data matches 1.. run function gm4_book_binders:binder/placement/drop_stored_item
+
+# kill armor stand
+kill @s

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/place_lectern.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/place_lectern.mcfunction
@@ -1,0 +1,12 @@
+# @s = raycast AEC
+# at start location
+# run from binder/placement/revoke_advancement
+
+scoreboard players set gm4_ray_counter gm4_count 0
+execute as @s at @s run function gm4_book_binders:binder/placement/ray
+
+# detect lectern facing and convert to tag
+execute at @s align xyz unless entity @e[type=armor_stand,dx=0,dy=0,dz=0,tag=gm4_book_binder] run function gm4_book_binders:binder/placement/detect_facing
+
+# kill ray
+kill @s

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/ray.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/ray.mcfunction
@@ -1,0 +1,6 @@
+# @s = area effect cloud ray used to detect a lectern
+# run from binder/placement/place_lectern
+
+scoreboard players add gm4_ray_counter gm4_count 1
+tp @s ^ ^ ^0.01
+execute if score gm4_ray_counter gm4_count matches 0..500 at @s unless block ~ ~ ~ lectern run function gm4_book_binders:binder/placement/ray

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/revoke_advancement.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/placement/revoke_advancement.mcfunction
@@ -1,0 +1,9 @@
+# @s = player that just placed a lectern
+# run from advancement place_new_lectern
+
+# revoke advancement and summon ray
+advancement revoke @s only gm4_book_binders:place_new_lectern
+summon area_effect_cloud ~ ~ ~ {Tags:["gm4_book_binders_ray"]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[tag=gm4_book_binders_ray,limit=1,sort=nearest] ^ ^ ^ ~ ~
+
+execute as @e[tag=gm4_book_binders_ray,limit=1,sort=nearest] run function gm4_book_binders:binder/placement/place_lectern

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/binding.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/binding.mcfunction
@@ -1,0 +1,19 @@
+# as book binder marker armor stands with leather in hand
+# at @s
+#run from gm4_book_binders:binder/recipes/leather
+
+# reset fake players
+scoreboard players set enchantments_left gm4_binder_data 0
+
+#append first enchant from foot storage into enchanted book
+data modify entity @e[type=item,tag=gm4_empty_enchanted_book,limit=1,sort=nearest,distance=..0.3] Item.tag.StoredEnchantments append from entity @s ArmorItems[0].tag.StoredEnchantments[0]
+# delete enchantment from foot storage
+data remove entity @s ArmorItems[0].tag.StoredEnchantments[0]
+#check if foot storage still has enchants in it
+execute store result score enchantments_left gm4_binder_data run data get entity @s ArmorItems[0].tag.StoredEnchantments
+
+#delete the leather if so, loop otherwise
+execute if score enchantments_left gm4_binder_data matches 1.. run function gm4_book_binders:binder/recipes/binding
+
+# advancement
+advancement grant @a[distance=..3,gamemode=!spectator] only gm4:book_binders_bind

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/check_recipes.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/check_recipes.mcfunction
@@ -1,0 +1,8 @@
+# as book binder marker armor stands
+# at @s
+#run from gm4_book_binders:process_binders
+
+# check for binding/debinding
+execute if entity @s[nbt={HandItems:[{id:"minecraft:paper",tag:{gm4_book_binders:{item:"enchanted_page"}}}]}] run function gm4_book_binders:binder/recipes/page
+execute if entity @s[nbt={HandItems:[{id:"minecraft:enchanted_book"}]}] run function gm4_book_binders:binder/recipes/enchanted_book
+execute if entity @s[nbt={HandItems:[{id:"minecraft:leather"}]},tag=gm4_book_binder_with_page] run function gm4_book_binders:binder/recipes/leather

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/debinding.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/debinding.mcfunction
@@ -1,0 +1,24 @@
+# as book binder marker armor stands with enchanted book in hand
+# at @s
+#run from gm4_book_binders:binder/recipes/enchanted_book
+
+# reset fake players
+scoreboard players set enchantments_left gm4_binder_data 0
+
+# summon paper item (y offset to deposit items in hopper, but still make them pop out of a solid block)
+summon item ~ ~-0.26 ~ {Tags:["gm4_empty_enchanted_page"],PickupDelay:0s,Item:{id:"minecraft:paper",Count:1b,tag:{gm4_book_binders:{item:"enchanted_page"},display:{Name:'{"text":"Enchanted Page","italic":false}'},Enchantments:[]}}}
+#append first enchant from book into paper
+data modify entity @e[type=item,tag=gm4_empty_enchanted_page,limit=1,sort=nearest,distance=..0.3] Item.tag.Enchantments append from entity @s HandItems[0].tag.StoredEnchantments[0]
+# delete enchantment from book
+data remove entity @s HandItems[0].tag.StoredEnchantments[0]
+#check if book still has enchants in it
+execute store result score enchantments_left gm4_binder_data run data get entity @s HandItems[0].tag.StoredEnchantments
+
+# reset tags
+tag @e[type=item,distance=..0.3] remove gm4_empty_enchanted_page
+
+#delete the book if so, loop otherwise
+execute if score enchantments_left gm4_binder_data matches 1.. run function gm4_book_binders:binder/recipes/debinding
+
+# advancement
+advancement grant @a[distance=..3,gamemode=!spectator] only gm4:book_binders_debind

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/enchanted_book.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/enchanted_book.mcfunction
@@ -1,0 +1,13 @@
+# as book binder marker armor stands with enchanted book in hand
+# at @s
+#run from binder/recipes/check_recipes
+
+# transfer enchants onto pages
+function gm4_book_binders:binder/recipes/debinding
+
+# delete used up book
+data remove entity @s HandItems[0]
+
+# sounds and visuals
+playsound minecraft:block.beehive.shear master @a ~ ~ ~ 0.4 0.1
+particle item enchanted_book ^-.15 ^1.05 ^.05 .1 .1 .1 .07 6

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/leather.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/leather.mcfunction
@@ -1,0 +1,20 @@
+# as book binder marker armor stands with leather in hand
+# at @s
+#run from binder/recipes/check_recipes
+
+# summon empty enchanted book
+summon item ~ ~-0.26 ~ {Tags:["gm4_empty_enchanted_book"],PickupDelay:0s,Item:{id:"minecraft:enchanted_book",Count:1b,tag:{StoredEnchantments:[]}}}
+
+# remove the leather
+data remove entity @s HandItems[0]
+
+# compose enchants
+function gm4_book_binders:binder/recipes/binding
+
+# reset tags
+tag @s remove gm4_book_binder_with_page
+tag @e[type=item,distance=..0.3] remove gm4_empty_enchanted_book
+
+# sounds and visuals
+playsound minecraft:item.armor.equip_leather block @a ~ ~ ~ 0.4 1.5
+particle crit ^-.15 ^1.05 ^.05 .1 0 .1 .1 8

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/page.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/recipes/page.mcfunction
@@ -1,0 +1,17 @@
+# as book binder marker armor stands with enchanted page in hand
+# at @s
+#run from gm4_book_binders:binder/recipes/check_recipes
+
+# transfer data from paper to foot storage
+data modify entity @s ArmorItems[0].tag.StoredEnchantments append from entity @s HandItems[0].tag.Enchantments[0]
+
+# delete the held page item
+data remove entity @s HandItems[0]
+
+# mark armor stand as holding at least one page
+tag @s add gm4_book_binder_with_page
+
+# sounds and visuals
+playsound minecraft:item.book.page_turn block @a ~ ~ ~ 0.6 0.7
+playsound minecraft:entity.item.pickup block @a ~ ~ ~ 0.4 0.1
+particle enchant ^-.15 ^1.05 ^.05 .1 .1 .1 .1 10

--- a/gm4_book_binders/data/gm4_book_binders/functions/binder/tick.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/binder/tick.mcfunction
@@ -1,0 +1,16 @@
+# @s an active book binder
+# at @s
+# run from gm4_book_binders:process_binders
+
+# check for the existence of an hand item
+scoreboard players reset has_hand_item gm4_binder_data
+execute store success score has_hand_item gm4_binder_data if entity @s[nbt={HandItems:[{Count:1b}]}]
+
+# handle binders with item in hand slot
+execute if score has_hand_item gm4_binder_data matches 1.. if predicate gm4_book_binders:successful_process run function gm4_book_binders:binder/recipes/check_recipes
+
+# look for hopper in the back and move item into hand slot
+execute if score has_hand_item gm4_binder_data matches 0 if entity @s[tag=gm4_book_binder_north] positioned ~ ~ ~1 if block ~ ~ ~ hopper[facing=north,enabled=true] run function gm4_book_binders:binder/hopper/grab
+execute if score has_hand_item gm4_binder_data matches 0 if entity @s[tag=gm4_book_binder_south] positioned ~ ~ ~-1 if block ~ ~ ~ hopper[facing=south,enabled=true] run function gm4_book_binders:binder/hopper/grab
+execute if score has_hand_item gm4_binder_data matches 0 if entity @s[tag=gm4_book_binder_east] positioned ~-1 ~ ~ if block ~ ~ ~ hopper[facing=east,enabled=true] run function gm4_book_binders:binder/hopper/grab
+execute if score has_hand_item gm4_binder_data matches 0 if entity @s[tag=gm4_book_binder_west] positioned ~1 ~ ~ if block ~ ~ ~ hopper[facing=west,enabled=true] run function gm4_book_binders:binder/hopper/grab

--- a/gm4_book_binders/data/gm4_book_binders/functions/init.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/init.mcfunction
@@ -1,0 +1,11 @@
+# scoreboard init
+scoreboard objectives add gm4_count dummy
+scoreboard objectives add gm4_binder_data dummy
+
+# base init
+execute unless score book_binders gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Book Binders"}
+scoreboard players set book_binders gm4_modules 1
+
+schedule function gm4_book_binders:main 10t
+
+#$moduleUpdateList

--- a/gm4_book_binders/data/gm4_book_binders/functions/load.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_book_binders load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Book Binders",require:"Gamemode 4"}
+
+execute if score gm4_book_binders load matches 1 run function gm4_book_binders:init
+execute unless score gm4_book_binders load matches 1 run schedule clear gm4_book_binders:main

--- a/gm4_book_binders/data/gm4_book_binders/functions/main.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/main.mcfunction
@@ -1,0 +1,4 @@
+schedule function gm4_book_binders:main 16t
+
+# handle book binders
+execute as @e[type=armor_stand,tag=gm4_book_binder] at @s run function gm4_book_binders:process_binders

--- a/gm4_book_binders/data/gm4_book_binders/functions/process_binders.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/functions/process_binders.mcfunction
@@ -1,0 +1,15 @@
+# @s any book binder armor stand
+# at @s
+# run from gm4_book_binders:main
+
+# disable bookbinders with books on actual lectern
+execute unless entity @s[tag=gm4_book_binder_active] run function gm4_book_binders:binder/placement/enable
+execute unless block ~ ~ ~ lectern[has_book=false] run function gm4_book_binders:binder/placement/disable
+
+# slow clock per book binder for recipe processing
+scoreboard players add @s[tag=gm4_book_binder_active] gm4_binder_data 1
+execute if score @s gm4_binder_data matches 4.. run scoreboard players set @s gm4_binder_data 0
+
+
+#process binders that aren't locked on a slow clock
+execute if score @s[tag=gm4_book_binder_active] gm4_binder_data matches 0 at @s run function gm4_book_binders:binder/tick

--- a/gm4_book_binders/data/gm4_book_binders/predicates/successful_process.json
+++ b/gm4_book_binders/data/gm4_book_binders/predicates/successful_process.json
@@ -1,0 +1,4 @@
+{
+  "condition": "minecraft:random_chance",
+  "chance": 0.82
+}

--- a/gm4_book_binders/data/load/tags/functions/gm4_book_binders.json
+++ b/gm4_book_binders/data/load/tags/functions/gm4_book_binders.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_book_binders:load"
+    ]
+}

--- a/gm4_book_binders/data/load/tags/functions/load.json
+++ b/gm4_book_binders/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_book_binders"
+    ]
+}

--- a/gm4_book_binders/pack.mcmeta
+++ b/gm4_book_binders/pack.mcmeta
@@ -1,0 +1,31 @@
+{
+  "pack":{
+    "pack_format":0,
+    "description":"A Gamemode 4 Module"
+  },
+  "module_name":"Book Binders",
+  "module_id":"book_binders",
+  "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+  "site_description":"Someone forgot to type a description!",
+  "site_categories":[],
+  "video_link":"YOUTUBE_VIDEO_URL",
+  "wiki_link":"WIKI_URL",
+  "required_modules":[
+    "module_id of required module",
+    "or leave array empty"
+  ],
+  "recommended_modules":[
+    "module_id of recommended module",
+    "or leave array empty"
+  ],
+  "credits":{
+    "comment":"All credit arrays are optional and more can be created as needed. They will be displayed on the site page under their headings.",
+    "Creator":[
+      ["USERNAME","OPTIONAL_LINK"]
+    ],
+    "Updated By":[
+      ["USERNAME","OPTIONAL_LINK"],
+      ["USERNAME","OPTIONAL_LINK"]
+    ]
+  }
+}


### PR DESCRIPTION
This add the Book Binders module as seen on [a Development Stream in December 2019](https://www.youtube.com/watch?v=Qc0cVQwHTYU).

**How to obtain a Book Binder**
Any lectern acts as a Book Binder. Book Binders is essentially adding a new feature to minecraft's lecterns.

**How to use a Book Binder**
Book Binders can be operated manually by right-clicking ingredients onto it or via hoppers. Book Binders are fully compatible with hoppers, the input being on the back side of the lectern.

Book Binders have two modes; Binding and Debinding.

- Debind an enchanted book by placing it in the Book Binder
- Bind a new enchanted book by placing any amount of enchanted pages in the binder and finish the operation using a piece of leather

![2020-03-23_21 46 56](https://user-images.githubusercontent.com/41843855/77361611-e03a9100-6d4f-11ea-9140-6d426821f4c1.png)


