### PR TITLE
Add Server Utility Modules (Multiplayer Sleeping, AFK Detector, Increased Shulker Skells, Better Head Drops)

### DIFF
--- a/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
+++ b/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "bell",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Get back to work!",
+        {"translate": "advancement.gm4.afk_detector.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You've been away from your keyboard for 24 hours",
+        {"translate": "advancement.gm4.afk_detector.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:you_still_there",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_afk_detector/data/gm4/advancements/you_still_there.json
+++ b/gm4_afk_detector/data/gm4/advancements/you_still_there.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "dead_bush",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You still there?",
+        {"translate": "advancement.gm4.afk_detector.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Go away from your keyboard for the first time",
+        {"translate": "advancement.gm4.afk_detector.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/afk_away.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/afk_away.mcfunction
@@ -1,0 +1,12 @@
+team join gm4_afk @s[team=]
+#For each team you have on your server, replace TEAM with the team name
+#
+#team join afk_TEAM @s[team=TEAM]
+#
+#Example:
+#
+#team join afk_Admin @s[team=Admin]
+
+tag @s add gm4_afk
+
+tellraw @a ["",{"selector":"@s"},{"text":" is now away from their keyboard","color":"gray"}]

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/afk_back.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/afk_back.mcfunction
@@ -1,0 +1,12 @@
+team leave @s[team=gm4_afk]
+#For each team you have on your server, replace TEAM with the team name
+#
+#team join TEAM @s[team=afk_TEAM]
+#
+#Example:
+#
+#team join Admin @s[team=afk_Admin]
+
+tag @s remove gm4_afk
+scoreboard players set @s gm4_afk_count 0
+tellraw @a ["",{"selector":"@s"},{"text":" is now back at their keyboard","color":"gray"}]

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
@@ -1,0 +1,27 @@
+scoreboard players set @s gm4_afk_still 0
+
+#Store Pos
+execute store result score @s gm4_afk_x run data get entity @s Pos[0]
+execute store result score @s gm4_afk_y run data get entity @s Pos[1]
+execute store result score @s gm4_afk_z run data get entity @s Pos[2]
+
+#Check for movment
+execute if score @s gm4_afk_x = @s gm4_afk_x1 run scoreboard players add @s gm4_afk_still 1
+execute if score @s gm4_afk_y = @s gm4_afk_y1 run scoreboard players add @s gm4_afk_still 1
+execute if score @s gm4_afk_z = @s gm4_afk_z1 run scoreboard players add @s gm4_afk_still 1
+
+#Store 2nd Pos
+execute store result score @s gm4_afk_x1 run data get entity @s Pos[0]
+execute store result score @s gm4_afk_y1 run data get entity @s Pos[1]
+execute store result score @s gm4_afk_z1 run data get entity @s Pos[2]
+
+scoreboard players add @s[scores={gm4_afk_still=3},tag=!gm4_afk] gm4_afk_count 1
+scoreboard players set @s[scores={gm4_afk_still=..2}] gm4_afk_count 0
+scoreboard players add @s[tag=gm4_afk] gm4_afk_total 1
+
+advancement grant @s[scores={gm4_afk_total=1}] only gm4:you_still_there
+advancement grant @s[scores={gm4_afk_total=86400}] only gm4:get_back_to_work
+
+execute as @s[scores={gm4_afk_count=900..},tag=!gm4_afk] run function gm4_afk_detector:afk_away
+execute as @s[scores={gm4_afk_count=0},tag=gm4_afk] run function gm4_afk_detector:afk_back
+

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/clock.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/clock.mcfunction
@@ -1,0 +1,3 @@
+execute as @a run function gm4_afk_detector:check_pos
+
+schedule function gm4_afk_detector:clock 20t

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/init.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/init.mcfunction
@@ -1,0 +1,25 @@
+team add gm4_afk
+team modify gm4_afk prefix ["",{"text":"[AFK] ","color":"gray"}]
+
+scoreboard objectives add gm4_afk_leave minecraft.custom:minecraft.leave_game
+scoreboard objectives add gm4_afk_still dummy
+scoreboard objectives add gm4_afk_count dummy
+scoreboard objectives add gm4_afk_total dummy
+
+scoreboard objectives add gm4_afk_x dummy
+scoreboard objectives add gm4_afk_y dummy
+scoreboard objectives add gm4_afk_z dummy
+scoreboard objectives add gm4_afk_x1 dummy
+scoreboard objectives add gm4_afk_y1 dummy
+scoreboard objectives add gm4_afk_z1 dummy
+
+function gm4_afk_detector:init_team
+
+execute as @a[gamemode=!spectator] run function gm4_afk_detector:check_pos
+
+execute unless score afk_detector gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"AFK Detector"}
+scoreboard players set afk_detector gm4_modules 1
+
+schedule function gm4_afk_detector:clock 20t
+
+#$moduleUpdateList

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/init_team.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/init_team.mcfunction
@@ -1,0 +1,11 @@
+#For each team you have on your server, replace TEAM with the team name
+#
+#team add afk_TEAM
+#team modify TEAM prefix ["",{"text":"[AFK] ","color":"gray"}]
+#
+#Example:
+#
+#team add afk_Admin
+#team modify afk_Admin prefix ["",{"text":"[AFK] ","color":"gray"}]
+#Modify color to match original team if required
+#team modify afk_Admin color aqua

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/load.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_afk_detector load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"AFK Detector",require:"Gamemode 4"}
+
+execute if score gm4_afk_detector load matches 1 run function gm4_afk_detector:init
+execute unless score gm4_afk_detector load matches 1 run schedule clear gm4_afk_detector:main

--- a/gm4_afk_detector/data/load/tags/functions/gm4_afk_detector.json
+++ b/gm4_afk_detector/data/load/tags/functions/gm4_afk_detector.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_afk_detector:load"
+    ]
+}

