### PR TITLE
Fix Soulutions in the Offhand

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/predicates/player/equipment/glass_bottle/in_offhand.json
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/predicates/player/equipment/glass_bottle/in_offhand.json
@@ -3,7 +3,7 @@
   "entity": "this",
   "predicate": {
     "equipment": {
-      "mainhand": {
+      "offhand": {
         "item": "minecraft:glass_bottle"
       }
     }


### PR DESCRIPTION
the `gm4_zauber_cauldrons:player/equipment/glass_bottle/in_offhand` predicate was checking the mainhand for a glass bottle, instead of the offhand