### PR TITLE
Poses Pack: Head/Body fix

### DIFF
--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/body.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/body.mcfunction
@@ -1,5 +1,5 @@
 # @s = armor_stand ..1 from writable_book
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{Body:[0.0f,0f,0f]}}
+data merge entity @s {Pose:{Body:[0.01f,0f,0f]}}
 execute store result entity @s Pose.Body[0] float 1 run scoreboard players get pose_x gm4_pose_rot
 execute store result entity @s Pose.Body[1] float 1 run scoreboard players get pose_y gm4_pose_rot

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/head.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/head.mcfunction
@@ -1,5 +1,5 @@
 # @s = armor_stand ..1 from writable_book
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{Head:[0.0f,0f,0f]}}
+data merge entity @s {Pose:{Head:[0.01f,0f,0f]}}
 execute store result entity @s Pose.Head[0] float 1 run scoreboard players get pose_x gm4_pose_rot
 execute store result entity @s Pose.Head[1] float 1 run scoreboard players get pose_y gm4_pose_rot


### PR DESCRIPTION
Revert change from data storage update.

Setting the head and body pose to [0.0f,0f,0f] deletes this nbt, making it unable to set to any pose.