### PR TITLE
Health Boost Effect Compatibility

### DIFF
--- a/gm4_heart_canisters/data/gm4_heart_canisters/functions/apply_health_boost.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/functions/apply_health_boost.mcfunction
@@ -13,5 +13,7 @@ attribute @s[scores={gm4_heart_can=8}] minecraft:generic.max_health modifier add
 attribute @s[scores={gm4_heart_can=9}] minecraft:generic.max_health modifier add 38a576e7-341b-46ed-a9e3-7b7291beae72 gm4_hc_health_boost 36 add
 attribute @s[scores={gm4_heart_can=10}] minecraft:generic.max_health modifier add 38a576e7-341b-46ed-a9e3-7b7291beae72 gm4_hc_health_boost 40 add
 
-effect give @s health_boost 1 1
-effect clear @s health_boost
+tag @s[nbt={ActiveEffects:[{Id:21b}]}] add gm4_hc_has_effect
+effect give @s[tag=!gm4_hc_has_effect] health_boost 1
+effect clear @s[tag=!gm4_hc_has_effect] health_boost
+tag @s remove gm4_hc_has_effect

--- a/gm4_heart_canisters/data/gm4_heart_canisters/functions/apply_health_boost.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/functions/apply_health_boost.mcfunction
@@ -13,7 +13,7 @@ attribute @s[scores={gm4_heart_can=8}] minecraft:generic.max_health modifier add
 attribute @s[scores={gm4_heart_can=9}] minecraft:generic.max_health modifier add 38a576e7-341b-46ed-a9e3-7b7291beae72 gm4_hc_health_boost 36 add
 attribute @s[scores={gm4_heart_can=10}] minecraft:generic.max_health modifier add 38a576e7-341b-46ed-a9e3-7b7291beae72 gm4_hc_health_boost 40 add
 
-tag @s[nbt={ActiveEffects:[{Id:21b}]}] add gm4_hc_has_effect
+tag @s[predicate=gm4_heart_canisters:has_health_boost] add gm4_hc_has_effect
 effect give @s[tag=!gm4_hc_has_effect] health_boost 1
 effect clear @s[tag=!gm4_hc_has_effect] health_boost
 tag @s remove gm4_hc_has_effect

--- a/gm4_heart_canisters/data/gm4_heart_canisters/predicates/has_health_boost.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/predicates/has_health_boost.json
@@ -1,0 +1,9 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "effects": {
+      "minecraft:health_boost": {}
+    }
+  }
+}


### PR DESCRIPTION
This change makes it so that heart canisters only clear the health boost effect if the player doesn't already have the effect, improving compatibility with modules that do use health boost as an effect.