### PR TITLE
Activate Celaro Shamir stealth on sneak only

### DIFF
--- a/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/functions/active.mcfunction
@@ -1,2 +1,2 @@
 scoreboard players set @s gm4_desire_lines 0
-execute if block ~ ~ ~ #gm4_celaro_shamir:tall_plants run effect give @s invisibility 1 0 true
+execute if predicate gm4_celaro_shamir:stealth_active run effect give @s invisibility 1 0 true

--- a/gm4_desire_lines/data/gm4_celaro_shamir/predicates/stealth_active.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/predicates/stealth_active.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "flags": {
+      "is_sneaking": true
+    },
+    "location": {
+      "block": {
+        "tag": "gm4_celaro_shamir:tall_plants"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Celaro's ability to turn the player invisible while within tall foliage is supposed to complement the shamir's main purpose of covering the player's tracks (by suppressing Desire Lines). However, the invisibility effect ends up being triggered accidentally just by running around in areas with lots of tall grass and flowers, so it is less of an easter egg and cool feature, and more of a weird effect that is triggered haphazardly.

This pull request makes it so that the Celaro shamir's invisibility effect also requires the player to be sneaking rather than just being within the block space of tall foliage, which feels more natural and "stealthy", and more interesting to play around with.