### PR TITLE
Fix Trapped Signs Delay

### DIFF
--- a/gm4_trapped_signs/data/gm4_trapped_signs/functions/deactivate.mcfunction
+++ b/gm4_trapped_signs/data/gm4_trapped_signs/functions/deactivate.mcfunction
@@ -20,3 +20,4 @@ execute if block ~ ~ ~ #minecraft:wall_signs[facing=east] run fill ~-1 ~-2 ~ ~-1
 execute if block ~ ~ ~ #minecraft:wall_signs[facing=east] run fill ~-2 ~ ~ ~-2 ~ ~ redstone_wire[power=0] replace redstone_wire[power=1]
 execute if block ~ ~ ~ #minecraft:wall_signs[facing=east] run fill ~-1 ~ ~1 ~-1 ~ ~-1 redstone_wire[power=0] replace redstone_wire[power=1]
 tag @s remove gm4_trapped_signs_pulsed
+scoreboard players reset @s gm4_ts_delay

--- a/gm4_trapped_signs/data/gm4_trapped_signs/functions/init.mcfunction
+++ b/gm4_trapped_signs/data/gm4_trapped_signs/functions/init.mcfunction
@@ -1,4 +1,5 @@
 scoreboard objectives add gm4_count dummy
+scoreboard objectives add gm4_ts_delay dummy
 
 execute unless score trapped_signs gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Trapped Signs"}
 scoreboard players set trapped_signs gm4_modules 1

--- a/gm4_trapped_signs/data/gm4_trapped_signs/functions/process.mcfunction
+++ b/gm4_trapped_signs/data/gm4_trapped_signs/functions/process.mcfunction
@@ -3,7 +3,8 @@
 
 execute if entity @s[tag=!gm4_trapped_signs_completed] at @s unless block ~ ~ ~ #minecraft:signs{Text1:"{\"text\":\"\"}",Text2:"{\"text\":\"\"}",Text3:"{\"text\":\"\"}",Text4:"{\"text\":\"\"}"} run function gm4_trapped_signs:complete
 
-execute if entity @s[tag=gm4_trapped_signs_pulsed] at @s run function gm4_trapped_signs:deactivate
+scoreboard players add @s[tag=gm4_trapped_signs_pulsed] gm4_ts_delay 1
+execute if entity @s[tag=gm4_trapped_signs_pulsed,scores={gm4_ts_delay=2..}] at @s run function gm4_trapped_signs:deactivate
 execute if entity @s[tag=gm4_trapped_signs_need_pulse] at @s run function gm4_trapped_signs:activate
 
 execute unless block ~ ~ ~ #minecraft:signs run function gm4_trapped_signs:destroy


### PR DESCRIPTION
Currently, trapped signs do not power anything because the redstone dust is only powered for 1 game tick which is not long enough for any redstone component.

This change will extend that duration to 2 gameticks which is one redstone tick.