### PR TITLE
Improves Metallurgy's Spectator Handler

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
@@ -18,7 +18,7 @@ scoreboard players set levity_active gm4_ml_data 0
 scoreboard players add current_sensus_layer gm4_ml_data 1
 execute if score current_sensus_layer gm4_ml_data matches 6.. run scoreboard players set current_sensus_layer gm4_ml_data 0
 
-execute as @a[gamemode=!spectator] run function gm4_metallurgy:player
+execute as @a run function gm4_metallurgy:player
 
 execute as @e[scores={gm4_bolt_time=1..}] at @s run function gm4_ender_bolt_shamir:main
 scoreboard players reset * gm4_bolt_damage

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/player.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/player.mcfunction
@@ -11,8 +11,8 @@ tag @s remove gm4_has_sensus
 tag @s remove gm4_has_levity
 tag @s remove gm4_has_forterra
 
-execute if predicate gm4_metallurgy:shamir_in_hand at @s run function gm4_metallurgy:shamir_in_hand
-execute if predicate gm4_metallurgy:shamir_equipped at @s run function gm4_metallurgy:shamir_equipped
+execute if predicate gm4_metallurgy:shamir_in_hand at @s[gamemode=!spectator] run function gm4_metallurgy:shamir_in_hand
+execute if predicate gm4_metallurgy:shamir_equipped at @s[gamemode=!spectator] run function gm4_metallurgy:shamir_equipped
 
 execute if entity @s[scores={gm4_volt_time=-1..},tag=!gm4_has_conduction] at @s run function gm4_conduction_shamir:deselected_tool
 


### PR DESCRIPTION
This change allows the module to revoke the "gm4_has_shamir" tags from spectators, whilst not allowing these tags to be re-applied onto spectators. This should make sure all base-packaged shamirs only work on non-spectator players, thereby fixing #416 .
Not that this only affects shamirs packaged within the metallurgy base.