### PR TITLE
Display Frames - Kill Lazy Loaded AECs

### DIFF
--- a/gm4_display_frames/data/gm4_display_frames/functions/init.mcfunction
+++ b/gm4_display_frames/data/gm4_display_frames/functions/init.mcfunction
@@ -1,3 +1,5 @@
+scoreboard objectives add gm4_df_time dummy
+
 execute unless score gm4_display_frames gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Display Frames"}
 scoreboard players set gm4_display_frames gm4_modules 1
 

--- a/gm4_display_frames/data/gm4_display_frames/functions/main.mcfunction
+++ b/gm4_display_frames/data/gm4_display_frames/functions/main.mcfunction
@@ -1,7 +1,6 @@
 execute as @e[type=#gm4_display_frames:frame,tag=gm4_df_invis_frame] at @s if entity @a[gamemode=!spectator,distance=..8,limit=1] run function gm4_display_frames:frame/invisible/process
 
 # kill lazy loaded AECs
-scoreboard players add @e[type=area_effect_cloud,tag=gm4_df_potion_tracker] gm4_df_time 1
-kill @e[type=area_effect_cloud,tag=gm4_df_potion_tracker,scores={gm4_df_time=2..}]
+execute as @e[type=area_effect_cloud,tag=gm4_df_potion_tracker] run function gm4_display_frames:thrown_potion_tracking/kill
 
 schedule function gm4_display_frames:main 16t

--- a/gm4_display_frames/data/gm4_display_frames/functions/main.mcfunction
+++ b/gm4_display_frames/data/gm4_display_frames/functions/main.mcfunction
@@ -1,3 +1,7 @@
 execute as @e[type=#gm4_display_frames:frame,tag=gm4_df_invis_frame] at @s if entity @a[gamemode=!spectator,distance=..8,limit=1] run function gm4_display_frames:frame/invisible/process
 
+# kill lazy loaded AECs
+scoreboard players add @e[type=area_effect_cloud,tag=gm4_df_potion_tracker] gm4_df_time 1
+kill @e[type=area_effect_cloud,tag=gm4_df_potion_tracker,scores={gm4_df_time=2..}]
+
 schedule function gm4_display_frames:main 16t

--- a/gm4_display_frames/data/gm4_display_frames/functions/thrown_potion_tracking/kill.mcfunction
+++ b/gm4_display_frames/data/gm4_display_frames/functions/thrown_potion_tracking/kill.mcfunction
@@ -1,0 +1,7 @@
+# force-kills tracker AECs in case they are in lazy loaded chunks
+# @s = gm4_df_potion_tracker AEC
+# at world spawn
+# run from main
+
+scoreboard players add @s gm4_df_time 1
+kill @s[scores={gm4_df_time=2..}]


### PR DESCRIPTION
The AECs summoned by the potions could end up in lazy chunks and not get ticked to increase their age.