### PR TITLE
Desire Lines: Add Celaro Shamir

### DIFF
--- a/gm4_desire_lines/data/gm4/tags/items/boots.json
+++ b/gm4_desire_lines/data/gm4/tags/items/boots.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:netherite_boots",
+    "minecraft:diamond_boots",
+    "minecraft:golden_boots",
+    "minecraft:chainmail_boots",
+    "minecraft:iron_boots",
+    "minecraft:leather_boots"
+  ]
+}

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set @s gm4_desire_lines 0
+execute if block ~ ~ ~ #tall_flowers run effect give @s invisibility 1 0 true

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
@@ -1,2 +1,2 @@
 scoreboard players set @s gm4_desire_lines 0
-execute if block ~ ~ ~ #tall_flowers run effect give @s invisibility 1 0 true
+execute if block ~ ~ ~ #gm4_celaro_shamir:tall_plants run effect give @s invisibility 1 0 true

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/check_item_validity.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/check_item_validity.mcfunction
@@ -1,0 +1,4 @@
+#@s = band is trying to apply to
+#run from #gm4_metallurgy:check_item_validity
+
+execute if entity @e[type=item,tag=gm4_ml_source,dx=0,nbt={Item:{tag:{gm4_metallurgy:{stored_shamir:"celaro"}}}}] run function gm4_celaro_shamir:mark_item_validity

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/mark_item_validity.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/mark_item_validity.mcfunction
@@ -1,0 +1,9 @@
+#@s = band is trying to apply to
+#run from check_item_validity
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:netherite_boots"}}]
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:diamond_boots"}}]
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:golden_boots"}}]
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:chainmail_boots"}}]
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:iron_boots"}}]
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:leather_boots"}}]

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/summon_band.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/summon_band.mcfunction
@@ -1,0 +1,4 @@
+# @s = a mould with matching metal inside
+#run from metallurgy:casting/summon_band/aluminium via #gm4_metallurgy:summon_band/aluminium
+
+loot spawn ~ ~ ~ loot gm4_celaro_shamir:band

--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/tick.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/tick.mcfunction
@@ -1,0 +1,1 @@
+execute if predicate gm4_celaro_shamir:shamir_active run function gm4_celaro_shamir:active

--- a/gm4_desire_lines/data/gm4_celaro_shamir/loot_tables/band.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/loot_tables/band.json
@@ -1,0 +1,36 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_metallurgy:aluminium_band",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_nbt",
+                            "tag": "{CustomModelData:103,gm4_metallurgy:{stored_shamir:\"celaro\"}}"
+                        },
+                        {
+                            "function": "minecraft:set_lore",
+                            "replace": false,
+                            "lore": [
+                                {
+                                    "translate": "%1$s%3427655$s",
+                                    "with": [
+                                        "Celaro",
+                                        {
+                                            "translate": "item.gm4.shamir.celaro"
+                                        }
+                                    ],
+                                    "italic": false,
+                                    "color": "gray"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_desire_lines/data/gm4_celaro_shamir/predicates/shamir_active.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/predicates/shamir_active.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "feet": {
+        "nbt": "{gm4_metallurgy:{active_shamir:\"celaro\"}}"
+      }
+    }
+  }
+}

--- a/gm4_desire_lines/data/gm4_celaro_shamir/predicates/shamir_active.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/predicates/shamir_active.json
@@ -4,6 +4,7 @@
   "predicate": {
     "equipment": {
       "feet": {
+        "tag": "gm4:boots",
         "nbt": "{gm4_metallurgy:{active_shamir:\"celaro\"}}"
       }
     }

--- a/gm4_desire_lines/data/gm4_celaro_shamir/tags/blocks/tall_plants.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/tags/blocks/tall_plants.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#minecraft:tall_flowers",
+    "minecraft:tall_grass",
+    "minecraft:large_fern"
+  ]
+}

--- a/gm4_desire_lines/data/gm4_desire_lines/tags/functions/expansion.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/tags/functions/expansion.json
@@ -1,4 +1,5 @@
 {
   "values": [
+    "gm4_celaro_shamir:tick"
   ]
 }

--- a/gm4_desire_lines/data/gm4_metallurgy/tags/functions/check_item_validity.json
+++ b/gm4_desire_lines/data/gm4_metallurgy/tags/functions/check_item_validity.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+      "gm4_celaro_shamir:check_item_validity"
+    ]
+  }

--- a/gm4_desire_lines/data/gm4_metallurgy/tags/functions/summon_band/aluminium.json
+++ b/gm4_desire_lines/data/gm4_metallurgy/tags/functions/summon_band/aluminium.json
@@ -1,0 +1,5 @@
+{
+    "values":[
+      "gm4_celaro_shamir:summon_band"
+    ]
+  }


### PR DESCRIPTION
Celaro is a new type of Aluminium Band that can be placed on boots, included in the Desire Lines module when loaded alongside Metallurgy. When applied to the player's boots, the Celaro shamir will simply suppress the the effects of Desire Lines, just like the Boots of Ostara. There is also a fun easter egg suggested by Bloo if you stand in tall flowers while wearing Celaro boots.