### PR TITLE
Tunnel bores model cosmetics

### DIFF
--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/create.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/create.mcfunction
@@ -4,7 +4,7 @@
 
 # kill existing cart and summon new cart
 kill @s
-summon furnace_minecart ~ ~ ~ {CustomName:'{"text":"Minecart with Piston"}',CustomDisplayTile:1b,DisplayState:{Name:"minecraft:piston",Properties:{extended:"true",facing:"up"}},DisplayOffset:6,Tags:["gm4_tunnel_bore"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,CustomName:'{"text":"gm4_bore_storage"}',Tags:[gm4_bore_storage]}]}
+summon furnace_minecart ~ ~ ~ {CustomName:'{"text":"Minecart with Piston"}',CustomDisplayTile:1b,DisplayState:{Name:"minecraft:piston",Properties:{facing:"up"}},DisplayOffset:6,Tags:["gm4_tunnel_bore"],Passengers:[{id:"minecraft:area_effect_cloud",Duration:2147483647,CustomName:'{"text":"gm4_bore_storage"}',Tags:[gm4_bore_storage]}]}
 
 # initiate scores
 scoreboard players add @e[type=area_effect_cloud,tag=gm4_bore_storage,distance=..0.1] gm4_bore_rail 0

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/clear_rotation.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/clear_rotation.mcfunction
@@ -1,0 +1,10 @@
+# @s = tunnel bores that left their tracks
+# at world spawn
+# called by gm4_tunnel_bores:update_direction
+
+data merge entity @s {DisplayState:{Properties:{facing:"up"}}}
+
+tag @s remove gm4_tunnel_bore_south
+tag @s remove gm4_tunnel_bore_north
+tag @s remove gm4_tunnel_bore_east
+tag @s remove gm4_tunnel_bore_west

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
@@ -5,8 +5,8 @@
 # store previous direction for use in gm4_tunnel_bores:bore/direction/store_push_east_west and gm4_tunnel_bores:bore/direction/store_push_north_south
 scoreboard players operation previous_direction gm4_bore_data = @s gm4_bore_data
 
-# clear tunnel bore orientation tags and reset visuals if out of rails
-execute at @s unless block ~ ~ ~ #minecraft:rails unless entity @s[tag=!gm4_tunnel_bore_south,tag=!gm4_tunnel_bore_west,tag=!gm4_tunnel_bore_east,tag=!gm4_tunnel_bore_north] run function gm4_tunnel_bores:bore/direction/clear_rotation
+# clear tunnel bore orientation tags and visuals if not on valid rails
+execute at @s if score @s gm4_bore_data matches -1 unless entity @s[tag=!gm4_tunnel_bore_south,tag=!gm4_tunnel_bore_west,tag=!gm4_tunnel_bore_east,tag=!gm4_tunnel_bore_north] run function gm4_tunnel_bores:bore/direction/clear_rotation
 
 # set direction to -1. This will stay if cart is not on a valid rail
 scoreboard players set @s gm4_bore_data -1

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
@@ -5,6 +5,9 @@
 # store previous direction for use in gm4_tunnel_bores:bore/direction/store_push_east_west and gm4_tunnel_bores:bore/direction/store_push_north_south
 scoreboard players operation previous_direction gm4_bore_data = @s gm4_bore_data
 
+# clear tunnel bore orientation tags and visuals if not on rails
+execute at @s unless block ~ ~ ~ #minecraft:rails unless entity @s[tag=!gm4_tunnel_bore_south,tag=!gm4_tunnel_bore_west,tag=!gm4_tunnel_bore_east,tag=!gm4_tunnel_bore_north] run function gm4_tunnel_bores:bore/direction/clear_rotation
+
 # set direction to -1. This will stay if cart is not on a valid rail
 scoreboard players set @s gm4_bore_data -1
 

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_direction.mcfunction
@@ -5,7 +5,7 @@
 # store previous direction for use in gm4_tunnel_bores:bore/direction/store_push_east_west and gm4_tunnel_bores:bore/direction/store_push_north_south
 scoreboard players operation previous_direction gm4_bore_data = @s gm4_bore_data
 
-# clear tunnel bore orientation tags and visuals if not on rails
+# clear tunnel bore orientation tags and reset visuals if out of rails
 execute at @s unless block ~ ~ ~ #minecraft:rails unless entity @s[tag=!gm4_tunnel_bore_south,tag=!gm4_tunnel_bore_west,tag=!gm4_tunnel_bore_east,tag=!gm4_tunnel_bore_north] run function gm4_tunnel_bores:bore/direction/clear_rotation
 
 # set direction to -1. This will stay if cart is not on a valid rail

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation.mcfunction
@@ -2,6 +2,11 @@
 # at world spawn
 # called by gm4_tunnel_bores:update_direction
 
