### PR TITLE
Fixes netherite tools not working as intended

### DIFF
--- a/gm4_moneo_shamir/data/gm4_moneo_shamir/functions/active_tool.mcfunction
+++ b/gm4_moneo_shamir/data/gm4_moneo_shamir/functions/active_tool.mcfunction
@@ -11,6 +11,6 @@ execute if score tool_max_damage gm4_ml_data matches 59 run function gm4_moneo_s
 execute if score tool_max_damage gm4_ml_data matches 131 run function gm4_moneo_shamir:tools/materials/stone
 execute if score tool_max_damage gm4_ml_data matches 250 run function gm4_moneo_shamir:tools/materials/iron
 execute if score tool_max_damage gm4_ml_data matches 1561 run function gm4_moneo_shamir:tools/materials/diamond
-execute if score tool_max_damage gm4_ml_data matches 2006 run function gm4_moneo_shamir:tools/materials/netherite
+execute if score tool_max_damage gm4_ml_data matches 2031 run function gm4_moneo_shamir:tools/materials/netherite
 execute if score tool_max_damage gm4_ml_data matches 33 run function gm4_moneo_shamir:tools/materials/gold
 execute if score tool_max_damage gm4_ml_data matches 237 run function gm4_moneo_shamir:tools/shears

--- a/gm4_moneo_shamir/data/gm4_moneo_shamir/functions/tools/materials/netherite.mcfunction
+++ b/gm4_moneo_shamir/data/gm4_moneo_shamir/functions/tools/materials/netherite.mcfunction
@@ -3,6 +3,6 @@
 
 scoreboard players operation tool_max_damage gm4_ml_data -= tool_current_damage gm4_ml_data
 
-execute if score tool_max_damage gm4_ml_data matches 11..25 run effect give @s minecraft:mining_fatigue 2 0
-execute if score tool_max_damage gm4_ml_data matches ..25 at @s run playsound minecraft:block.lantern.hit master @s ~ ~ ~ 5 2
-execute if score tool_max_damage gm4_ml_data matches ..10 run effect give @s minecraft:mining_fatigue 2 1
+execute if score tool_max_damage gm4_ml_data matches 21..50 run effect give @s minecraft:mining_fatigue 2 0
+execute if score tool_max_damage gm4_ml_data matches ..50 at @s run playsound minecraft:block.lantern.hit master @s ~ ~ ~ 5 2
+execute if score tool_max_damage gm4_ml_data matches ..20 run effect give @s minecraft:mining_fatigue 2 1

--- a/gm4_moneo_shamir/data/gm4_moneo_shamir/tags/items/tools.json
+++ b/gm4_moneo_shamir/data/gm4_moneo_shamir/tags/items/tools.json
@@ -1,5 +1,9 @@
 {
     "values": [
+        "minecraft:netherite_shovel",
+        "minecraft:netherite_pickaxe",
+        "minecraft:netherite_hoe",
+        "minecraft:netherite_axe",
         "minecraft:golden_shovel",
         "minecraft:golden_pickaxe",
         "minecraft:golden_hoe",


### PR DESCRIPTION
In the initial check if they are holding a moneo tool it checks against an item tag in which netherite tools were missing.
The max durability check it does in gm4_moneo:active_tool was wrong
I also modified the durability warning values to be the same as diamond due the the fact it mines at the same speed so you will have the same amount of time to react.

This fixes issue #456 