### PR TITLE
[1.17] Poses pack: paste fix

### DIFF
--- a/gm4_poses_pack/data/gm4_poses_pack/functions/paste.mcfunction
+++ b/gm4_poses_pack/data/gm4_poses_pack/functions/paste.mcfunction
@@ -2,7 +2,7 @@
 # @s = armor_stand whose pose is being pasted
 
 # Select item entity to paste armor stand pose from.
-execute as @e[type=item,sort=nearest,tag=!gm4_pose_copied,nbt={Item:{id:"minecraft:armor_stand",tag:{EntityTag:{}}}},distance=..1,limit=1] run function gm4_better_armour_stands:paste_item
+execute as @e[type=item,sort=nearest,tag=!gm4_pose_copied,nbt={Item:{id:"minecraft:armor_stand",tag:{EntityTag:{}}}},distance=..1,limit=1] run function gm4_poses_pack:paste_item
 
 # Copy tags from item entity to armor stand.
 data modify entity @s Pose set from storage gm4_better_armour_stands:temp EntityTag.Pose


### PR DESCRIPTION
This fixes the `paste` command, because a non existing function was called previously