### PR TITLE
Change sound effects of and add particles to disassemblers

### DIFF
--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -32,6 +32,6 @@ execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function g
 
 execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode master @a[distance=..5] ~ ~ ~ .33 1.5
 execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast master @a[distance=..5] ~ ~ ~ 1.5 1.1
-execute as @e[type=minecraft:armor_stand,sort=nearest,limit=1] at @s run particle minecraft:firework ~ ~.75 ~ .1 0 .1 .15 6 force
+particle minecraft:firework ~ ~.75 ~ .1 0 .1 .15 6 force
 
 execute if score result_items gm4_disassembler matches 0.. run kill @s

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -31,7 +31,7 @@ execute if entity @s[nbt={Item:{id:"minecraft:shears"}}] run function gm4_disass
 execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function gm4_disassemblers:items/flint_and_steel
 
 execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode master @a[distance=..5] ~ ~ ~ .33 1.5
-execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast master @a[distance=..5] ~ ~ ~ 1.5 1.1
+execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast block @a[distance=..5] ~ ~ ~ 0.66 1.1
 particle minecraft:firework ~ ~.75 ~ .1 0 .1 .15 6 force
 
 execute if score result_items gm4_disassembler matches 0.. run kill @s

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -30,6 +30,8 @@ execute if entity @s[nbt={Item:{id:"minecraft:iron_hoe"}}] run function gm4_disa
 execute if entity @s[nbt={Item:{id:"minecraft:shears"}}] run function gm4_disassemblers:items/shears
 execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function gm4_disassemblers:items/flint_and_steel
 
-execute if score result_items gm4_disassembler matches 0 run playsound minecraft:block.anvil.place master @a[distance=..5] ~ ~ ~ 3 0
-execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:block.anvil.use master @a[distance=..5] ~ ~ ~ 3 2
+execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode master @a[distance=..5] ~ ~ ~ .33 1.5
+execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast master @a[distance=..5] ~ ~ ~ 1.5 1.1
+execute as @e[type=minecraft:armor_stand,sort=nearest,limit=1] at @s run particle minecraft:firework ~ ~.75 ~ .1 0 .1 .15 6 force
+
 execute if score result_items gm4_disassembler matches 0.. run kill @s

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -30,7 +30,7 @@ execute if entity @s[nbt={Item:{id:"minecraft:iron_hoe"}}] run function gm4_disa
 execute if entity @s[nbt={Item:{id:"minecraft:shears"}}] run function gm4_disassemblers:items/shears
 execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function gm4_disassemblers:items/flint_and_steel
 
-execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode master @a[distance=..5] ~ ~ ~ .33 1.5
+execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode block @a[distance=..5] ~ ~ ~ .33 1.5
 execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast block @a[distance=..5] ~ ~ ~ 0.66 1.1
 particle minecraft:smoke ~ ~2.2 ~ .1 0 .1 .03 8 force
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -32,6 +32,6 @@ execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function g
 
 execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode block @a[distance=..5] ~ ~ ~ .33 1.5
 execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast block @a[distance=..5] ~ ~ ~ 0.66 1.1
-particle minecraft:smoke ~ ~2.2 ~ .1 0 .1 .03 8 force
+particle minecraft:smoke ~ ~1 ~ .1 0 .1 .03 8 force
 
 execute if score result_items gm4_disassembler matches 0.. run kill @s

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/check_disassemble_recipe.mcfunction
@@ -32,6 +32,6 @@ execute if entity @s[nbt={Item:{id:"minecraft:flint_and_steel"}}] run function g
 
 execute if score result_items gm4_disassembler matches 0 run playsound minecraft:entity.dragon_fireball.explode master @a[distance=..5] ~ ~ ~ .33 1.5
 execute if score result_items gm4_disassembler matches 1.. run playsound minecraft:entity.firework_rocket.large_blast block @a[distance=..5] ~ ~ ~ 0.66 1.1
-particle minecraft:firework ~ ~.75 ~ .1 0 .1 .15 6 force
+particle minecraft:smoke ~ ~2.2 ~ .1 0 .1 .03 8 force
 
 execute if score result_items gm4_disassembler matches 0.. run kill @s


### PR DESCRIPTION
I thought of this while making the models for the gm4 machine blocks. I always look at the recipe of the item when trying to come up with how to re texture the block, and I realized that the design of this machine block is a bit inconsistent. Its recipe only uses stone, TNT and redstone inside a custom crafter which is only more cobblestone and redstone. However, it uses the anvil place and use noises which really don't match the recipe of the block. I reimagined it as a block of reinforced stone where Steve places items to be blown up in a controlled manner, hoping to recycle some of the scraps (but it often blows up the whole thing), and changed the sounds accordingly. I also added some particles to increase the effect.

You can see a video of the changes in action here:
http://puu.sh/GT9Fy/74d7abbbcc.mp4

EDIT: maybe "minecraft:smoke ~ ~1 ~ .1 0 .1 .05 3 force" looks a bit better? I'm open to suggestions, if you like the explosion idea but think the particles and sounds could improve.