### PR TITLE
Add stone_button to smelteries

### DIFF
--- a/gm4_smelteries/data/gm4_smelteries/functions/check_ore.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/check_ore.mcfunction
@@ -6,7 +6,7 @@ data modify entity @s HandItems[0] set from block ^ ^ ^1 Items[{Slot:0b}]
 replaceitem entity @s armor.head air
 execute store result score can_smelt gm4_bf_data run loot replace entity @s armor.head fish gm4_smelteries:smeltable_display ~ ~ ~ mainhand
 replaceitem entity @s weapon air
-execute if score can_smelt gm4_bf_data matches 0 run replaceitem entity @s armor.head gray_stained_glass
+execute if score can_smelt gm4_bf_data matches 0 run replaceitem entity @s armor.head gray_stained_glass{CustomModelData:1}
 
 #check if the furnace is close to finish smelting, and then the structure
 execute if score can_smelt gm4_bf_data matches 1.. if score @s gm4_bf_data matches 184..199 if block ~ ~1 ~ #gm4_smelteries:air if block ~1 ~ ~1 iron_block if block ~1 ~ ~-1 iron_block if block ~-1 ~ ~1 iron_block if block ~-1 ~ ~-1 iron_block if block ~1 ~1 ~1 iron_block if block ~1 ~1 ~-1 iron_block if block ~-1 ~1 ~1 iron_block if block ~-1 ~1 ~-1 iron_block if block ^ ^ ^-1 iron_block if block ^1 ^ ^ iron_block if block ^-1 ^ ^ iron_block if block ^ ^1 ^-1 iron_block if block ^1 ^1 ^ iron_block if block ^-1 ^1 ^ iron_block run function gm4_smelteries:start_ticking

--- a/gm4_smelteries/data/gm4_smelteries/functions/create.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/create.mcfunction
@@ -1,7 +1,7 @@
 # @s - custom crafter with smeltery recipe
 # called by recipe_check
 
-data merge entity @s {CustomName:'"gm4_smeltery"',Rotation:[45f,0f],ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}],HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 45f, 0f],LeftArm:[0f, 0f, 0f]},Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Silent:1b}
+data merge entity @s {CustomName:'"gm4_smeltery"',Rotation:[45f,0f],ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}],HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{LeftArm:[0f, 0f, 0f]},Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Silent:1b}
 setblock ~ ~ ~ hopper{CustomName:'{"translate":"%1$s%3427655$s","with":["Smeltery",{"translate":"block.gm4.smeltery"}]}'}
 playsound block.anvil.use block @a[distance=..4] ~ ~ ~ 1 0.8
 advancement grant @a[distance=..4] only gm4:smelteries

--- a/gm4_smelteries/data/gm4_smelteries/functions/create.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/create.mcfunction
@@ -1,7 +1,7 @@
 # @s - custom crafter with smeltery recipe
 # called by recipe_check
 
-data merge entity @s {CustomName:'"gm4_smeltery"',Rotation:[45f,0f],ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}],Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Silent:1b}
+data merge entity @s {CustomName:'"gm4_smeltery"',Rotation:[45f,0f],ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}],HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 45f, 0f],LeftArm:[0f, 0f, 0f]},Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Silent:1b}
 setblock ~ ~ ~ hopper{CustomName:'{"translate":"%1$s%3427655$s","with":["Smeltery",{"translate":"block.gm4.smeltery"}]}'}
 playsound block.anvil.use block @a[distance=..4] ~ ~ ~ 1 0.8
 advancement grant @a[distance=..4] only gm4:smelteries

--- a/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
@@ -2,12 +2,30 @@
 # @s - smeltery that isn't pointing to a furnace
 # called by process
 
