### PR TITLE
Fix adding shamirs on items with Custom Model Data

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -3,6 +3,6 @@ data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[t
 data modify entity @s Item.tag.gm4_metallurgy.ore_type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.ore_type
 data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
 execute as @e[type=item,tag=gm4_ml_source,dx=0,limit=1] if data entity @s Item.tag.gm4_metallurgy.custom_model_data run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
-execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
+data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 function #gm4_metallurgy:apply_band


### PR DESCRIPTION
Adding a band should always write to Item.tag.gm4_metallurgy.custom_model_data, even if the item already has Custom Model Data, so that it can be later retrieved when removing the band.