### PR TITLE
Reduce range for dragon flap sound when end fishing

### DIFF
--- a/gm4_end_fishing/data/gm4_end_fishing/functions/go_fish/bobber_animation.mcfunction
+++ b/gm4_end_fishing/data/gm4_end_fishing/functions/go_fish/bobber_animation.mcfunction
@@ -2,7 +2,7 @@
 #run from tick
 
 scoreboard players add @s gm4_ef_data 1
-execute if score @s gm4_ef_data matches 1 at @s run playsound minecraft:entity.ender_dragon.flap neutral @a[distance=..50] ~ ~ ~ 4 0.7
+execute if score @s gm4_ef_data matches 1 at @s run playsound minecraft:entity.ender_dragon.flap neutral @a[distance=..15] ~ ~ ~ 4 0.7
 execute if score @s gm4_ef_data matches 1..5 at @s run tp @s ~ ~-0.1 ~
 execute if score @s gm4_ef_data matches 5 at @e[type=minecraft:fishing_bobber,limit=1,distance=..0.0001] run summon item ~ ~ ~ {NoGravity:1,PickupDelay:32767,Age:6000,Item:{id:"minecraft:stone_button",Count:1}}
 execute if score @s gm4_ef_data matches 11..15 at @s run tp @s ~ ~0.1 ~


### PR DESCRIPTION
The range right now (50) is huge. You normally stop hearing sounds at a distance of 15, so I reduced this to that. Right now it's kinda hard/annoying to stay away from other players that are fishing near you