+execute if entity @s[tag=!gm4_tunnel_bore_south] if score @s gm4_bore_data matches 0 at @s run function gm4_tunnel_bores:bore/direction/update_rotation_south
+execute if entity @s[tag=!gm4_tunnel_bore_west] if score @s gm4_bore_data matches 90 at @s run function gm4_tunnel_bores:bore/direction/update_rotation_west
+execute if entity @s[tag=!gm4_tunnel_bore_east] if score @s gm4_bore_data matches -90 at @s run function gm4_tunnel_bores:bore/direction/update_rotation_east
+execute if entity @s[tag=!gm4_tunnel_bore_north] if score @s gm4_bore_data matches 180 at @s run function gm4_tunnel_bores:bore/direction/update_rotation_north
+
 execute if score @s gm4_bore_data matches 0 at @s run tp @s ~ ~ ~ 0 ~
 execute if score @s gm4_bore_data matches 90 at @s run tp @s ~ ~ ~ 90 ~
 execute if score @s gm4_bore_data matches -90 at @s run tp @s ~ ~ ~ -90 ~

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_east.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_east.mcfunction
@@ -1,0 +1,9 @@
+# @s = tunnel bores on tracks facing east
+# at world spawn
+# called by gm4_tunnel_bores:update_rotation
+
+data merge entity @s {DisplayState:{Properties:{facing:"south"}}}
+tag @s add gm4_tunnel_bore_east
+tag @s remove gm4_tunnel_bore_west
+tag @s remove gm4_tunnel_bore_south
+tag @s remove gm4_tunnel_bore_north

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_north.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_north.mcfunction
@@ -1,0 +1,9 @@
+# @s = tunnel bores on tracks facing north
+# at world spawn
+# called by gm4_tunnel_bores:update_rotation
+
+data merge entity @s {DisplayState:{Properties:{facing:"north"}}}
+tag @s add gm4_tunnel_bore_north
+tag @s remove gm4_tunnel_bore_east
+tag @s remove gm4_tunnel_bore_west
+tag @s remove gm4_tunnel_bore_south

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_south.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_south.mcfunction
@@ -1,0 +1,9 @@
+# @s = tunnel bores on tracks facing south
+# at world spawn
+# called by gm4_tunnel_bores:update_rotation
+
+data merge entity @s {DisplayState:{Properties:{facing:"south"}}}
+tag @s add gm4_tunnel_bore_south
+tag @s remove gm4_tunnel_bore_east
+tag @s remove gm4_tunnel_bore_west
+tag @s remove gm4_tunnel_bore_north

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_west.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/direction/update_rotation_west.mcfunction
@@ -1,0 +1,9 @@
+# @s = tunnel bores on tracks facing west
+# at world spawn
+# called by gm4_tunnel_bores:update_rotation
+
+data merge entity @s {DisplayState:{Properties:{facing:"north"}}}
+tag @s add gm4_tunnel_bore_west
+tag @s remove gm4_tunnel_bore_east
+tag @s remove gm4_tunnel_bore_south
+tag @s remove gm4_tunnel_bore_north

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/mine/stop_cart.mcfunction
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/functions/bore/mine/stop_cart.mcfunction
@@ -2,8 +2,8 @@
 # at tunnel bore minecart
 # called by gm4_tunnel_bores:bore/mine/break_block and gm4_tunnel_bores:bore/check_cart_environment
 
-# stop cart (physically)
-data merge entity @s {Motion:[0.0,0.0,0.0],PushX:0.0,PushZ:0.0}
+# stop cart (physically) (and visually)
+data merge entity @s {DisplayState:{Properties:{facing:"up"}},Motion:[0.0,0.0,0.0],PushX:0.0,PushZ:0.0}
 
 # stop cart (code flag)
 scoreboard players set @s gm4_bore_data -1


### PR DESCRIPTION
DEMO: http://puu.sh/GV19J/180728e048.mp4

This will change the piston's orientation depending on where the minecart is facing and will change the orientation back to "up" if it fails to place a rail or runs out. It makes it much easier to see when the tunnel bore is set up properly and looks nicer overall (except for the fraction of a second when it turns some corners or goes up or down, but all minecarts with block passengers do that, and tunnel bores rarely do ¯\_(ツ)_/¯). I tried to limit the amount of NBT operations made by adding temporary tags when rotating so that the NBT operations happen once per turn (and tunnel bores don't really turn all that much in practice) and similarly when clearing the orientation back to up. Feel free to (please!) make suggestions on how to improve this.