### PR TITLE
Add AFK Detector

### DIFF
--- a/gm4_afk_detector/data/gm4/advancements/are_you_still_there.json
+++ b/gm4_afk_detector/data/gm4/advancements/are_you_still_there.json
@@ -7,7 +7,7 @@
     "title": {
       "translate": "%1$s%3427655$s",
       "with": [
-        "You still there?",
+        "Are you still there?",
         {"translate": "advancement.gm4.afk_detector.title"}
       ]
     },

--- a/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
+++ b/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
@@ -20,7 +20,7 @@
       "color": "gray"
     }
   },
-  "parent": "gm4:you_still_there",
+  "parent": "gm4:are_you_still_there",
   "criteria": {
     "impossible": {
       "trigger": "minecraft:impossible"

--- a/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
+++ b/gm4_afk_detector/data/gm4/advancements/get_back_to_work.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "bell",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Get back to work!",
+        {"translate": "advancement.gm4.afk_detector.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You've been away from your keyboard for 24 hours",
+        {"translate": "advancement.gm4.afk_detector.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:you_still_there",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_afk_detector/data/gm4/advancements/you_still_there.json
+++ b/gm4_afk_detector/data/gm4/advancements/you_still_there.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "item": "dead_bush",
+      "nbt": "{CustomModelData:1}"
+    },
+    "title": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "You still there?",
+        {"translate": "advancement.gm4.afk_detector.title"}
+      ]
+    },
+    "description": {
+      "translate": "%1$s%3427655$s",
+      "with": [
+        "Go away from your keyboard for the first time",
+        {"translate": "advancement.gm4.afk_detector.description"}
+      ],
+      "color": "gray"
+    }
+  },
+  "parent": "gm4:root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/afk_away.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/afk_away.mcfunction
@@ -1,0 +1,12 @@
+team join gm4_afk @s[team=]
+#For each team you have on your server, replace TEAM with the team name
+#
+#team join afk_TEAM @s[team=TEAM]
+#
+#Example:
+#
+#team join afk_Admin @s[team=Admin]
+
+tag @s add gm4_afk
+
+tellraw @a ["",{"selector":"@s"},{"text":" is now away from their keyboard","color":"gray"}]

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/afk_back.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/afk_back.mcfunction
@@ -1,0 +1,12 @@
+team leave @s[team=gm4_afk]
+#For each team you have on your server, replace TEAM with the team name
+#
+#team join TEAM @s[team=afk_TEAM]
+#
+#Example:
+#
+#team join Admin @s[team=afk_Admin]
+
+tag @s remove gm4_afk
+scoreboard players set @s gm4_afk_count 0
+tellraw @a ["",{"selector":"@s"},{"text":" is now back at their keyboard","color":"gray"}]

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
@@ -19,7 +19,7 @@ scoreboard players add @s[scores={gm4_afk_still=3},tag=!gm4_afk] gm4_afk_count 1
 scoreboard players set @s[scores={gm4_afk_still=..2}] gm4_afk_count 0
 scoreboard players add @s[tag=gm4_afk] gm4_afk_total 1
 
