### PR TITLE
Standardized GM4 color team names

### DIFF
--- a/gm4_holographic_tags/data/gm4_holographic_tags/functions/init.mcfunction
+++ b/gm4_holographic_tags/data/gm4_holographic_tags/functions/init.mcfunction
@@ -1,36 +1,36 @@
-team add gm4_ht_white
-team add gm4_ht_orange
-team add gm4_ht_magenta
-team add gm4_ht_lightblue
-team add gm4_ht_yellow
-team add gm4_ht_lime
-team add gm4_ht_pink
-team add gm4_ht_gray
-team add gm4_ht_lightgray
-team add gm4_ht_cyan
-team add gm4_ht_purple
-team add gm4_ht_blue
-team add gm4_ht_brown
-team add gm4_ht_green
-team add gm4_ht_red
-team add gm4_ht_black
+team add gm4_white
+team add gm4_orange
+team add gm4_magenta
+team add gm4_lightblue
+team add gm4_yellow
+team add gm4_lime
+team add gm4_pink
+team add gm4_gray
+team add gm4_lightgray
+team add gm4_cyan
+team add gm4_purple
+team add gm4_blue
+team add gm4_brown
+team add gm4_green
+team add gm4_red
+team add gm4_black
 
-team modify gm4_ht_white color white
-team modify gm4_ht_orange color gold
-team modify gm4_ht_magenta color light_purple
-team modify gm4_ht_lightblue color aqua
-team modify gm4_ht_yellow color yellow
-team modify gm4_ht_lime color green
-team modify gm4_ht_pink color red
-team modify gm4_ht_gray color dark_gray
-team modify gm4_ht_lightgray color gray
-team modify gm4_ht_cyan color dark_aqua
-team modify gm4_ht_purple color dark_purple
-team modify gm4_ht_blue color blue
-team modify gm4_ht_brown color dark_blue
-team modify gm4_ht_green color dark_green
-team modify gm4_ht_red color dark_red
-team modify gm4_ht_black color black
+team modify gm4_white color white
+team modify gm4_orange color gold
+team modify gm4_magenta color light_purple
+team modify gm4_lightblue color aqua
+team modify gm4_yellow color yellow
+team modify gm4_lime color green
+team modify gm4_pink color red
+team modify gm4_gray color dark_gray
+team modify gm4_lightgray color gray
+team modify gm4_cyan color dark_aqua
+team modify gm4_purple color dark_purple
+team modify gm4_blue color blue
+team modify gm4_brown color dark_blue
+team modify gm4_green color dark_green
+team modify gm4_red color dark_red
+team modify gm4_black color black
 
 execute unless score holographic_tags gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Holographic Tags"}
 scoreboard players set holographic_tags gm4_modules 1

--- a/gm4_holographic_tags/data/gm4_holographic_tags/functions/set_color.mcfunction
+++ b/gm4_holographic_tags/data/gm4_holographic_tags/functions/set_color.mcfunction
@@ -1,19 +1,19 @@
 # @s = item frame with renamed name tag if on a wool block
 # run from create_hologram
 
-execute if block ^ ^ ^-.75 white_wool run team join gm4_ht_white
-execute if block ^ ^ ^-.75 orange_wool run team join gm4_ht_orange
-execute if block ^ ^ ^-.75 magenta_wool run team join gm4_ht_magenta
-execute if block ^ ^ ^-.75 light_blue_wool run team join gm4_ht_lightblue
-execute if block ^ ^ ^-.75 yellow_wool run team join gm4_ht_yellow
-execute if block ^ ^ ^-.75 lime_wool run team join gm4_ht_lime
-execute if block ^ ^ ^-.75 pink_wool run team join gm4_ht_pink
-execute if block ^ ^ ^-.75 gray_wool run team join gm4_ht_gray
-execute if block ^ ^ ^-.75 light_gray_wool run team join gm4_ht_lightgray
-execute if block ^ ^ ^-.75 cyan_wool run team join gm4_ht_cyan
-execute if block ^ ^ ^-.75 purple_wool run team join gm4_ht_purple
-execute if block ^ ^ ^-.75 blue_wool run team join gm4_ht_blue
-execute if block ^ ^ ^-.75 brown_wool run team join gm4_ht_brown
-execute if block ^ ^ ^-.75 green_wool run team join gm4_ht_green
-execute if block ^ ^ ^-.75 red_wool run team join gm4_ht_red
-execute if block ^ ^ ^-.75 black_wool run team join gm4_ht_black
+execute if block ^ ^ ^-.75 white_wool run team join gm4_white
+execute if block ^ ^ ^-.75 orange_wool run team join gm4_orange
+execute if block ^ ^ ^-.75 magenta_wool run team join gm4_magenta
+execute if block ^ ^ ^-.75 light_blue_wool run team join gm4_lightblue
+execute if block ^ ^ ^-.75 yellow_wool run team join gm4_yellow
+execute if block ^ ^ ^-.75 lime_wool run team join gm4_lime
+execute if block ^ ^ ^-.75 pink_wool run team join gm4_pink
+execute if block ^ ^ ^-.75 gray_wool run team join gm4_gray
+execute if block ^ ^ ^-.75 light_gray_wool run team join gm4_lightgray
+execute if block ^ ^ ^-.75 cyan_wool run team join gm4_cyan
+execute if block ^ ^ ^-.75 purple_wool run team join gm4_purple
+execute if block ^ ^ ^-.75 blue_wool run team join gm4_blue
+execute if block ^ ^ ^-.75 brown_wool run team join gm4_brown
+execute if block ^ ^ ^-.75 green_wool run team join gm4_green
+execute if block ^ ^ ^-.75 red_wool run team join gm4_red
+execute if block ^ ^ ^-.75 black_wool run team join gm4_black


### PR DESCRIPTION
* replaced Team names from gm4_ht_color to gm4_color

In the event future datapacks use in-game Teams for colors, removing the datapack-specific naming scheme allows every datapack to use a GM4-standard team name