### PR TITLE
Optimize Tinker

### DIFF
--- a/gm4_metallurgy/data/gm4_tinker_shamir/functions/active.mcfunction
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/functions/active.mcfunction
@@ -1,5 +1,7 @@
-#run from main
-#@s = players holding a tinker tool
+# @s = players holding a tinker tool
+# at @s
+# run from gm4_metallurgy:shamir_in_hand
+
 execute if entity @s[predicate=gm4_tinker_shamir:holding_shovel] run function gm4_tinker_shamir:compact/shovel
 execute if entity @s[predicate=gm4_tinker_shamir:holding_pickaxe] run function gm4_tinker_shamir:compact/pickaxe
 execute if entity @s[predicate=gm4_tinker_shamir:holding_sword] run function gm4_tinker_shamir:compact/sword

--- a/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/hoe.mcfunction
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/hoe.mcfunction
@@ -1,2 +1,13 @@
-execute if entity @s[nbt={Inventory:[{id:"minecraft:melon_slice",Count:64b}]}] run function gm4_tinker_shamir:compact/melon_slice
-execute if entity @s[nbt={Inventory:[{id:"minecraft:wheat",Count:64b}]}] run function gm4_tinker_shamir:compact/wheat
+# @s = player holding tinker shovel
+# at @s
+# run from gm4_tinker_shamir:active
+
+# pull inventory into storage
+data modify storage gm4_tinker_shamir:temp/player/inventory Inventory set from entity @s Inventory
+
+# check for compacting operations
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:melon_slice",Count:64b}] run function gm4_tinker_shamir:compact/melon_slice
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:wheat",Count:64b}] run function gm4_tinker_shamir:compact/wheat
+
+# clear storage
+data remove storage gm4_tinker_shamir:temp/player/inventory Inventory

--- a/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/pickaxe.mcfunction
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/pickaxe.mcfunction
@@ -1,10 +1,21 @@
-execute if entity @s[nbt={Inventory:[{id:"minecraft:netherite_ingot",Count:64b}]}] run function gm4_tinker_shamir:compact/netherite_ingot
-execute if entity @s[nbt={Inventory:[{id:"minecraft:emerald",Count:64b}]}] run function gm4_tinker_shamir:compact/emerald
-execute if entity @s[nbt={Inventory:[{id:"minecraft:diamond",Count:64b}]}] run function gm4_tinker_shamir:compact/diamond
-execute if entity @s[nbt={Inventory:[{id:"minecraft:redstone",Count:64b}]}] run function gm4_tinker_shamir:compact/redstone
-execute if entity @s[nbt={Inventory:[{id:"minecraft:coal",Count:64b}]}] run function gm4_tinker_shamir:compact/coal
-execute if entity @s[nbt={Inventory:[{id:"minecraft:lapis_lazuli",Count:64b}]}] run function gm4_tinker_shamir:compact/lapis_lazuli
-execute if entity @s[nbt={Inventory:[{id:"minecraft:iron_ingot",Count:64b}]}] run function gm4_tinker_shamir:compact/iron_ingot
-execute if entity @s[nbt={Inventory:[{id:"minecraft:gold_ingot",Count:64b}]}] run function gm4_tinker_shamir:compact/gold_ingot
-execute if entity @s[nbt={Inventory:[{id:"minecraft:iron_nugget",Count:64b}]}] run function gm4_tinker_shamir:compact/iron_nugget
-execute if entity @s[nbt={Inventory:[{id:"minecraft:gold_nugget",Count:64b}]}] run function gm4_tinker_shamir:compact/gold_nugget
+# @s = player holding tinker shovel
+# at @s
+# run from gm4_tinker_shamir:active
+
+# pull inventory into storage
+data modify storage gm4_tinker_shamir:temp/player/inventory Inventory set from entity @s Inventory
+
+# check for compacting operations
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:netherite_ingot",Count:64b}] run function gm4_tinker_shamir:compact/netherite_ingot
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:emerald",Count:64b}] run function gm4_tinker_shamir:compact/emerald
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:diamond",Count:64b}] run function gm4_tinker_shamir:compact/diamond
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:redstone",Count:64b}] run function gm4_tinker_shamir:compact/redstone
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:coal",Count:64b}] run function gm4_tinker_shamir:compact/coal
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:lapis_lazuli",Count:64b}] run function gm4_tinker_shamir:compact/lapis_lazuli
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:iron_ingot",Count:64b}] run function gm4_tinker_shamir:compact/iron_ingot
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:gold_ingot",Count:64b}] run function gm4_tinker_shamir:compact/gold_ingot
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:iron_nugget",Count:64b}] run function gm4_tinker_shamir:compact/iron_nugget
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:gold_nugget",Count:64b}] run function gm4_tinker_shamir:compact/gold_nugget
+
+# clear storage
+data remove storage gm4_tinker_shamir:temp/player/inventory Inventory

--- a/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/shovel.mcfunction
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/shovel.mcfunction
@@ -1,2 +1,13 @@
-execute if entity @s[nbt={Inventory:[{id:"minecraft:snowball",Count:16b}]}] run function gm4_tinker_shamir:compact/snowball
-execute if entity @s[nbt={Inventory:[{id:"minecraft:clay_ball",Count:64b}]}] run function gm4_tinker_shamir:compact/clay_ball
+# @s = player holding tinker shovel
+# at @s
+# run from gm4_tinker_shamir:active
+
+# pull inventory into storage
+data modify storage gm4_tinker_shamir:temp/player/inventory Inventory set from entity @s Inventory
+
+# check for compacting operations
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:snowball",Count:16b}] run function gm4_tinker_shamir:compact/snowball
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:clay_ball",Count:64b}] run function gm4_tinker_shamir:compact/clay_ball
+
+# clear storage
+data remove storage gm4_tinker_shamir:temp/player/inventory Inventory

--- a/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/sword.mcfunction
+++ b/gm4_metallurgy/data/gm4_tinker_shamir/functions/compact/sword.mcfunction
@@ -1,1 +1,13 @@
-execute if entity @s[nbt={Inventory:[{id:"minecraft:slime_ball",Count:64b}]}] run function gm4_tinker_shamir:compact/slime_ball
+# @s = player holding tinker shovel
+# at @s
+# run from gm4_tinker_shamir:active
+
+# pull inventory into storage
+# this is technically slightly more laggy in this case, but more cases might be added in the future
+data modify storage gm4_tinker_shamir:temp/player/inventory Inventory set from entity @s Inventory
+
+# check for compacting operations
+execute if data storage gm4_tinker_shamir:temp/player/inventory Inventory[{id:"minecraft:slime_ball",Count:64b}] run function gm4_tinker_shamir:compact/slime_ball
+
+# clear storage
+data remove storage gm4_tinker_shamir:temp/player/inventory Inventory


### PR DESCRIPTION
This introduces a NBT `storage` into tinker, reducing the number of player NBT lookups to _at most_ one per clock pulse.