-advancement grant @s[scores={gm4_afk_total=1}] only gm4:you_still_there
+advancement grant @s[scores={gm4_afk_total=1}] only gm4:are_you_still_there
 advancement grant @s[scores={gm4_afk_total=86400}] only gm4:get_back_to_work
 
 execute as @s[scores={gm4_afk_count=900..},tag=!gm4_afk] run function gm4_afk_detector:afk_away

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/check_pos.mcfunction
@@ -1,0 +1,27 @@
+scoreboard players set @s gm4_afk_still 0
+
+#Store Pos
+execute store result score @s gm4_afk_x run data get entity @s Pos[0]
+execute store result score @s gm4_afk_y run data get entity @s Pos[1]
+execute store result score @s gm4_afk_z run data get entity @s Pos[2]
+
+#Check for movment
+execute if score @s gm4_afk_x = @s gm4_afk_x1 run scoreboard players add @s gm4_afk_still 1
+execute if score @s gm4_afk_y = @s gm4_afk_y1 run scoreboard players add @s gm4_afk_still 1
+execute if score @s gm4_afk_z = @s gm4_afk_z1 run scoreboard players add @s gm4_afk_still 1
+
+#Store 2nd Pos
+execute store result score @s gm4_afk_x1 run data get entity @s Pos[0]
+execute store result score @s gm4_afk_y1 run data get entity @s Pos[1]
+execute store result score @s gm4_afk_z1 run data get entity @s Pos[2]
+
+scoreboard players add @s[scores={gm4_afk_still=3},tag=!gm4_afk] gm4_afk_count 1
+scoreboard players set @s[scores={gm4_afk_still=..2}] gm4_afk_count 0
+scoreboard players add @s[tag=gm4_afk] gm4_afk_total 1
+
+advancement grant @s[scores={gm4_afk_total=1}] only gm4:you_still_there
+advancement grant @s[scores={gm4_afk_total=86400}] only gm4:get_back_to_work
+
+execute as @s[scores={gm4_afk_count=900..},tag=!gm4_afk] run function gm4_afk_detector:afk_away
+execute as @s[scores={gm4_afk_count=0},tag=gm4_afk] run function gm4_afk_detector:afk_back
+

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/clock.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/clock.mcfunction
@@ -1,0 +1,3 @@
+execute as @a run function gm4_afk_detector:check_pos
+
+schedule function gm4_afk_detector:clock 20t

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/init.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/init.mcfunction
@@ -1,0 +1,25 @@
+team add gm4_afk
+team modify gm4_afk prefix ["",{"text":"[AFK] ","color":"gray"}]
+
+scoreboard objectives add gm4_afk_leave minecraft.custom:minecraft.leave_game
+scoreboard objectives add gm4_afk_still dummy
+scoreboard objectives add gm4_afk_count dummy
+scoreboard objectives add gm4_afk_total dummy
+
+scoreboard objectives add gm4_afk_x dummy
+scoreboard objectives add gm4_afk_y dummy
+scoreboard objectives add gm4_afk_z dummy
+scoreboard objectives add gm4_afk_x1 dummy
+scoreboard objectives add gm4_afk_y1 dummy
+scoreboard objectives add gm4_afk_z1 dummy
+
+function gm4_afk_detector:init_team
+
+execute as @a[gamemode=!spectator] run function gm4_afk_detector:check_pos
+
+execute unless score afk_detector gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"AFK Detector"}
+scoreboard players set afk_detector gm4_modules 1
+
+schedule function gm4_afk_detector:clock 20t
+
+#$moduleUpdateList

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/init_team.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/init_team.mcfunction
@@ -1,0 +1,11 @@
+#For each team you have on your server, replace TEAM with the team name
+#
+#team add afk_TEAM
+#team modify TEAM prefix ["",{"text":"[AFK] ","color":"gray"}]
+#
+#Example:
+#
+#team add afk_Admin
+#team modify afk_Admin prefix ["",{"text":"[AFK] ","color":"gray"}]
+#Modify color to match original team if required
+#team modify afk_Admin color aqua

--- a/gm4_afk_detector/data/gm4_afk_detector/functions/load.mcfunction
+++ b/gm4_afk_detector/data/gm4_afk_detector/functions/load.mcfunction
@@ -1,0 +1,5 @@
+execute if score gm4 load matches 1 run scoreboard players set gm4_afk_detector load 1
+execute unless score gm4 load matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"AFK Detector",require:"Gamemode 4"}
+
+execute if score gm4_afk_detector load matches 1 run function gm4_afk_detector:init
+execute unless score gm4_afk_detector load matches 1 run schedule clear gm4_afk_detector:main

--- a/gm4_afk_detector/data/load/tags/functions/gm4_afk_detector.json
+++ b/gm4_afk_detector/data/load/tags/functions/gm4_afk_detector.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_afk_detector:load"
+    ]
+}

--- a/gm4_afk_detector/data/load/tags/functions/load.json
+++ b/gm4_afk_detector/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#load:gm4_afk_detector"
+    ]
+}

--- a/gm4_afk_detector/pack.mcmeta
+++ b/gm4_afk_detector/pack.mcmeta
@@ -1,0 +1,25 @@
+{
+    "pack": {
+        "pack_format": 5,
+        "description": "AFK Detector"
+    },
+    "module_name": "AFK Detector",
+    "module_id": "afk_detector",
+    "creation_meta":"Created using the Gamemode 4 Module Template Generator (gm4.co/modules/generator)",
+    "site_description": "Detect and label players away from their keyboards",
+    "site_categories": [],
+    "video_link": "YOUTUBE_VIDEO_URL",
+    "wiki_link": "WIKI_URL",
+    "required_modules": [],
+    "recommended_modules": [
+        "multiplayer_sleeping"
+    ],
+    "credits": {
+        "Creator": [
+            [
+                "mcpeachpies",
+                "https://youtube.com/mcpeachpies"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
_Server Utility Module_
**Gamemode 4 AFK Detector**
Detect, tag, and announce players away from their keyboards

Players who have not moved for 15 minutes will be announced and tagged as AFK

Players without set teams will receive an AFK prefix attached to their name
Can be configured to work with already established teams.
See the following mcfunction files under /data/gm4_afk_detector/functions/
afk_away.mcfunction
afk_back.mcfunction
init_team.mcfunction

gm4_afk tag used for players detected as AFK

Compatible with gm4_multiplayer_sleeping to exclude AFK players required sleeping players calculations