--- a/gm4_afk_detector/data/load/tags/functions/load.json
+++ b/gm4_afk_detector/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_afk_detector"
+    ]
+}

--- a/gm4_afk_detector/pack.mcmeta
+++ b/gm4_afk_detector/pack.mcmeta
@@ -1,0 +1,25 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "AFK Detector"
+    },
+    "module_name": "AFK Detector",
+    "module_id": "afk_detector",
+    "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "Detect and label players away from their keyboards",
+    "site_categories": [],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [
+        "multiplayer_sleeping"
+    ],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}

--- a/gm4_better_head_drops/data/gm4/advancements/better_head_drops.json
+++ b/gm4_better_head_drops/data/gm4/advancements/better_head_drops.json
@@ -1,0 +1,34 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:player_head"
+	},
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Decapitation",
+        {"translate": "advancement.gm4.player_head_drops.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Explode a charged Creeper and drop a player head",
+        {"translate": "advancement.gm4.player_head_drops.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+        "c1": {
+            "trigger": "minecraft:entity_killed_player",
+            "conditions": {
+                "entity": {
+                    "type": "minecraft:creeper",
+                    "nbt": "{powered:1b}"
+                }
+            }
+        }
+    }
+}

--- a/gm4_better_head_drops/data/gm4_better_head_drops/functions/init.mcfunction
+++ b/gm4_better_head_drops/data/gm4_better_head_drops/functions/init.mcfunction
@@ -1,0 +1,4 @@
+execute unless score better_head_drops gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Better Head Drops"}
+scoreboard players set better_head_drops gm4_modules 1
+
+#$moduleUpdateList

--- a/gm4_better_head_drops/data/gm4_better_head_drops/functions/load.mcfunction
+++ b/gm4_better_head_drops/data/gm4_better_head_drops/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_better_head_drops load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Better Head Drops",require:"Gamemode 4"}
+
+execute if score gm4_better_head_drops load matches 1 run function gm4_better_head_drops:init
+execute unless score gm4_better_head_drops load matches 1 run schedule clear gm4_better_head_drops:main

--- a/gm4_better_head_drops/data/load/tags/functions/gm4_better_head_drops.json
+++ b/gm4_better_head_drops/data/load/tags/functions/gm4_better_head_drops.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_better_head_drops:load"
+    ]
+}

