### PR TITLE
Poses Pack: Improve reliability of pose modification

### DIFF
--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/arm_left.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/arm_left.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{LeftArm:[0f,0f,0f]}}
-execute store result entity @s Pose.LeftArm[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
-execute store result entity @s Pose.LeftArm[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {LeftArm:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.LeftArm[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
+execute store result storage gm4_better_armour_stands:temp Pose.LeftArm[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/arm_right.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/arm_right.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{RightArm:[0f,0f,0f]}}
-execute store result entity @s Pose.RightArm[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
-execute store result entity @s Pose.RightArm[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {RightArm:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.RightArm[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
+execute store result storage gm4_better_armour_stands:temp Pose.RightArm[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/body.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/body.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{Body:[0.01f,0f,0f]}}
-execute store result entity @s Pose.Body[0] float 1 run scoreboard players get pose_x gm4_pose_rot
-execute store result entity @s Pose.Body[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {Body:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.Body[0] float 1 run scoreboard players get pose_x gm4_pose_rot
+execute store result storage gm4_better_armour_stands:temp Pose.Body[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/head.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/head.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{Head:[0.01f,0f,0f]}}
-execute store result entity @s Pose.Head[0] float 1 run scoreboard players get pose_x gm4_pose_rot
-execute store result entity @s Pose.Head[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {Head:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.Head[0] float 1 run scoreboard players get pose_x gm4_pose_rot
+execute store result storage gm4_better_armour_stands:temp Pose.Head[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/leg_left.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/leg_left.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{LeftLeg:[0f,0f,0f]}}
-execute store result entity @s Pose.LeftLeg[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
-execute store result entity @s Pose.LeftLeg[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {LeftLeg:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.LeftLeg[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
+execute store result storage gm4_better_armour_stands:temp Pose.LeftLeg[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/leg_right.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/leg_right.mcfunction
@@ -1,5 +1,11 @@
 # @s = armor_stand ..1 from writable_book
+
+# Initialize scoreboard and storage with pose data.
 function gm4_poses_pack:pose/update_values
-data merge entity @s {Pose:{RightLeg:[0f,0f,0f]}}
-execute store result entity @s Pose.RightLeg[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
-execute store result entity @s Pose.RightLeg[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+data modify storage gm4_better_armour_stands:temp Pose set value {RightLeg:[0f,0f,0f]}
+execute store result storage gm4_better_armour_stands:temp Pose.RightLeg[0] float 1 run scoreboard players remove pose_x gm4_pose_rot 90
+execute store result storage gm4_better_armour_stands:temp Pose.RightLeg[1] float 1 run scoreboard players get pose_y gm4_pose_rot
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_arm_left.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_arm_left.mcfunction
@@ -1,6 +1,12 @@
 # @s = armor_stand ..1 from writable_book
-data merge entity @s {Pose:{RightArm:[0f,0f,0f]}}
-data modify entity @s Pose.RightArm[0] set from entity @s Pose.LeftArm[0]
-execute store result entity @s Pose.RightArm[1] float -1 run data get entity @s Pose.LeftArm[1]
-execute store result entity @s Pose.RightArm[2] float -1 run data get entity @s Pose.LeftArm[2]
+
+# Initialize storage with mirrored pose data.
+data modify storage gm4_better_armour_stands:temp Pose set value {RightArm:[0f,0f,0f]}
+data modify storage gm4_better_armour_stands:temp Pose.RightArm[0] set from entity @s Pose.LeftArm[0]
+execute store result storage gm4_better_armour_stands:temp Pose.RightArm[1] float -1 run data get entity @s Pose.LeftArm[1]
+execute store result storage gm4_better_armour_stands:temp Pose.RightArm[2] float -1 run data get entity @s Pose.LeftArm[2]
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose
 tag @s add gm4_pose_changed

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_arm_right.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_arm_right.mcfunction
@@ -1,6 +1,12 @@
 # @s = armor_stand ..1 from writable_book
-data merge entity @s {Pose:{LeftArm:[0f,0f,0f]}}
-data modify entity @s Pose.LeftArm[0] set from entity @s Pose.RightArm[0]
-execute store result entity @s Pose.LeftArm[1] float -1 run data get entity @s Pose.RightArm[1]
-execute store result entity @s Pose.LeftArm[2] float -1 run data get entity @s Pose.RightArm[2]
+
+# Initialize storage with mirrored pose data.
+data modify storage gm4_better_armour_stands:temp Pose set value {LeftArm:[0f,0f,0f]}
+data modify storage gm4_better_armour_stands:temp Pose.LeftArm[0] set from entity @s Pose.RightArm[0]
+execute store result storage gm4_better_armour_stands:temp Pose.LeftArm[1] float -1 run data get entity @s Pose.RightArm[1]
+execute store result storage gm4_better_armour_stands:temp Pose.LeftArm[2] float -1 run data get entity @s Pose.RightArm[2]
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose
 tag @s add gm4_pose_changed

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_leg_left.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_leg_left.mcfunction
@@ -1,6 +1,12 @@
 # @s = armor_stand ..1 from writable_book
-data merge entity @s {Pose:{RightLeg:[0f,0f,0f]}}
-data modify entity @s Pose.RightLeg[0] set from entity @s Pose.LeftLeg[0]
-execute store result entity @s Pose.RightLeg[1] float -1 run data get entity @s Pose.LeftLeg[1]
-execute store result entity @s Pose.RightLeg[2] float -1 run data get entity @s Pose.LeftLeg[2]
+
+# Initialize storage with mirrored pose data.
+data modify storage gm4_better_armour_stands:temp Pose set value {RightLeg:[0f,0f,0f]}
+data modify storage gm4_better_armour_stands:temp Pose.RightLeg[0] set from entity @s Pose.LeftLeg[0]
+execute store result storage gm4_better_armour_stands:temp Pose.RightLeg[1] float -1 run data get entity @s Pose.LeftLeg[1]
+execute store result storage gm4_better_armour_stands:temp Pose.RightLeg[2] float -1 run data get entity @s Pose.LeftLeg[2]
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose
 tag @s add gm4_pose_changed

--- a/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_leg_right.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/pose/player/mirror_leg_right.mcfunction
@@ -1,6 +1,12 @@
 # @s = armor_stand ..1 from writable_book
-data merge entity @s {Pose:{LeftLeg:[0f,0f,0f]}}
-data modify entity @s Pose.LeftLeg[0] set from entity @s Pose.RightLeg[0]
-execute store result entity @s Pose.LeftLeg[1] float -1 run data get entity @s Pose.RightLeg[1]
-execute store result entity @s Pose.LeftLeg[2] float -1 run data get entity @s Pose.RightLeg[2]
+
+# Initialize storage with mirrored pose data.
+data modify storage gm4_better_armour_stands:temp Pose set value {LeftLeg:[0f,0f,0f]}
+data modify storage gm4_better_armour_stands:temp Pose.LeftLeg[0] set from entity @s Pose.RightLeg[0]
+execute store result storage gm4_better_armour_stands:temp Pose.LeftLeg[1] float -1 run data get entity @s Pose.RightLeg[1]
+execute store result storage gm4_better_armour_stands:temp Pose.LeftLeg[2] float -1 run data get entity @s Pose.RightLeg[2]
+
+# Copy pose data from storage to entity.
+data modify entity @s Pose merge from storage gm4_better_armour_stands:temp Pose
+data remove storage gm4_better_armour_stands:temp Pose
 tag @s add gm4_pose_changed


### PR DESCRIPTION
Dennis recently fixed an issue where pose would not be updated properly due to the pose for `Head`/`Body` first being overwritten to `[0f,0f,0f]`, which would cause the NBT tag to be removed, which makes the NBT path used to copy the new pose fail.

However, this does not fix the case where the first element is exactly `0f`: when it is copied to the entity as part of pose modification, the whole pose will be deleted in the same way it was with the erroneous code setting the pose to `[0f,0f,0f]`, in turn making it impossible to copy the remaining elements as the NBT path fails.

This commit constructs the new pose in storage and then copies it to the entity all at once to avoid NBT being reset partway which would lead to same issue as Dennis partially fixed. Theoretically this could be done for `Body`/`Head` and not the other body parts (as arms and legs have different defaults), but it is better to be consistent and safe for the other body parts, so this commit applies this fix to every pose as a failsafe.