### PR TITLE
Add Multiplayer Sleeping

### DIFF
--- a/gm4_multiplayer_sleeping/.vscode/settings.json
+++ b/gm4_multiplayer_sleeping/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.wordWrap": "on"
+}

--- a/gm4_multiplayer_sleeping/.vscode/settings.json
+++ b/gm4_multiplayer_sleeping/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.wordWrap": "on"
-}

--- a/gm4_multiplayer_sleeping/data/gm4/advancements/deep_sleeper.json
+++ b/gm4_multiplayer_sleeping/data/gm4/advancements/deep_sleeper.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "blue_bed",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Deep Sleeper",
+        {"translate": "advancement.gm4.multiplayer_sleeping.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You've slept for been asleep for a while, time to wake up don't you think?",
+        {"translate": "advancement.gm4.multiplayer_sleeping.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:well_rested",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_multiplayer_sleeping/data/gm4/advancements/well_rested.json
+++ b/gm4_multiplayer_sleeping/data/gm4/advancements/well_rested.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "light_blue_bed",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Well Rested",
+        {"translate": "advancement.gm4.multiplayer_sleeping.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Get a good night's sleep",
+        {"translate": "advancement.gm4.multiplayer_sleeping.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/enter_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/enter_bed.mcfunction
@@ -1,0 +1,8 @@
+#Player Count
+tag @s add gm4_in_bed
+function gm4_multiplayer_sleeping:player_count
+
+tellraw @a ["",{"selector":"@s"},{"text":" is now sleeping (","color":"gray"},{"score":{"name":"value_sleepers","objective":"gm4_sleep_count"}},{"text":"/","color":"gray"},{"score":{"name":"value_required","objective":"gm4_sleep_count"}},{"text":") ","color":"gray"},{"text":"[Cancel]","color":"red","clickEvent":{"action":"run_command","value":"/trigger gm4_sleep_kick set 1"},"hoverEvent":{"action":"show_text","value":["",{"text":"Kick ","color":"white"},{"selector":"@a[tag=gm4_in_bed]"},{"text":" from their beds","color":"white"}]}}]
+
+#Sleeping players vs required check
+execute if score value_sleepers gm4_sleep_count >= value_required gm4_sleep_count run schedule function gm4_multiplayer_sleeping:pass_time 100t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/exit_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/exit_bed.mcfunction
@@ -1,0 +1,6 @@
+tag @s remove gm4_in_bed
+function gm4_multiplayer_sleeping:player_count
+
+
+
+tellraw @a[tag=gm4_in_bed] ["",{"selector":"@s"},{"text":" is no longer sleeping (","color":"gray"},{"score":{"name":"value_sleepers","objective":"gm4_sleep_count"}},{"text":"/","color":"gray"},{"score":{"name":"value_required","objective":"gm4_sleep_count"}},{"text":")","color":"gray"}]

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/init.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/init.mcfunction
@@ -1,0 +1,17 @@
+scoreboard objectives add gm4_sleep_count dummy
+scoreboard objectives add gm4_sleep_total dummy
+scoreboard objectives add gm4_sleep_kick trigger
+
+scoreboard players set value_morning gm4_sleep_count 23450
+scoreboard players set value_night gm4_sleep_count 12550
+scoreboard players set value_percentage gm4_sleep_count 4
+scoreboard players set value_minimum gm4_sleep_count 1
+
+function gm4_multiplayer_sleeping:player_count
+
+execute unless score multiplayer_sleeping gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Multiplayer Sleeping"}
+scoreboard players set multiplayer_sleeping gm4_modules 1
+
+schedule function gm4_multiplayer_sleeping:main 10t
+
+#$moduleUpdateList

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/kick_bed.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/kick_bed.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s ["",{"text":"Kicked ","color":"gray"},{"selector":"@a[tag=gm4_in_bed]"},{"text":" out of bed","color":"gray"}]
+tellraw @a[tag=gm4_in_bed] ["",{"text":"Kicked out of bed by ","color":"gray"},{"selector":"@s"}]
+
+effect give @a[tag=gm4_in_bed] minecraft:resistance 1 255 true
+effect give @a[tag=gm4_in_bed] minecraft:instant_damage 1 1 true
+
+scoreboard players set @s gm4_sleep_kick 0

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/load.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/load.mcfunction
@@ -1,0 +1,7 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_multiplayer_sleeping load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Multiplayer Sleeping",require:"Gamemode 4"}
+
+execute if score gm4_multiplayer_sleeping load matches 1 run function gm4_multiplayer_sleeping:init
+execute unless score gm4_multiplayer_sleeping load matches 1 run schedule clear gm4_multiplayer_sleeping:main
+
+

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/main.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/main.mcfunction
@@ -1,0 +1,10 @@
+scoreboard players enable @a gm4_sleep_kick
+execute as @a[scores={gm4_sleep_kick=1..}] run function gm4_multiplayer_sleeping:kick_bed
+
+#Bed Check
+execute as @a[nbt={SleepTimer:0s},tag=gm4_in_bed] run function gm4_multiplayer_sleeping:exit_bed
+execute as @a[tag=!gm4_in_bed] if data entity @s SleepingX run function gm4_multiplayer_sleeping:enter_bed
+
+execute store result score value_daytime gm4_sleep_count run time query daytime
+
+schedule function gm4_multiplayer_sleeping:main 16t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/pass_time.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/pass_time.mcfunction
@@ -1,0 +1,14 @@
+#Weather Controls
+execute if score value_daytime gm4_sleep_count < value_night gm4_sleep_count run weather thunder 1
+execute if score value_daytime gm4_sleep_count > value_morning gm4_sleep_count run weather thunder 1
+
+#Advancements
+scoreboard players add @a[tag=gm4_in_bed] gm4_sleep_total 1
+advancement grant @a[tag=gm4_in_bed,scores={gm4_sleep_total=50..100}] only gm4:well_rested
+advancement grant @a[tag=gm4_in_bed,scores={gm4_sleep_total=3600..}] only gm4:deep_sleeper
+
+#Time Passing
+execute if score value_daytime gm4_sleep_count > value_night gm4_sleep_count as @a[tag=gm4_in_bed,limit=5] run time add 200t
+
+#Clock
+execute if score value_daytime gm4_sleep_count > value_night gm4_sleep_count if score value_sleepers gm4_sleep_count >= value_required gm4_sleep_count run schedule function gm4_multiplayer_sleeping:pass_time 20t

--- a/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/player_count.mcfunction
+++ b/gm4_multiplayer_sleeping/data/gm4_multiplayer_sleeping/functions/player_count.mcfunction
@@ -1,0 +1,10 @@
+#Sleeping players
+execute store result score value_sleepers gm4_sleep_count if entity @a[nbt={Dimension:"minecraft:overworld"},tag=gm4_in_bed]
+
+#Total player count & Required player calculation
+execute store result score value_players gm4_sleep_count if entity @a[gamemode=!spectator,nbt={Dimension:"minecraft:overworld"},tag=!gm4_afk]
+scoreboard players operation value_required gm4_sleep_count = value_players gm4_sleep_count
+scoreboard players operation value_required gm4_sleep_count /= value_percentage gm4_sleep_count
+
+#Minimum cut-off
+execute if score value_required gm4_sleep_count <= value_minimum gm4_sleep_count run scoreboard players set value_required gm4_sleep_count 1

--- a/gm4_multiplayer_sleeping/data/load/tags/functions/gm4_multiplayer_sleeping.json
+++ b/gm4_multiplayer_sleeping/data/load/tags/functions/gm4_multiplayer_sleeping.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_multiplayer_sleeping:load"
+    ]
+}

--- a/gm4_multiplayer_sleeping/data/load/tags/functions/load.json
+++ b/gm4_multiplayer_sleeping/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_multiplayer_sleeping"
+    ]
+}

--- a/gm4_multiplayer_sleeping/pack.mcmeta
+++ b/gm4_multiplayer_sleeping/pack.mcmeta
@@ -1,0 +1,27 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "Gamemode 4 Multiplayer Sleeping for MC1.16"
+    },
+    "module_name": "Multiplayer Sleeping",
+    "module_id": "multiplayer_sleeping",
+    "creation_meta": "Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "All for players to sleep on a server without requiring everyone to be in a bed",
+    "site_categories": [
+    	"Server Utilities"
+    ],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [
+    	"afk_detector"
+    ],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
_Server Utility Module_
**Gamemode 4 Multiplayer Sleeping**
Allow for players to sleep on a server without requiring everyone to be in a bed.
_For Minecraft 1.16. Version for MC1.15 also available by request_

When 25% of online players are sleeping, time will begin to pass during the night. Time will increase faster with more players sleeping (Maximum speed with 5 players sleeping)

Features a chat messages alerting required player count for sleeping, also alerts sleeping players if someone leaves a bed.
Chat message has a cancel button to kick sleeping if night is required. Sleeping players are alerted to kicker

Clears rain and thunderstorms, thunderstorms can also be cleared during the day.
Compatible with gm4_afk_detector to ignore AFK players when checking for total player count