### PR TITLE
Fix Orbis 1.16

### DIFF
--- a/gm4_orbis/data/gm4_orbis/functions/main.mcfunction
+++ b/gm4_orbis/data/gm4_orbis/functions/main.mcfunction
@@ -5,4 +5,4 @@ execute at @a[tag=!gm4_orbis_disabled] positioned ~-8 ~ ~-8 as @e[type=area_effe
 # kill chunk markers that have been generated and have all adjacent chunks generated
 execute as @e[type=area_effect_cloud,tag=gm4_chunk,tag=gm4_generated] at @s run function gm4_orbis:chunk/kill
 # if the chunk where the player is in hasn't been generated, spawn a new chunk marker
-execute as @a[tag=!gm4_orbis_disabled,nbt={Dimension:0}] at @s unless block ~ 0 ~ barrier run function gm4_orbis:chunk/init
+execute as @a[tag=!gm4_orbis_disabled,nbt={Dimension:"minecraft:overworld"}] at @s unless block ~ 0 ~ barrier run function gm4_orbis:chunk/init

--- a/gm4_orbis/data/gm4_orbis/loot_tables/detect_biome.json
+++ b/gm4_orbis/data/gm4_orbis/loot_tables/detect_biome.json
@@ -404,7 +404,25 @@
                     {
                       "condition": "minecraft:location_check",
                       "predicate": {
-                        "biome": "minecraft:nether"
+                        "biome": "minecraft:nether_wastes"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:location_check",
+                      "predicate": {
+                        "biome": "minecraft:soul_sand_valley"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:location_check",
+                      "predicate": {
+                        "biome": "minecraft:crimson_forest"
+                      }
+                    },
+                    {
+                      "condition": "minecraft:location_check",
+                      "predicate": {
+                        "biome": "minecraft:warped_forest"
                       }
                     }
                   ]


### PR DESCRIPTION
- changed {Dimension:0} to {Dimension:"minecraft:overworld"}

- replaced single nether biome with the four new nether biomes in detect_biome loot table