### PR TITLE
Speed Paths' speed boost: potion effect -> attribute modifier

### DIFF
--- a/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/add_speed.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/add_speed.mcfunction
@@ -4,5 +4,5 @@
 # run from main
 
 tag @s add gm4_on_path
-scoreboard players set @s gm4_speed_paths 40
+scoreboard players set @s gm4_speed_paths 5
 attribute @s minecraft:generic.movement_speed modifier add dc33007e-5da4-4fad-a850-9c5a058c22ba gm4_speed_paths_speed_boost 0.2 multiply_base

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/add_speed.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/add_speed.mcfunction
@@ -1,0 +1,8 @@
+# applies the Speed Paths attribute and gm4_on_path tag
+# @s = player upon stepping on a speed path
+# at @s
+# run from main
+
+tag @s add gm4_on_path
+scoreboard players set @s gm4_speed_paths 40
+attribute @s minecraft:generic.movement_speed modifier add dc33007e-5da4-4fad-a850-9c5a058c22ba gm4_speed_paths_speed_boost 0.2 multiply_base

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/check_path.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/check_path.mcfunction
@@ -1,0 +1,10 @@
+# checks if the player is still on a speed path
+# @s = player, with gm4_on_path tag
+# at @s
+# run from main
+
+execute positioned ~ ~1 ~ run particle minecraft:entity_effect ^ ^ ^0.2 0.75 0.9 1 0.8 0
+execute if entity @s[scores={gm4_speed_paths=1..}] unless block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players operation @s gm4_speed_paths -= #5 gm4_speed_paths
+execute if block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players set @s gm4_speed_paths 40
+
+execute at @s[scores={gm4_speed_paths=..0}] run function gm4_speed_paths:apply_effects/remove_speed

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/check_path.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/check_path.mcfunction
@@ -3,8 +3,7 @@
 # at @s
 # run from main
 
-execute positioned ~ ~1 ~ run particle minecraft:entity_effect ^ ^ ^0.2 0.75 0.9 1 0.8 0
-execute if entity @s[scores={gm4_speed_paths=1..}] unless block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players operation @s gm4_speed_paths -= #5 gm4_speed_paths
-execute if block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players set @s gm4_speed_paths 40
+execute if entity @s[scores={gm4_speed_paths=1..}] unless block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players remove @s gm4_speed_paths 1
+execute if block ~ ~-0.9 ~ minecraft:grass_path run scoreboard players set @s gm4_speed_paths 5
 
 execute at @s[scores={gm4_speed_paths=..0}] run function gm4_speed_paths:apply_effects/remove_speed

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/remove_speed.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/apply_effects/remove_speed.mcfunction
@@ -1,0 +1,7 @@
+# removes the Speed Path attribute speed and on_path tag
+# @s = player, 2 after no longer being on a speed path
+# at @s
+# run from apply_effects/check_path
+
+attribute @s minecraft:generic.movement_speed modifier remove dc33007e-5da4-4fad-a850-9c5a058c22ba
+tag @s remove gm4_on_path

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/init.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/init.mcfunction
@@ -1,8 +1,7 @@
-scoreboard objectives add gm4_speed_paths dummy
-scoreboard players set #5 gm4_speed_paths 5
-
 execute unless score speed_paths gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Speed Paths"}
 scoreboard players set speed_paths gm4_modules 1
+
+scoreboard objectives add gm4_speed_paths dummy
 
 schedule function gm4_speed_paths:main 1t
 

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/init.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/init.mcfunction
@@ -1,3 +1,6 @@
+scoreboard objectives add gm4_speed_paths dummy
+scoreboard players set #5 gm4_speed_paths 5
+
 execute unless score speed_paths gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Speed Paths"}
 scoreboard players set speed_paths gm4_modules 1
 

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/main.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/main.mcfunction
@@ -1,4 +1,4 @@
-execute as @a run attribute @s minecraft:generic.movement_speed modifier remove dc33007e-5da4-4fad-a850-9c5a058c22ba
-execute as @a at @s if block ~ ~-0.9 ~ grass_path run attribute @s minecraft:generic.movement_speed modifier add dc33007e-5da4-4fad-a850-9c5a058c22ba gm4_speed_paths_speed_boost 0.2 multiply_base
+execute as @a[tag=!gm4_on_path] at @s if block ~ ~-0.9 ~ minecraft:grass_path run function gm4_speed_paths:apply_effects/add_speed
+execute as @a[tag=gm4_on_path] at @s run function gm4_speed_paths:apply_effects/check_path
 
 schedule function gm4_speed_paths:main 8t

--- a/gm4_speed_paths/data/gm4_speed_paths/functions/main.mcfunction
+++ b/gm4_speed_paths/data/gm4_speed_paths/functions/main.mcfunction
@@ -1,3 +1,4 @@
-execute as @a at @s if block ~ ~-0.9 ~ grass_path unless entity @s[nbt={ActiveEffects:[{Id:1b,ShowParticles:1b}]}] run effect give @s speed 2 0 true
+execute as @a run attribute @s minecraft:generic.movement_speed modifier remove dc33007e-5da4-4fad-a850-9c5a058c22ba
+execute as @a at @s if block ~ ~-0.9 ~ grass_path run attribute @s minecraft:generic.movement_speed modifier add dc33007e-5da4-4fad-a850-9c5a058c22ba gm4_speed_paths_speed_boost 0.2 multiply_base
 
 schedule function gm4_speed_paths:main 8t

--- a/gm4_speed_paths/pack.mcmeta
+++ b/gm4_speed_paths/pack.mcmeta
@@ -29,6 +29,9 @@
             [
                 "Misode",
                 "https://twitter.com/misode_"
+            ],
+            [
+                "TheEpyonProject"
             ]
         ]
     }


### PR DESCRIPTION
Making the speed boost an attribute modifier allows the player to stack additional speed effects (vanilla potions or beacons, and Zauber speed armor) 