--- a/gm4_better_head_drops/data/load/tags/functions/load.json
+++ b/gm4_better_head_drops/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_better_head_drops"
+    ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/bastion_treasure.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/bastion_treasure.json
@@ -1,0 +1,377 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.25
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 2.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ],
+          "name": "minecraft:netherite_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 14,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ],
+          "name": "minecraft:ancient_debris"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ],
+          "name": "minecraft:netherite_scrap"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
+            }
+          ],
+          "name": "minecraft:ancient_debris"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:diamond_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 6,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:diamond_chestplate"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 6,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:diamond_helmet"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 6,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:diamond_leggings"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 6,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:diamond_boots"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 6,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            }
+          ],
+          "name": "minecraft:diamond_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            }
+          ],
+          "name": "minecraft:diamond_chestplate"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            }
+          ],
+          "name": "minecraft:diamond_helmet"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            }
+          ],
+          "name": "minecraft:diamond_boots"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0.2,
+                "max": 0.65
+              }
+            }
+          ],
+          "name": "minecraft:diamond_leggings"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:diamond"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 2.0,
+        "max": 4.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 5.0,
+                "max": 21.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:spectral_arrow"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_block"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 9.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 9.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:crying_obsidian"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8.0,
+                "max": 23.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:quartz"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gilded_blackstone"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:magma_cream"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8.0,
+                "max": 16.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_nugget"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/jungle_temple.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/jungle_temple.json
@@ -1,0 +1,162 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.25
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 2.0,
+        "max": 6.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:diamond"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 7.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:bamboo"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:emerald"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 4.0,
+                "max": 6.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:bone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 16,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 7.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:rotten_flesh"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "name": "minecraft:saddle"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:iron_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:golden_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:diamond_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:enchant_with_levels",
+              "levels": 30,
+              "treasure": true
+            }
+          ],
+          "name": "minecraft:book"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/jungle_temple_dispenser.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/jungle_temple_dispenser.json
@@ -1,0 +1,33 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 2.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 30,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 7.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:set_nbt",
+              "tag": "{Potion:\"minecraft:poison\"}"
+            }
+          ],
+          "name": "minecraft:tipped_arrow"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/pillager_outpost.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/pillager_outpost.json
@@ -1,0 +1,193 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.15
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 0.0,
+        "max": 1.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:crossbow"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 2.0,
+        "max": 3.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 7,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:wheat"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:potato"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:carrot"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 3.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:dark_oak_log"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 2.0,
+        "max": 3.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 7,
+          "name": "minecraft:experience_bottle"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 4,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 6.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:string"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 4,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 7.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:arrow"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:tripwire_hook"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:book"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/simple_dungeon.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/simple_dungeon.json
@@ -1,0 +1,288 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.025
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 3.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:saddle"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:golden_apple"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "name": "minecraft:enchanted_golden_apple"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:music_disc_13"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:music_disc_cat"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:name_tag"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "name": "minecraft:golden_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:iron_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:diamond_horse_armor"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:book"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 4.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:bread"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:wheat"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "name": "minecraft:bucket"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:redstone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:coal"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:melon_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:pumpkin_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:beetroot_seeds"
+        }
+      ]
+    },
+    {
+      "rolls": 3,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:bone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gunpowder"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:rotten_flesh"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:string"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/stronghold_crossing.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/stronghold_crossing.json
@@ -1,0 +1,134 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.25
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 4.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 4.0,
+                "max": 9.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:redstone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:coal"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:bread"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 3.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:apple"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:iron_pickaxe"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:enchant_with_levels",
+              "levels": 30,
+              "treasure": true
+            }
+          ],
+          "name": "minecraft:book"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/chests/woodland_mansion.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/chests/woodland_mansion.json
@@ -1,0 +1,288 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.5
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 3.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:lead"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:golden_apple"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "name": "minecraft:enchanted_golden_apple"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:music_disc_13"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:music_disc_cat"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:name_tag"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "name": "minecraft:chainmail_chestplate"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "name": "minecraft:diamond_hoe"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:diamond_chestplate"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:book"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "min": 1.0,
+        "max": 4.0,
+        "type": "minecraft:uniform"
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "name": "minecraft:bread"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 20,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:wheat"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "name": "minecraft:bucket"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:redstone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 15,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:coal"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:melon_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:pumpkin_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2.0,
+                "max": 4.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:beetroot_seeds"
+        }
+      ]
+    },
+    {
+      "rolls": 3,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:bone"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gunpowder"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:rotten_flesh"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 8.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:string"
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/entities/creeper.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/entities/creeper.json
@@ -1,0 +1,69 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:gunpowder"
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:tag",
+          "name": "minecraft:creeper_drop_music_discs",
+          "expand": true
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:entity_properties",
+          "predicate": {
+            "type": "#minecraft:skeletons"
+          },
+          "entity": "killer"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:creeper_head"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.025,
+          "looting_multiplier": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/entities/ender_dragon.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/entities/ender_dragon.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dragon_head",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.025
+            },
+            {
+              "condition": "minecraft:random_chance_with_looting",
+              "chance": 0.025,
+              "looting_multiplier": 0.01
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/entities/player.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/entities/player.json
@@ -1,0 +1,60 @@
+{
+	"type": "minecraft:entity",
+	"pools": [
+	  {
+		"rolls": 1,
+		"entries": [
+		  {
+			"type": "minecraft:item",
+			"name": "minecraft:player_head",
+			"functions": [
+			  {
+				"function": "minecraft:fill_player_head",
+				"entity": "this"
+			  },
+			  {
+				"function": "minecraft:set_count",
+				"count": 1
+			  }
+			],
+			"conditions": [
+			  {
+				"condition": "minecraft:entity_properties",
+				"entity": "killer",
+				"predicate": {
+				  "type": "minecraft:creeper",
+				  "nbt": "{powered:1b}"
+				}
+			  }
+			]
+		  }
+		]
+	  },
+	  {
+		"rolls": 1,
+		"entries": [
+		  {
+			"type": "minecraft:item",
+			"name": "minecraft:player_head",
+			"functions": [
+			  {
+				"function": "minecraft:fill_player_head",
+				"entity": "this"
+			  }
+			],
+			"conditions": [
+			  {
+				"condition": "minecraft:killed_by_player",
+				"inverse": false
+			  },
+			  {
+				"condition": "minecraft:random_chance_with_looting",
+				"chance": 0.025,
+				"looting_multiplier": 0.01
+			  }
+			]
+		  }
+		]
+	  }
+	]
+  }

--- a/gm4_better_head_drops/data/minecraft/loot_tables/entities/skeleton.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/entities/skeleton.json
@@ -1,0 +1,76 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:arrow"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:bone"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:skeleton_skull"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.025,
+          "looting_multiplier": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/data/minecraft/loot_tables/entities/zombie.json
+++ b/gm4_better_head_drops/data/minecraft/loot_tables/entities/zombie.json
@@ -1,0 +1,77 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 0.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "minecraft:rotten_flesh"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:carrot"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:potato"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.025,
+          "looting_multiplier": 0.01
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:zombie_head"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.025,
+          "looting_multiplier": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_better_head_drops/pack.mcmeta
+++ b/gm4_better_head_drops/pack.mcmeta
@@ -1,0 +1,25 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "Gamemode 4 Better Head Drops"
+    },
+    "module_name": "Better Head Drops",
+    "module_id": "better_head_drops",
+    "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "Recieve player heads when killed by charged creepers and addition skull drops from default mobs",
+    "site_categories": [],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [
+        "undead_players"
+    ],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}

