### PR TITLE
Allow defuse shamir to work on armor stands

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
@@ -19,6 +19,7 @@ scoreboard players add current_sensus_layer gm4_ml_data 1
 execute if score current_sensus_layer gm4_ml_data matches 6.. run scoreboard players set current_sensus_layer gm4_ml_data 0
 
 execute as @a[gamemode=!spectator] run function gm4_metallurgy:player
+execute as @e[type=minecraft:armor_stand] if predicate gm4_metallurgy:shamir_equipped at @s run function gm4_metallurgy:shamir_equipped
 
 execute as @e[scores={gm4_bolt_time=1..}] at @s run function gm4_ender_bolt_shamir:main
 scoreboard players reset * gm4_bolt_damage


### PR DESCRIPTION
With this addition you could place defuse on armor stands to protect your area, so players without defuse can enter it without accidentally letting a creeper blow up

Suggestion was approved a couple months ago on GM4 Labs https://discordapp.com/channels/515225138006851624/515578870540533771/652231317148401674 