### PR TITLE
Make band recycling not give you the same band again

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/add_metal/initialize.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/add_metal/initialize.mcfunction
@@ -6,6 +6,9 @@ data modify storage gm4_metallurgy:temp/item/ore gm4_metallurgy set from entity 
 execute store result score metal_amount gm4_ml_data run data get storage gm4_metallurgy:temp/item/ore gm4_metallurgy.metal.amount[0]
 execute if data storage gm4_metallurgy:temp/item/ore gm4_metallurgy{item:"obsidian_cast"} run scoreboard players set is_obsidian_cast gm4_ml_data 1
 
+# store CMD of item in scoreboard if its a recycled band
+execute unless score @s gm4_ml_sh_id matches 1.. run execute store result score @s gm4_ml_sh_id run data get entity @e[type=item,tag=gm4_ml_in_animation,dx=0,dz=0,nbt={Item:{Count:1b,tag:{gm4_metallurgy:{metal:{castable:1b},item:"obsidian_cast"}}},OnGround:1b},limit=1] Item.tag.CustomModelData
+
 # absorb ore item
 execute if data storage gm4_metallurgy:temp/item/ore gm4_metallurgy.metal{type:"copper"} run function gm4_metallurgy:casting/add_metal/add_copper
 execute if data storage gm4_metallurgy:temp/item/ore gm4_metallurgy.metal{type:"barium"} run function gm4_metallurgy:casting/add_metal/add_barium

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/finish_band.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/finish_band.mcfunction
@@ -1,6 +1,10 @@
 # @s = mould requesting a band
 # run from any function in casting/summon_band
 
+# kill band with the same CMD as the CMD of possible recycled band
+execute as @e[type=item,distance=..0.1,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}] run execute store result score @s gm4_ml_sh_id run data get entity @s Item.tag.CustomModelData
+execute as @e[type=item,distance=..0.1,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}] if score @s gm4_ml_sh_id = @e[type=vex,tag=gm4_sand_ring,distance=..0.1,limit=1] gm4_ml_sh_id run kill @s
+
 #select a random item and kill others
 tag @e[type=item,distance=..0.1,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}},sort=random,limit=1] add gm4_ml_selected_band
 kill @e[type=item,distance=..0.1,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}},tag=!gm4_ml_selected_band]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/init.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/init.mcfunction
@@ -1,5 +1,6 @@
 scoreboard objectives add gm4_ml_data dummy
 scoreboard objectives add gm4_ml_heat dummy
+scoreboard objectives add gm4_ml_sh_id dummy
 
 scoreboard objectives add gm4_ml_ore_ba dummy
 scoreboard objectives add gm4_ml_ore_al dummy


### PR DESCRIPTION
Makes the vex mould store the CMD of the recycled band as a score, then kills the band with the same CMD when they are summoned before selecting one.