### PR TITLE
Center Wormhole TNT on player

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/player/wormhole_targeting/set_dimension.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/player/wormhole_targeting/set_dimension.mcfunction
@@ -16,4 +16,4 @@ tp @a[tag=gm4_zc_wormhole_consumer,limit=1] ~.5 ~.7 ~.5
 # play arrival animation
 particle minecraft:portal ~.5 ~1.3 ~.5 .25 .25 .25 0 100 force @a[distance=..32]
 execute positioned ~.5 ~.7 ~.5 run playsound minecraft:entity.enderman.teleport player @a[distance=..8] ~ ~ ~ 1 .3
-execute unless entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,dx=0,dy=0,dz=0] run summon tnt
+execute unless entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,dx=0,dy=0,dz=0] run summon tnt ~.5 ~.7 ~.5


### PR DESCRIPTION
TNT spawned by wormholes was aligned to the most negative corner of the block, this PR centers the TNT on the player.