--- a/gm4_increased_shulker_shells/data/gm4_increased_shulker_shells/functions/init.mcfunction
+++ b/gm4_increased_shulker_shells/data/gm4_increased_shulker_shells/functions/init.mcfunction
@@ -1,0 +1,4 @@
+execute unless score increased_shulker_shells gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Increased Shulker Shells"}
+scoreboard players set increased_shulker_shells gm4_modules 1
+
+#$moduleUpdateList

--- a/gm4_increased_shulker_shells/data/gm4_increased_shulker_shells/functions/load.mcfunction
+++ b/gm4_increased_shulker_shells/data/gm4_increased_shulker_shells/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_increased_shulker_shells load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Increased Shulker Shells",require:"Gamemode 4"}
+
+execute if score gm4_increased_shulker_shells load matches 1 run function gm4_increased_shulker_shells:init
+execute unless score gm4_increased_shulker_shells load matches 1 run schedule clear gm4_increased_shulker_shells:main

--- a/gm4_increased_shulker_shells/data/load/tags/functions/gm4_increased_shulker_shells.json
+++ b/gm4_increased_shulker_shells/data/load/tags/functions/gm4_increased_shulker_shells.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_increased_shulker_shells:load"
+    ]
+}

--- a/gm4_increased_shulker_shells/data/load/tags/functions/load.json
+++ b/gm4_increased_shulker_shells/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_increased_shulker_shells"
+    ]
+}

--- a/gm4_increased_shulker_shells/data/minecraft/loot_tables/entities/shulker.json
+++ b/gm4_increased_shulker_shells/data/minecraft/loot_tables/entities/shulker.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 1.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:shulker_shell"
+        }
+      ]
+     },
+      {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 1.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:shulker_shell"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0,
+          "looting_multiplier": 0.25
+        }
+      ]
+     }
+  ]
+}

--- a/gm4_increased_shulker_shells/pack.mcmeta
+++ b/gm4_increased_shulker_shells/pack.mcmeta
@@ -1,0 +1,23 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "Gamemode 4 Increased Shulker Shells"
+    },
+    "module_name": "Increased Shulker Shells",
+    "module_id": "increased_shulker_shells",
+  "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "Receive 1 Shulker shell from every Shulker with a chance to drop 2 shells with Looting!",
+    "site_categories": [],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}

