### PR TITLE
Add CustomModelData to Obsidian Casts

### DIFF
--- a/gm4_lumos_shamir/data/gm4_lumos_shamir/loot_tables/band.json
+++ b/gm4_lumos_shamir/data/gm4_lumos_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
 					"functions": [
 						{
 							"function": "minecraft:set_nbt",
-							"tag": "{CustomModelData:114,gm4_metallurgy:{stored_shamir:\"lumos\",custom_model_data:114}}"
+							"tag": "{CustomModelData:114,gm4_metallurgy:{stored_shamir:\"lumos\"}}"
 						},
 						{
 							"function": "minecraft:set_lore",

--- a/gm4_lumos_shamir/data/gm4_lumos_shamir/loot_tables/band.json
+++ b/gm4_lumos_shamir/data/gm4_lumos_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
 					"functions": [
 						{
 							"function": "minecraft:set_nbt",
-							"tag": "{gm4_metallurgy:{stored_shamir:\"lumos\",custom_model_data:114}}"
+							"tag": "{CustomModelData:114,gm4_metallurgy:{stored_shamir:\"lumos\",custom_model_data:114}}"
 						},
 						{
 							"function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"arborenda\",custom_model_data:112}}"
+                            "tag": "{CustomModelData:112,gm4_metallurgy:{stored_shamir:\"arborenda\",custom_model_data:112}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:112,gm4_metallurgy:{stored_shamir:\"arborenda\",custom_model_data:112}}"
+                            "tag": "{CustomModelData:112,gm4_metallurgy:{stored_shamir:\"arborenda\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_conduction_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_conduction_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:104,gm4_metallurgy:{stored_shamir:\"conduction\",custom_model_data:104}}"
+                            "tag": "{CustomModelData:104,gm4_metallurgy:{stored_shamir:\"conduction\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_conduction_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_conduction_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"conduction\",custom_model_data:104}}"
+                            "tag": "{CustomModelData:104,gm4_metallurgy:{stored_shamir:\"conduction\",custom_model_data:104}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_defuse_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_defuse_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"defuse\",custom_model_data:106}}"
+                            "tag": "{CustomModelData:106,gm4_metallurgy:{stored_shamir:\"defuse\",custom_model_data:106}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_defuse_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_defuse_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:106,gm4_metallurgy:{stored_shamir:\"defuse\",custom_model_data:106}}"
+                            "tag": "{CustomModelData:106,gm4_metallurgy:{stored_shamir:\"defuse\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_ender_bolt_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_ender_bolt_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"ender_bolt\",custom_model_data:105}}"
+                            "tag": "{CustomModelData:105,gm4_metallurgy:{stored_shamir:\"ender_bolt\",custom_model_data:105}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_ender_bolt_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_ender_bolt_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:105,gm4_metallurgy:{stored_shamir:\"ender_bolt\",custom_model_data:105}}"
+                            "tag": "{CustomModelData:105,gm4_metallurgy:{stored_shamir:\"ender_bolt\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:107,gm4_metallurgy:{stored_shamir:\"forterra\",custom_model_data:107}}"
+                            "tag": "{CustomModelData:107,gm4_metallurgy:{stored_shamir:\"forterra\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"forterra\",custom_model_data:107}}"
+                            "tag": "{CustomModelData:107,gm4_metallurgy:{stored_shamir:\"forterra\",custom_model_data:107}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_gemini_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_gemini_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"gemini\",custom_model_data:109}}"
+                            "tag": "{CustomModelData:109,gm4_metallurgy:{stored_shamir:\"gemini\",custom_model_data:109}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_gemini_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_gemini_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:109,gm4_metallurgy:{stored_shamir:\"gemini\",custom_model_data:109}}"
+                            "tag": "{CustomModelData:109,gm4_metallurgy:{stored_shamir:\"gemini\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_hypexperia_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_hypexperia_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"hypexperia\",custom_model_data:110}}"
+                            "tag": "{CustomModelData:110,gm4_metallurgy:{stored_shamir:\"hypexperia\",custom_model_data:110}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_hypexperia_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_hypexperia_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:110,gm4_metallurgy:{stored_shamir:\"hypexperia\",custom_model_data:110}}"
+                            "tag": "{CustomModelData:110,gm4_metallurgy:{stored_shamir:\"hypexperia\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_levity_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_levity_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:102,gm4_metallurgy:{stored_shamir:\"levity\",custom_model_data:102}}"
+                            "tag": "{CustomModelData:102,gm4_metallurgy:{stored_shamir:\"levity\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_levity_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_levity_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"levity\",custom_model_data:102}}"
+                            "tag": "{CustomModelData:102,gm4_metallurgy:{stored_shamir:\"levity\",custom_model_data:102}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/check.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/check.mcfunction
@@ -5,6 +5,6 @@
 scoreboard players set valid_item gm4_ml_data 0
 execute as @e[type=item,dx=0,limit=1,nbt={Item:{Count:1b}},nbt=!{Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}] run function gm4_metallurgy:smooshing/add_band/check_item
 
-execute if score valid_item gm4_ml_data matches 1 run data merge entity @s {Item:{id:"minecraft:obsidian",tag:{display:{Lore:['{"translate":"%1$s%3427655$s","with":["Slightly Damaged Obsidian",{"translate":"item.gm4.slightly_damaged_obsidian"}],"italic":false}']}}},Tags:["gm4_ml_smooshed"]}
+execute if score valid_item gm4_ml_data matches 1 run data merge entity @s {Item:{id:"minecraft:obsidian",tag:{CustomModelData:1,display:{Lore:['{"translate":"%1$s%3427655$s","with":["Slightly Damaged Obsidian",{"translate":"item.gm4.slightly_damaged_obsidian"}],"italic":false}']}}},Tags:["gm4_ml_smooshed"]}
 execute if score valid_item gm4_ml_data matches 1 run data remove entity @s Item.tag.gm4_metallurgy
 execute if score valid_item gm4_ml_data matches 1 run data remove entity @s Item.tag.SkullOwner

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -2,5 +2,5 @@ data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_sh
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
-execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.CustomModelData
+execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -2,5 +2,6 @@ data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_sh
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
-execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
+execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -2,6 +2,5 @@ data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_sh
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
-data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
-execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
+execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.CustomModelData
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -2,6 +2,6 @@ data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_sh
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
-data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
-execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
+data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -4,4 +4,6 @@ data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=i
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
 data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+execute unless data entity @s Item.tag.CustomModelData unless data entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
+execute unless data entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData run data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -2,8 +2,7 @@ data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_sh
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
-data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+execute as @e[type=item,tag=gm4_ml_source,dx=0,limit=1] if data entity @s Item.tag.gm4_metallurgy.custom_model_data run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
+execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
-execute unless data entity @s Item.tag.CustomModelData unless data entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
-execute unless data entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData run data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
 function #gm4_metallurgy:apply_band

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -3,4 +3,5 @@
 
 data modify entity @s Item.tag.display.Lore append from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[-1]
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
-data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
+data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -3,5 +3,4 @@
 
 data modify entity @s Item.tag.display.Lore append from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[-1]
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
-data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
 data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -3,5 +3,4 @@
 
 data modify entity @s Item.tag.display.Lore append from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[-1]
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
-data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
-data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
+data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -4,3 +4,4 @@
 data modify entity @s Item.tag.display.Lore append from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[-1]
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
 data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
+data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data

--- a/gm4_metallurgy/data/gm4_musical_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_musical_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"musical\",custom_model_data:108}}"
+                            "tag": "{CustomModelData:108,gm4_metallurgy:{stored_shamir:\"musical\",custom_model_data:108}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_musical_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_musical_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:108,gm4_metallurgy:{stored_shamir:\"musical\",custom_model_data:108}}"
+                            "tag": "{CustomModelData:108,gm4_metallurgy:{stored_shamir:\"musical\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_sensus_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_sensus_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"sensus\",custom_model_data:101}}"
+                            "tag": "{CustomModelData:101,gm4_metallurgy:{stored_shamir:\"sensus\",custom_model_data:101}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_sensus_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_sensus_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:101,gm4_metallurgy:{stored_shamir:\"sensus\",custom_model_data:101}}"
+                            "tag": "{CustomModelData:101,gm4_metallurgy:{stored_shamir:\"sensus\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_spiraculum_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_spiraculum_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"spiraculum\",custom_model_data:100}}"
+                            "tag": "{CustomModelData:100,gm4_metallurgy:{stored_shamir:\"spiraculum\",custom_model_data:100}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_spiraculum_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_spiraculum_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:100,gm4_metallurgy:{stored_shamir:\"spiraculum\",custom_model_data:100}}"
+                            "tag": "{CustomModelData:100,gm4_metallurgy:{stored_shamir:\"spiraculum\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_tinker_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:111,gm4_metallurgy:{stored_shamir:\"tinker\",custom_model_data:111}}"
+                            "tag": "{CustomModelData:111,gm4_metallurgy:{stored_shamir:\"tinker\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_metallurgy/data/gm4_tinker_shamir/loot_tables/band.json
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"tinker\",custom_model_data:111}}"
+                            "tag": "{CustomModelData:111,gm4_metallurgy:{stored_shamir:\"tinker\",custom_model_data:111}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_moneo_shamir/data/gm4_moneo_shamir/loot_tables/band.json
+++ b/gm4_moneo_shamir/data/gm4_moneo_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:113,gm4_metallurgy:{stored_shamir:\"moneo\",custom_model_data:113}}"
+                            "tag": "{CustomModelData:113,gm4_metallurgy:{stored_shamir:\"moneo\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_moneo_shamir/data/gm4_moneo_shamir/loot_tables/band.json
+++ b/gm4_moneo_shamir/data/gm4_moneo_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"moneo\",custom_model_data:113}}"
+                            "tag": "{CustomModelData:113,gm4_metallurgy:{stored_shamir:\"moneo\",custom_model_data:113}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
+++ b/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:106,gm4_metallurgy:{stored_shamir:\"percurro\",custom_model_data:106}}"
+                            "tag": "{CustomModelData:117,gm4_metallurgy:{stored_shamir:\"percurro\",custom_model_data:117}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
+++ b/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{gm4_metallurgy:{stored_shamir:\"percurro\",custom_model_data:106}}"
+                            "tag": "{CustomModelData:106,gm4_metallurgy:{stored_shamir:\"percurro\",custom_model_data:106}}"
                         },
                         {
                             "function": "minecraft:set_lore",

--- a/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
+++ b/gm4_percurro_shamir/data/gm4_percurro_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:117,gm4_metallurgy:{stored_shamir:\"percurro\",custom_model_data:117}}"
+                            "tag": "{CustomModelData:117,gm4_metallurgy:{stored_shamir:\"percurro\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",


### PR DESCRIPTION
Right now, Obsidian Casts with a metal band hold the number of the CustomModelData they will give the item they are applied to in the gm4_metallurgy tag, but don't have CustomModelData themselves (except for mundane bands). Note that Fulcio, Helious and Corripio would still need this change to be applied. (If this is merged, keep in mind that both Percurro and Defuse currently have the tag gm4_metallurgy.custom_model_data:106, and when this is used to set CustomModelData to the Obsidian Cast it would cause a problem for resource packs. I suggest changing the custom model data of percurro to a different, unused number).