### PR TITLE
Better Armour Stands: equip overwrite check

### DIFF
--- a/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/apply_book.mcfunction
+++ b/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/apply_book.mcfunction
@@ -33,6 +33,6 @@ execute if data storage gm4_better_armour_stands:temp {pages:["no turn"]} run ta
 execute if data storage gm4_better_armour_stands:temp {pages:["no turn"]} run tag @s remove gm4_turn_anticlockwise
 
 # Equip dropped item into specified slot even if this is normally impossible.
-execute if data storage gm4_better_armour_stands:temp {pages:["equip head"]} run function gm4_better_armour_stands:equip/head
-execute if data storage gm4_better_armour_stands:temp {pages:["equip hand"]} run function gm4_better_armour_stands:equip/hand
-execute if data storage gm4_better_armour_stands:temp {pages:["equip offhand"]} run function gm4_better_armour_stands:equip/offhand
+execute if data storage gm4_better_armour_stands:temp {pages:["equip head"]} unless data entity @s ArmorItems[3].Count run function gm4_better_armour_stands:equip/head
+execute if data storage gm4_better_armour_stands:temp {pages:["equip hand"]} unless data entity @s HandItems[0].Count run function gm4_better_armour_stands:equip/hand
+execute if data storage gm4_better_armour_stands:temp {pages:["equip offhand"]} unless data entity @s HandItems[1].Count run function gm4_better_armour_stands:equip/offhand


### PR DESCRIPTION
This check prevents an existing item in the armour stand to be overwritten by another item on the ground. 
In the data storage update this was removed on accident.