### PR TITLE
Fix Washing Tanks wiki link

### DIFF
--- a/gm4_washing_tanks/pack.mcmeta
+++ b/gm4_washing_tanks/pack.mcmeta
@@ -18,7 +18,7 @@
 		"Liquid Tanks"
 	],
 	"video_link":"",
-	"wiki_link":"wiki.gm4.co/wiki/Liquid_Tanks/Washing_Tanks",
+	"wiki_link": "https://wiki.gm4.co/wiki/Liquid_Tanks/Washing_Tanks",
 	"required_modules":[
 		"liquid_tanks"
 	],


### PR DESCRIPTION
- if "https://" isn't added to the start of the link, the gm4.co website will try to link to a subpage of gm4.co/