### PR TITLE
Fix #462 - Soul glass constantly refreshing

### DIFF
--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/check.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/check.mcfunction
@@ -1,7 +1,7 @@
 #@s = soul glass AEC
 #run from beacon_clock
 
-execute unless block ~ ~-1 ~ beacon{Primary:0} run function gm4_soul_glass:effect/update_effects
+execute unless block ~ ~-1 ~ beacon{Primary:-1} run function gm4_soul_glass:effect/update_effects
 
 execute store result score @s gm4_sg_levels run data get block ~ ~-1 ~ Levels
 

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
@@ -4,8 +4,8 @@
 execute store result score @s gm4_sg_primary run data get block ~ ~-1 ~ Primary
 execute store result score @s gm4_sg_secondary run data get block ~ ~-1 ~ Secondary
 
-data modify block ~ ~-1 ~ Primary set value 0
-data modify block ~ ~-1 ~ Secondary set value 0
+data modify block ~ ~-1 ~ Primary set value -1
+data modify block ~ ~-1 ~ Secondary set value -1
 
 playsound minecraft:entity.wither.spawn block @a[distance=..10] ~ ~ ~ .5 1.3
 particle minecraft:witch ~ ~-1 ~ 0.5 0.5 0.5 0 40 force


### PR DESCRIPTION
In 1.16.2 they changed the default value for a beacon with no effect to -1 this broke soul glass's update function as it checked for something not 0.

Fixes #462 