-execute at @s if entity @s[tag=gm4_bf_has_furnace] run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
-execute at @s if entity @s[tag=gm4_bf_has_furnace] run tp @s ~ ~ ~ -45 0
+# save initial state change
+scoreboard players add furnace_state_initial gm4_bf_data 0
+execute if entity @s[tag=gm4_bf_has_furnace] run scoreboard players add furnace_state_initial gm4_bf_data 1
+
+# check for furnaces
 tag @s remove gm4_bf_has_furnace
 execute if block ~1 ~ ~ furnace[facing=east] run tp @s ~ ~ ~ -90 0
 execute if block ~-1 ~ ~ furnace[facing=west] run tp @s ~ ~ ~ 90 0
 execute if block ~ ~ ~1 furnace[facing=south] run tp @s ~ ~ ~ 0 0
 execute if block ~ ~ ~-1 furnace[facing=north] run tp @s ~ ~ ~ 180 0
 execute at @s if block ^ ^ ^1 furnace run tag @s add gm4_bf_has_furnace
-execute at @s if block ^ ^ ^1 furnace run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:4}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
+
+# save final state
+scoreboard players add furnace_state_final gm4_bf_data 0
+execute if entity @s[tag=gm4_bf_has_furnace] run scoreboard players add furnace_state_final gm4_bf_data 1
+
+# calculate change
+scoreboard players operation furnace_state_final gm4_bf_data -= furnace_state_initial gm4_bf_data
+
+# apply texture changes
+execute if score furnace_state_final gm4_bf_data matches 1 run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:4}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
+execute if score furnace_state_final gm4_bf_data matches -1 run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
+scoreboard players reset furnace_state_initial gm4_bf_data
+scoreboard players reset furnace_state_final gm4_bf_data
+
+# tilt if no furnace was found
+execute at @s unless block ^ ^ ^1 furnace run tp @s ~ ~ ~ 45 0

--- a/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
@@ -2,6 +2,8 @@
 # @s - smeltery that isn't pointing to a furnace
 # called by process
 
+execute at @s if entity @s[tag=gm4_bf_has_furnace] run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
+execute at @s if entity @s[tag=gm4_bf_has_furnace] run tp @s ~ ~ ~ -45 0
 tag @s remove gm4_bf_has_furnace
 execute if block ~1 ~ ~ furnace[facing=east] run tp @s ~ ~ ~ -90 0
 execute if block ~-1 ~ ~ furnace[facing=west] run tp @s ~ ~ ~ 90 0
@@ -9,5 +11,3 @@ execute if block ~ ~ ~1 furnace[facing=south] run tp @s ~ ~ ~ 0 0
 execute if block ~ ~ ~-1 furnace[facing=north] run tp @s ~ ~ ~ 180 0
 execute at @s if block ^ ^ ^1 furnace run tag @s add gm4_bf_has_furnace
 execute at @s if block ^ ^ ^1 furnace run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:4}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
-execute at @s unless block ^ ^ ^1 furnace run tp @s ~ ~ ~ -45 0
-execute at @s unless block ^ ^ ^1 furnace run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}

--- a/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/find_furnace.mcfunction
@@ -8,4 +8,6 @@ execute if block ~-1 ~ ~ furnace[facing=west] run tp @s ~ ~ ~ 90 0
 execute if block ~ ~ ~1 furnace[facing=south] run tp @s ~ ~ ~ 0 0
 execute if block ~ ~ ~-1 furnace[facing=north] run tp @s ~ ~ ~ 180 0
 execute at @s if block ^ ^ ^1 furnace run tag @s add gm4_bf_has_furnace
-execute at @s unless block ^ ^ ^1 furnace run tp @s ~ ~ ~ 45 0
+execute at @s if block ^ ^ ^1 furnace run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:4}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}
+execute at @s unless block ^ ^ ^1 furnace run tp @s ~ ~ ~ -45 0
+execute at @s unless block ^ ^ ^1 furnace run data merge entity @s {HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{Head:[0f, 0f, 0f],LeftArm:[0f, 0f, 0f]}}

--- a/gm4_smelteries/data/gm4_smelteries/functions/process.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/process.mcfunction
@@ -10,7 +10,7 @@ execute unless block ^ ^ ^1 furnace run function gm4_smelteries:find_furnace
 
 # if furnace is lit, start checking for doubable items
 execute if entity @s[tag=gm4_bf_has_furnace] if block ^ ^ ^1 furnace[lit=true] run function gm4_smelteries:verify_furnace
