### PR TITLE
Give Celaro shamir unique CMD (118)

### DIFF
--- a/gm4_desire_lines/data/gm4_celaro_shamir/loot_tables/band.json
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/loot_tables/band.json
@@ -9,7 +9,7 @@
                     "functions": [
                         {
                             "function": "minecraft:set_nbt",
-                            "tag": "{CustomModelData:103,gm4_metallurgy:{stored_shamir:\"celaro\"}}"
+                            "tag": "{CustomModelData:118,gm4_metallurgy:{stored_shamir:\"celaro\"}}"
                         },
                         {
                             "function": "minecraft:set_lore",


### PR DESCRIPTION
Change CMD from 103 (helious) to 118.  I thought that we might still need to give these a unique number since I thought of a case where they might be needed (besides the texturing possibilities). I will make a PR that uses these for a gameplay feature sometime soon.