### PR TITLE
Fix for honey blocks spawning incorrectly

### DIFF
--- a/gm4_liquid_tanks/data/gm4_standard_liquids/functions/util/honey_casting/honey_stop.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_standard_liquids/functions/util/honey_casting/honey_stop.mcfunction
@@ -1,7 +1,7 @@
 #@s = gm4_lt_honey_display
 #run from standard_liquids:util/honey_casting/honey_rise
 
-summon item ~ ~1 ~ {Item:{id:"honey_block",Count:1}}
+execute at @s run summon item ~ ~1 ~ {Item:{id:"honey_block",Count:1}}
 playsound block.honey_block.place block @a[distance=..10]
 kill @s
 

--- a/gm4_liquid_tanks/data/gm4_standard_liquids/functions/util/honey_casting/honey_stop.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_standard_liquids/functions/util/honey_casting/honey_stop.mcfunction
@@ -2,7 +2,7 @@
 #run from standard_liquids:util/honey_casting/honey_rise
 
 execute at @s run summon item ~ ~1 ~ {Item:{id:"honey_block",Count:1}}
-playsound block.honey_block.place block @a[distance=..10]
+execute at @s run playsound block.honey_block.place block @a[distance=..10]
 kill @s
 
 execute unless entity @e[type=armor_stand,tag=gm4_lt_honey_display,limit=1] run schedule clear gm4_standard_liquids:util/honey_casting/honey_rise


### PR DESCRIPTION
ok so this doesn't technically fix the underlying issue apparently which is some schedule stuff but it does stop a duplicate honey block spawning at spawn while keeping the correct one so it's sort of fixed, aheh