--- a/gm4_multiplayer_sleeping/data/gm4/advancements/deep_sleeper.json
+++ b/gm4_multiplayer_sleeping/data/gm4/advancements/deep_sleeper.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "blue_bed",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Deep Sleeper",
+        {"translate": "advancement.gm4.multiplayer_sleeping.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You've slept for been asleep for a while, time to wake up don't you think?",
+        {"translate": "advancement.gm4.multiplayer_sleeping.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:well_rested",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_multiplayer_sleeping/data/gm4/advancements/well_rested.json
+++ b/gm4_multiplayer_sleeping/data/gm4/advancements/well_rested.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "light_blue_bed",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Well Rested",
+        {"translate": "advancement.gm4.multiplayer_sleeping.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Get a good night's sleep",
+        {"translate": "advancement.gm4.multiplayer_sleeping.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/enter_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/enter_bed.mcfunction
@@ -1,0 +1,8 @@
+#Player Count
+tag @s add gm4_in_bed
+function gm4_multiplayer_sleeping:player_count
+
+tellraw @a ["",{"selector":"@s"},{"text":" is now sleeping (","color":"gray"},{"score":{"name":"value_sleepers","objective":"gm4_sleep_count"}},{"text":"/","color":"gray"},{"score":{"name":"value_required","objective":"gm4_sleep_count"}},{"text":") ","color":"gray"},{"text":"[Cancel]","color":"red","clickEvent":{"action":"run_command","value":"/trigger gm4_sleep_kick set 1"},"hoverEvent":{"action":"show_text","value":["",{"text":"Kick ","color":"white"},{"selector":"@a[tag=gm4_in_bed]"},{"text":" from their beds","color":"white"}]}}]
+
+#Sleeping players vs required check
+execute if score value_sleepers gm4_sleep_count >= value_required gm4_sleep_count run schedule function gm4_multiplayer_sleeping:pass_time 100t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/exit_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/exit_bed.mcfunction
@@ -1,0 +1,6 @@
+tag @s remove gm4_in_bed
+function gm4_multiplayer_sleeping:player_count
+
+
+
+tellraw @a[tag=gm4_in_bed] ["",{"selector":"@s"},{"text":" is no longer sleeping (","color":"gray"},{"score":{"name":"value_sleepers","objective":"gm4_sleep_count"}},{"text":"/","color":"gray"},{"score":{"name":"value_required","objective":"gm4_sleep_count"}},{"text":")","color":"gray"}]

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/init.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/init.mcfunction
@@ -1,0 +1,17 @@
+scoreboard objectives add gm4_sleep_count dummy
+scoreboard objectives add gm4_sleep_total dummy
+scoreboard objectives add gm4_sleep_kick trigger
+
+scoreboard players set value_morning gm4_sleep_count 23450
+scoreboard players set value_night gm4_sleep_count 12550
+scoreboard players set value_percentage gm4_sleep_count 4
+scoreboard players set value_minimum gm4_sleep_count 1
+
+function gm4_multiplayer_sleeping:player_count
+
+execute unless score multiplayer_sleeping gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Multiplayer Sleeping"}
+scoreboard players set multiplayer_sleeping gm4_modules 1
+
+schedule function gm4_multiplayer_sleeping:main 10t
+
+#$moduleUpdateList

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/kick_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/kick_bed.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s ["",{"text":"Kicked ","color":"gray"},{"selector":"@a[tag=gm4_in_bed]"},{"text":" out of bed","color":"gray"}]
+tellraw @a[tag=gm4_in_bed] ["",{"text":"Kicked out of bed by ","color":"gray"},{"selector":"@s"}]
+
+effect give @a[tag=gm4_in_bed] minecraft:resistance 1 255 true
+effect give @a[tag=gm4_in_bed] minecraft:instant_damage 1 1 true
+
+scoreboard players set @s gm4_sleep_kick 0

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/load.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/load.mcfunction
@@ -1,0 +1,7 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_multiplayer_sleeping load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Multiplayer Sleeping",require:"Gamemode 4"}
+
+execute if score gm4_multiplayer_sleeping load matches 1 run function gm4_multiplayer_sleeping:init
+execute unless score gm4_multiplayer_sleeping load matches 1 run schedule clear gm4_multiplayer_sleeping:main
+
+

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/main.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/main.mcfunction
@@ -1,0 +1,10 @@
+scoreboard players enable @a gm4_sleep_kick
+execute as @a[scores={gm4_sleep_kick=1..}] run function gm4_multiplayer_sleeping:kick_bed
+
+#Bed Check
+execute as @a[nbt={SleepTimer:0s},tag=gm4_in_bed] run function gm4_multiplayer_sleeping:exit_bed
+execute as @a[tag=!gm4_in_bed] if data entity @s SleepingX run function gm4_multiplayer_sleeping:enter_bed
+
+execute store result score value_daytime gm4_sleep_count run time query daytime
+
+schedule function gm4_multiplayer_sleeping:main 16t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/pass_time.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/pass_time.mcfunction
@@ -1,0 +1,14 @@
+#Weather Controls
+execute if score value_daytime gm4_sleep_count < value_night gm4_sleep_count run weather thunder 1
+execute if score value_daytime gm4_sleep_count > value_morning gm4_sleep_count run weather thunder 1
+
+#Advancements
+scoreboard players add @a[tag=gm4_in_bed] gm4_sleep_total 1
+advancement grant @a[tag=gm4_in_bed,scores={gm4_sleep_total=50..100}] only gm4:well_rested
+advancement grant @a[tag=gm4_in_bed,scores={gm4_sleep_total=3600..}] only gm4:deep_sleeper
+
+#Time Passing
+execute if score value_daytime gm4_sleep_count > value_night gm4_sleep_count as @a[tag=gm4_in_bed,limit=5] run time add 200t
+
+#Clock
+execute if score value_daytime gm4_sleep_count > value_night gm4_sleep_count if score value_sleepers gm4_sleep_count >= value_required gm4_sleep_count run schedule function gm4_multiplayer_sleeping:pass_time 20t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/player_count.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/player_count.mcfunction
@@ -1,0 +1,10 @@
+#Sleeping players
+execute store result score value_sleepers gm4_sleep_count if entity @a[nbt={Dimension:"minecraft:overworld"},tag=gm4_in_bed]
+
+#Total player count & Required player calculation
+execute store result score value_players gm4_sleep_count if entity @a[gamemode=!spectator,nbt={Dimension:"minecraft:overworld"},tag=!gm4_afk]
+scoreboard players operation value_required gm4_sleep_count = value_players gm4_sleep_count
+scoreboard players operation value_required gm4_sleep_count /= value_percentage gm4_sleep_count
+
+#Minimum cut-off
+execute if score value_required gm4_sleep_count <= value_minimum gm4_sleep_count run scoreboard players set value_required gm4_sleep_count 1

--- a/gm4_multiplayer_sleeping/data/load/tags/functions/gm4_multiplayer_sleeping.json
+++ b/gm4_multiplayer_sleeping/data/load/tags/functions/gm4_multiplayer_sleeping.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_multiplayer_sleeping:load"
+    ]
+}

--- a/gm4_multiplayer_sleeping/data/load/tags/functions/load.json
+++ b/gm4_multiplayer_sleeping/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_multiplayer_sleeping"
+    ]
+}