-execute unless block ^ ^ ^1 furnace[lit=true] run replaceitem entity @s armor.head gray_stained_glass
+execute unless block ^ ^ ^1 furnace[lit=true] run replaceitem entity @s armor.head gray_stained_glass{CustomModelData:1}
 
 # particle
 execute if block ^ ^ ^1 furnace[lit=true] run particle large_smoke ^ ^.4 ^0.2 0 0.3 0 0 5 normal @a

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down.mcfunction
@@ -8,5 +8,5 @@ execute if block ~ ~ ~ command_block[facing=north] run setblock ~ ~ ~ hopper[fac
 execute if block ~ ~ ~ command_block[facing=down] run setblock ~ ~ ~ hopper[facing=down]
 
 data merge block ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Smeltery",{"translate":"block.gm4.smeltery"}]}'}
-summon armor_stand ~ ~-.4 ~ {Silent:1b,Small:1,NoGravity:1,Marker:1,Invulnerable:1,Invisible:1,DisabledSlots:2039552,Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Rotation:[45f,0f],Fire:200000,CustomName:'"gm4_smeltery"',ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}]}
+summon armor_stand ~ ~-.4 ~ {Silent:1b,Small:1,NoGravity:1,Marker:1,Invulnerable:1,Invisible:1,DisabledSlots:2039552,Tags:["gm4_smeltery","gm4_no_edit","gm4_machine"],Rotation:[45f,0f],Fire:200000,CustomName:'"gm4_smeltery"',ArmorItems:[{},{},{},{id:gray_stained_glass,Count:1,tag:{CustomModelData:1}}],HandItems:[{},{id:"minecraft:stone_button",Count:1b,tag:{CustomModelData:5}}],Pose:{LeftArm:[0f, 0f, 0f]}}
 playsound block.anvil.use block @a[distance=..4] ~ ~ ~ 1 0.8 1

--- a/gm4_smelteries/data/gm4_smelteries/loot_tables/smeltable_display.json
+++ b/gm4_smelteries/data/gm4_smelteries/loot_tables/smeltable_display.json
@@ -10,6 +10,12 @@
                         {
                             "type": "minecraft:item",
                             "name": "minecraft:gold_ore",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:1}"
+								}
+							],
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -22,6 +28,12 @@
 												{
                             "type": "minecraft:item",
                             "name": "minecraft:nether_gold_ore",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:1}"
+								}
+							],
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -34,6 +46,12 @@
                         {
                             "type": "minecraft:item",
                             "name": "minecraft:iron_ore",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:2}"
+								}
+							],
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -46,6 +64,12 @@
                         {
                             "type": "minecraft:item",
                             "name": "minecraft:sand",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:1}"
+								}
+							],
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -58,6 +82,12 @@
                         {
                             "type": "minecraft:item",
                             "name": "minecraft:red_sand",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:1}"
+								}
+							],
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -70,6 +100,12 @@
                         {
                             "type": "minecraft:item",
                             "name": "minecraft:chorus_flower",
+							"functions": [
+								{
+									"function": "minecraft:set_nbt",
+									"tag": "{CustomModelData:1}"
+								}
+							],	
                             "conditions": [
                                 {
                                     "condition": "minecraft:match_tool",
@@ -79,7 +115,7 @@
                                 }
                             ]
                         }
-										]
+					]
                 }
             ]
         }


### PR DESCRIPTION
This is slightly bigger than the other stone_button PRs, but it does essentially the same (allows me to retexture/remodel the block, but in this case it allows me to keep the display head). Some CMD switching had to happen in find_furnace because of the rotation, and it still glitches when it tries to find a new furnace, but hey, what can you do (at least it lasts only a fraction of a second. You can see it in the video below)

Also, it gives the display blocks custom model data so they can be retextured

Here's a preview of what can be done with the button (the files for this are in a PR in resources):
http://puu.sh/GThH2/3c74f2efee.mp4

