### PR TITLE
Update Ink Spitting Squid

### DIFF
--- a/gm4_ink_spitting_squid/data/gm4/advancements/ink_spitting_squid.json
+++ b/gm4_ink_spitting_squid/data/gm4/advancements/ink_spitting_squid.json
@@ -2,7 +2,7 @@
   "display": {
     "icon": {
       "item": "minecraft:ink_sac",
-      "nbt": "{display:{Name:'\"ink_spitting_squid logo\"'}}"
+      "nbt": "{CustomModelData:1}"
     },
     "title": {
       "translate": "%1$s%3427655$s",

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
@@ -1,3 +1,3 @@
-execute as @a[gamemode=!spectator] at @s if block ~ ~1 ~ water if entity @e[type=squid,distance=..2.2] run function gm4_ink_spitting_squid:squid_squirt
+execute at @e[type=squid] as @a[gamemode=!spectator,distance=..3] at @s positioned ^ ^ ^ if block ~ ~ ~ water run function gm4_ink_spitting_squid:squid_squirt
 
 schedule function gm4_ink_spitting_squid:main 16t

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
@@ -1,3 +1,3 @@
-execute at @e[type=squid] as @a[gamemode=!spectator,distance=..3] at @s positioned ^ ^ ^ if block ~ ~ ~ water run function gm4_ink_spitting_squid:squid_squirt
+execute at @e[type=squid] as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^ if block ~ ~ ~ water run function gm4_ink_spitting_squid:squid_squirt
 
 schedule function gm4_ink_spitting_squid:main 16t

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/squid_squirt.mcfunction
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/squid_squirt.mcfunction
@@ -4,4 +4,5 @@
 effect give @s nausea 5
 effect give @s blindness 5
 playsound minecraft:entity.squid.hurt hostile @a[distance=..5] ~ ~ ~ 1 2
+particle minecraft:squid_ink ^ ^ ^.5 .1 0 .1 0.05 10 normal @s
 advancement grant @s only gm4:ink_spitting_squid

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/squid_squirt.mcfunction
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/squid_squirt.mcfunction
@@ -1,5 +1,7 @@
 #@s = a player near a squid in water
-effect give @s nausea 5 0
-effect give @s blindness 5 0
-playsound minecraft:entity.squid.hurt master @a[distance=..2.2] ~ ~ ~ 1 2
+#run from main
+
+effect give @s nausea 5
+effect give @s blindness 5
+playsound minecraft:entity.squid.hurt hostile @a[distance=..5] ~ ~ ~ 1 2
 advancement grant @s only gm4:ink_spitting_squid

--- a/gm4_ink_spitting_squid/pack.mcmeta
+++ b/gm4_ink_spitting_squid/pack.mcmeta
@@ -20,12 +20,8 @@
         ],
         "Updated by": [
             [
-                "Bloo",
-                "https://www.twitter.com/Bloo_dev"
-            ],
-            [
-                "SpecialBuilder32",
-                "https://www.twitter.com/SpecialBuilder"
+                "BluePsychoRanger",
+                "https://www.twitter.com/BluPsychoRanger"
             ]
         ]
     }


### PR DESCRIPTION
- main runs to check all squids in the world, rather than all players in the world
- previously players wouldn't get blinded if in swim mode and the block above them isn't water (at the top layer of water)
- extended range to 3 blocks around squids
- modified play sound command to play as hostile instead of master and play in a larger radius
- fix ink sac in advancement to use CMD rather than name to indicate the custom texture support