--- a/gm4_multiplayer_sleeping/pack.mcmeta
+++ b/gm4_multiplayer_sleeping/pack.mcmeta
@@ -1,0 +1,27 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "Gamemode 4 Multiplayer Sleeping for MC1.16"
+    },
+    "module_name": "Multiplayer Sleeping",
+    "module_id": "multiplayer_sleeping",
+    "creation_meta": "Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "All for players to sleep on a server without requiring everyone to be in a bed",
+    "site_categories": [
+    	"Server Utilities"
+    ],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [
+    	"afk_detector"
+    ],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
**Addition for 4 new server utilities modules**

- Multiplayer Sleeping
- AFK Detector
- Increased Shulker Shells
- Better Head Drops

**Multiplayer Sleeping**
Allow for players to pass the night when 25% of online players are sleeping.
Only accounts for players in the overworld, compatible with AFK Detector

**AFK Detector**
Detect and announce AFK players to the server
Default role with AFK prefix, compatibility with additional roles can be set for prefixes
Recommended for Multiplayer Sleeping

**Increased Shulker Shells**
Guarantee a shell drop from shulkers, with a 25% of a second shell per looting level

**Better Head Drops**
Obtain player head drops from charged Creepers, can also be dropped when killed by another player with the same drop rate as Wither Skeleton skulls
Default entity skulls (Zombie, Skeleton, Creeper) have the same drop rate as Wither Skeleton skulls
Rare Steve player heads can be found in a range of structure loot chests