### PR TITLE
Add slow_falling negation to desire lines

### DIFF
--- a/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
@@ -7,4 +7,5 @@ execute if score @s gm4_desire_lines matches 30.. run scoreboard players set @s 
 execute if score @s gm4_desire_lines matches 1.. run scoreboard players remove @s gm4_desire_lines 20
 
 function #gm4_desire_lines:expansion
+scoreboard players set @s[nbt=!{ActiveEffects:[{id:28}]}] gm4_desire_lines 0
 execute if score desire_lines gm4_dl_random matches ..2 if score @s gm4_desire_lines matches 1.. positioned ~ ~ ~ run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
@@ -7,5 +7,5 @@ execute if score @s gm4_desire_lines matches 30.. run scoreboard players set @s 
 execute if score @s gm4_desire_lines matches 1.. run scoreboard players remove @s gm4_desire_lines 20
 
 function #gm4_desire_lines:expansion
-scoreboard players set @s[nbt={ActiveEffects:[{id:28}]}] gm4_desire_lines 0
+execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players set @s gm4_desire_lines 0
 execute if score desire_lines gm4_dl_random matches ..2 if score @s gm4_desire_lines matches 1.. positioned ~ ~ ~ run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/functions/player.mcfunction
@@ -7,5 +7,5 @@ execute if score @s gm4_desire_lines matches 30.. run scoreboard players set @s 
 execute if score @s gm4_desire_lines matches 1.. run scoreboard players remove @s gm4_desire_lines 20
 
 function #gm4_desire_lines:expansion
-scoreboard players set @s[nbt=!{ActiveEffects:[{id:28}]}] gm4_desire_lines 0
+scoreboard players set @s[nbt={ActiveEffects:[{id:28}]}] gm4_desire_lines 0
 execute if score desire_lines gm4_dl_random matches ..2 if score @s gm4_desire_lines matches 1.. positioned ~ ~ ~ run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/predicates/has_slow_falling.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicates/has_slow_falling.json
@@ -1,0 +1,9 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "effects": {
+      "slow_falling": {}
+    }
+  }
+}


### PR DESCRIPTION
This just cancels the ability for desire lines to affect blocks around the player if they have the slow falling potion effect.

(This will allow soul glass beacons to cancel desire lines' effects around them)

Edit: Moved slow_falling check from nbt to predicate