### PR TITLE
Update How shamirs add and remove lore

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -1,7 +1,12 @@
 data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
 data modify entity @s Item.tag.gm4_metallurgy.metal.type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.metal.type
-data modify entity @s Item.tag.display.Lore set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore
+
+# Prepend lore from the shamir
+data modify entity @s Item.tag.display.Lore prepend from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[2]
+data modify entity @s Item.tag.display.Lore prepend from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[1]
+data modify entity @s Item.tag.display.Lore prepend from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[0]
+
 execute as @e[type=item,tag=gm4_ml_source,dx=0,limit=1] if data entity @s Item.tag.gm4_metallurgy.custom_model_data run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data
 data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData
 execute unless data entity @s Item.tag.CustomModelData run data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.CustomModelData

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/check.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/check.mcfunction
@@ -1,12 +1,15 @@
+# @s = item with shamir on an anvil being crushed by a piston
+# run from prepare_transfer
 
-#check whether the other item is an obsidian block
+# Store lore into temp storage (to extract shamir lore)
+data modify storage gm4_metallurgy:temp item_lore set from entity @s Item.tag.display.Lore
 
+# Check whether the other item is an obsidian block
 scoreboard players set valid_obsidian gm4_ml_data 0
 execute as @e[type=item,dx=0,limit=1,nbt={Item:{Count:1b,id:"minecraft:obsidian"}}] run function gm4_metallurgy:smooshing/remove_band/found_obsidian
 
-#if both custom model data tags are the same, then we can delete it
+# If both custom model data tags are the same, then we can delete it
 execute store success score custom_model_data gm4_ml_data run data modify entity @s Item.tag.gm4_metallurgy.custom_model_data set from entity @s Item.tag.CustomModelData
 execute if score valid_obsidian gm4_ml_data matches 1 if score custom_model_data gm4_ml_data matches 0 run data remove entity @s Item.tag.CustomModelData
 
-execute if score valid_obsidian gm4_ml_data matches 1 run data remove entity @s Item.tag.gm4_metallurgy
-execute if score valid_obsidian gm4_ml_data matches 1 run data remove entity @s Item.tag.display.Lore
+execute if score valid_obsidian gm4_ml_data matches 1 run function gm4_metallurgy:smooshing/remove_band/clear_item

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/clear_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/clear_item.mcfunction
@@ -1,0 +1,15 @@
+# Remove metallurgy tag
+data remove entity @s Item.tag.gm4_metallurgy
+
+# Copies lore from item into temp storage
+data modify storage gm4_metallurgy:temp item_lore set from entity @s Item.tag.display.Lore
+
+# Clear new_lore
+data modify storage gm4_metallurgy:temp new_lore set value []
+
+# Iterates through and edits lore if found
+execute if data storage gm4_metallurgy:temp item_lore[0] run function gm4_metallurgy:smooshing/remove_band/clear_lore
+
+# Applies new lore
+data modify entity @s Item.tag.display.Lore set from storage gm4_metallurgy:temp new_lore
+

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/clear_lore.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/clear_lore.mcfunction
@@ -1,0 +1,15 @@
+# Sets item_lore_line from the first line of storage item_lore
+data modify storage gm4_metallurgy:temp item_lore_line set from storage gm4_metallurgy:temp item_lore[0]
+
+# Removes previous line (band type) from new_lore if current lore line is "Shamir"
+execute if data storage gm4_metallurgy:temp {item_lore_line:'{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}'} run data remove storage gm4_metallurgy:temp new_lore[-1]
+# Removes next line (the shamir type) or storage item_lore if current lore line is "Shamir"
+execute if data storage gm4_metallurgy:temp {item_lore_line:'{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}'} run data remove storage gm4_metallurgy:temp item_lore[1]
+# Adds line of lore to new_lore if it isn't "Shamir"
+execute unless data storage gm4_metallurgy:temp {item_lore_line:'{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}'} run data modify storage gm4_metallurgy:temp new_lore append from storage gm4_metallurgy:temp item_lore_line
+
+# Remove first line of lore in storage
+data remove storage gm4_metallurgy:temp item_lore[0]
+
+# If there's still lore in storage, run again
+execute if data storage gm4_metallurgy:temp item_lore[0] run function gm4_metallurgy:smooshing/remove_band/clear_lore

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -1,6 +1,9 @@
 # @s = new band item
 # run from smooshing/remove_band/found_obsidian
 
-data modify entity @s Item.tag.display.Lore append from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[-1]
+# Locate shamir lore
+execute if data storage gm4_metallurgy:temp item_lore[0] run function gm4_metallurgy:smooshing/remove_band/get_shamir_lore
+
+data modify entity @s Item.tag.display.Lore append from storage gm4_metallurgy:temp shamir_lore
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
 data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/get_shamir_lore.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/get_shamir_lore.mcfunction
@@ -1,0 +1,11 @@
+# Sets item_lore_line from the first line of storage item_lore
+data modify storage gm4_metallurgy:temp item_lore_line set from storage gm4_metallurgy:temp item_lore[0]
+
+# Add lore to storage shamir_lore if current lore line is "Shamir"
+execute if data storage gm4_metallurgy:temp {item_lore_line:'{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}'} run data modify storage gm4_metallurgy:temp shamir_lore set from storage gm4_metallurgy:temp item_lore[1]
+
+# Remove first line of lore in storage
+data remove storage gm4_metallurgy:temp item_lore[0]
+
+# If there's still lore in storage, run again
+execute if data storage gm4_metallurgy:temp item_lore[0] run function gm4_metallurgy:smooshing/remove_band/get_shamir_lore


### PR DESCRIPTION
Made it so shamirs prepend their lore to existing lore when added, updated removing shamirs so that it copies the lore to storage, finds the "Shamir" line and removes that and the surrounding lines before applying it back to the item, and also updated the way the finalized shamir item gets the lore from the item so that it gets the type of shamir in a similar way to how I remove specific lore.

Basically, adding and removing shamirs won't mess up your lore now.