### PR TITLE
Add Ancient Debris to Smelteries

### DIFF
--- a/gm4_smelteries/data/gm4_smelteries/loot_tables/smelt.json
+++ b/gm4_smelteries/data/gm4_smelteries/loot_tables/smelt.json
@@ -44,6 +44,18 @@
                         },
                         {
                             "type": "minecraft:item",
+                            "name": "minecraft:netherite_scrap",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:match_tool",
+                                    "predicate": {
+                                        "item": "minecraft:ancient_debris"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
                             "name": "minecraft:glass",
                             "conditions": [
                                 {

--- a/gm4_smelteries/data/gm4_smelteries/loot_tables/smeltable_display.json
+++ b/gm4_smelteries/data/gm4_smelteries/loot_tables/smeltable_display.json
@@ -45,6 +45,18 @@
                         },
                         {
                             "type": "minecraft:item",
+                            "name": "minecraft:ancient_debris",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:match_tool",
+                                    "predicate": {
+                                        "item": "minecraft:ancient_debris"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
                             "name": "minecraft:sand",
                             "conditions": [
                                 {


### PR DESCRIPTION
Ancient Debris is a metal ore, so smelteries should be able to double it. 