### PR TITLE
Particles Pack: Allow all particles and particle cloud size

### DIFF
--- a/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
@@ -3,7 +3,7 @@
 # run from gm4_better_armour_stands/store_book_pages
 
 # reset armor_stand and particle cloud
-execute if score @s gm4_particle matches 1.. run data modify entity @s Invisible set value 0
+data modify entity @s[scores={gm4_particle=1..}] Invisible set value 0
 kill @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..1,limit=1,sort=nearest]
 scoreboard players reset @s gm4_particle
 
@@ -20,4 +20,4 @@ execute if data storage gm4_better_armour_stands:temp {pages:["snow"]} run score
 execute if data storage gm4_better_armour_stands:temp {pages:["particle"]} run function gm4_particles_pack:particle_cloud
 
 # turn armor_stand invisible
-execute if score @s gm4_particle matches 1.. run data modify entity @s Invisible set value 1
+data modify entity @s[scores={gm4_particle=1..}] Invisible set value 1

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
@@ -1,4 +1,4 @@
-# @s = armor_stand to be modified
+# @s = armor_stand ..1 from writable_book
 #run by the better armor stand base module
 
 scoreboard players reset @s gm4_particle
@@ -9,13 +9,10 @@ execute if data storage gm4_better_armour_stands:temp {pages:["heart"]} run scor
 execute if data storage gm4_better_armour_stands:temp {pages:["flame"]} run scoreboard players set @s gm4_particle 2
 execute if data storage gm4_better_armour_stands:temp {pages:["barrier"]} run scoreboard players set @s gm4_particle 3
 execute if data storage gm4_better_armour_stands:temp {pages:["fireflies"]} run scoreboard players set @s gm4_particle 4
-execute if data storage gm4_better_armour_stands:temp {pages:["cloud"]} run scoreboard players set @s gm4_particle 5
-execute if data storage gm4_better_armour_stands:temp {pages:["bubbles"]} run scoreboard players set @s gm4_particle 6
 execute if data storage gm4_better_armour_stands:temp {pages:["growing"]} run scoreboard players set @s gm4_particle 7
 execute if data storage gm4_better_armour_stands:temp {pages:["drip"]} run scoreboard players set @s gm4_particle 8
 execute if data storage gm4_better_armour_stands:temp {pages:["snow"]} run scoreboard players set @s gm4_particle 9
 
-execute if score @s gm4_particle matches 5 run summon area_effect_cloud ~ ~1 ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:cloud,Tags:["gm4_particles_pack_cloud"]}
-execute if score @s gm4_particle matches 6 run summon area_effect_cloud ~ ~1 ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:bubble,Tags:["gm4_particles_pack_cloud"]}
+execute if data storage gm4_better_armour_stands:temp {pages:["particle"]} run function gm4_particles_pack:particle_cloud
 
 data merge entity @s[scores={gm4_particle=1..}] {Invisible:1b}

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
@@ -1,10 +1,13 @@
-# @s = armor_stand ..1 from writable_book
-#run by the better armor stand base module
+# @s = armor_stand
+# at @s
+# run from gm4_better_armour_stands/store_book_pages
 
-scoreboard players reset @s gm4_particle
-data merge entity @s[scores={gm4_particle=1..}] {Invisible:0b}
+# reset armor_stand and particle cloud
+execute if score @s gm4_particle matches 1.. run data modify entity @s Invisible set value 0
 kill @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..1,limit=1,sort=nearest]
+scoreboard players reset @s gm4_particle
 
+# check particle
 execute if data storage gm4_better_armour_stands:temp {pages:["heart"]} run scoreboard players set @s gm4_particle 1
 execute if data storage gm4_better_armour_stands:temp {pages:["flame"]} run scoreboard players set @s gm4_particle 2
 execute if data storage gm4_better_armour_stands:temp {pages:["barrier"]} run scoreboard players set @s gm4_particle 3
@@ -13,6 +16,8 @@ execute if data storage gm4_better_armour_stands:temp {pages:["growing"]} run sc
 execute if data storage gm4_better_armour_stands:temp {pages:["drip"]} run scoreboard players set @s gm4_particle 8
 execute if data storage gm4_better_armour_stands:temp {pages:["snow"]} run scoreboard players set @s gm4_particle 9
 
+# custom particle cloud
 execute if data storage gm4_better_armour_stands:temp {pages:["particle"]} run function gm4_particles_pack:particle_cloud
 
-data merge entity @s[scores={gm4_particle=1..}] {Invisible:1b}
+# turn armor_stand invisible
+execute if score @s gm4_particle matches 1.. run data modify entity @s Invisible set value 1

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/new_cloud.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/new_cloud.mcfunction
@@ -1,11 +1,20 @@
-# @s = new area_effect_cloud
-# run from apply_book
+# @s = new area_effect_cloud (particle cloud)
+# at @s
+# run from particle_cloud
+
+# set particle from book
+data modify entity @s Particle set from storage gm4_better_armour_stands:temp pages[1]
+
+# remove "banned" particles
+tag @s[nbt={Particle:"minecraft:elder_guardian"}] add gm4_particle_kill
+
+# update particle score or remove cloud
+execute unless entity @s[tag=gm4_particle_kill] run scoreboard players set @e[type=minecraft:armor_stand,tag=gm4_particle_target,distance=..1,sort=nearest,limit=1] gm4_particle 100
+execute if entity @s[tag=gm4_particle_kill] run kill @s
+
+# set cloud size
+data modify entity @s Radius set value 1
+execute if data storage gm4_better_armour_stands:temp {pages:["small"]} run data modify entity @s Radius set value 0.01
 
 # remove new tag
 tag @s remove gm4_particles_pack_cloud_new
-
-# armour stand invisible if valid particle
-execute unless entity @s[nbt={Particle:"minecraft:composter"}] positioned ~ ~1 ~ run data merge entity @e[type=minecraft:armor_stand,distance=..1,sort=nearest,limit=1] {Invisible:1b}
-
-# remove particle cloud if no valid particle
-kill @s[nbt={Particle:"minecraft:composter"}]

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/new_cloud.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/new_cloud.mcfunction
@@ -1,0 +1,11 @@
+# @s = new area_effect_cloud
+# run from apply_book
+
+# remove new tag
+tag @s remove gm4_particles_pack_cloud_new
+
+# armour stand invisible if valid particle
+execute unless entity @s[nbt={Particle:"minecraft:composter"}] positioned ~ ~1 ~ run data merge entity @e[type=minecraft:armor_stand,distance=..1,sort=nearest,limit=1] {Invisible:1b}
+
+# remove particle cloud if no valid particle
+kill @s[nbt={Particle:"minecraft:composter"}]

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/particle.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/particle.mcfunction
@@ -1,9 +1,11 @@
-# @s = armorstand with a particle score
+# @s = armor_stand with particle score
+# at @s
 # run from main
-execute if score @s gm4_particle matches 1 run particle heart ~ ~2.0 ~ .2 0 .2 0 1
-execute if score @s gm4_particle matches 2 run particle flame ~ ~.5 ~ 0 0 0 0 1 force
-execute if score @s gm4_particle matches 3 run particle barrier ~ ~.5 ~ 0 0 0 0 1
-execute if score @s gm4_particle matches 4 run particle end_rod ~ ~.5 ~ 10 10 10 0 8 force
-execute if score @s gm4_particle matches 7 run particle happy_villager ~ ~.5 ~ 2 0 2 0 1
+
+execute if score @s gm4_particle matches 1 run particle minecraft:heart ~ ~2.0 ~ .2 0 .2 0 1
+execute if score @s gm4_particle matches 2 run particle minecraft:flame ~ ~.5 ~ 0 0 0 0 1 force
+execute if score @s gm4_particle matches 3 run particle minecraft:barrier ~ ~.5 ~ 0 0 0 0 1
+execute if score @s gm4_particle matches 4 run particle minecraft:end_rod ~ ~.5 ~ 10 10 10 0 8 force
+execute if score @s gm4_particle matches 7 run particle minecraft:happy_villager ~ ~.5 ~ 2 0 2 0 1
 execute if score @s gm4_particle matches 8 run particle minecraft:dripping_water ~ ~.5 ~ 0.04 0 0.04 1 1
 execute if score @s gm4_particle matches 9 run particle minecraft:falling_dust snow ~ ~.5 ~ 8 0 8 1 10

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/particle_cloud.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/particle_cloud.mcfunction
@@ -1,15 +1,14 @@
-# @s = armor_stand ..1 from writable_book
+# @s = armor_stand
+# at @s
 # run from apply_book
 
-scoreboard players set @s gm4_particle 1000
+kill @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..1,sort=nearest,limit=1]
+scoreboard players reset @s gm4_particle
 
 # set particle cloud
-summon area_effect_cloud ~ ~1 ~ {Radius:1,RadiusOnUse:0,Particle:"minecraft:composter",Duration:2147483647,Tags:["gm4_particles_pack_cloud","gm4_particles_pack_cloud_new"]}
-data modify entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud_new,distance=..1,sort=nearest,limit=1] Particle set from storage gm4_better_armour_stands:temp pages[1]
-
-# set cloud size
-execute if data storage gm4_better_armour_stands:temp {pages:["small"]} run data merge entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..10,sort=nearest,limit=1] {Radius:0.01f}
-execute if data storage gm4_better_armour_stands:temp {pages:["big"]} run data merge entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..10,sort=nearest,limit=1] {Radius:3f}
+summon area_effect_cloud ~ ~1 ~ {CustomName:'"gm4_particle_cloud"',Tags:["gm4_particles_pack_cloud","gm4_particles_pack_cloud_new"],Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:"minecraft:elder_guardian"}
 
 # new cloud checks
-execute as @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud_new] run function gm4_particles_pack:new_cloud
+tag @s add gm4_particle_target
+execute as @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud_new,distance=..1,sort=nearest,limit=1] run function gm4_particles_pack:new_cloud
+tag @s remove gm4_particle_target

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/particle_cloud.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/particle_cloud.mcfunction
@@ -1,0 +1,15 @@
+# @s = armor_stand ..1 from writable_book
+# run from apply_book
+
+scoreboard players set @s gm4_particle 1000
+
+# set particle cloud
+summon area_effect_cloud ~ ~1 ~ {Radius:1,RadiusOnUse:0,Particle:"minecraft:composter",Duration:2147483647,Tags:["gm4_particles_pack_cloud","gm4_particles_pack_cloud_new"]}
+data modify entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud_new,distance=..1,sort=nearest,limit=1] Particle set from storage gm4_better_armour_stands:temp pages[1]
+
+# set cloud size
+execute if data storage gm4_better_armour_stands:temp {pages:["small"]} run data merge entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..10,sort=nearest,limit=1] {Radius:0.01f}
+execute if data storage gm4_better_armour_stands:temp {pages:["big"]} run data merge entity @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..10,sort=nearest,limit=1] {Radius:3f}
+
+# new cloud checks
+execute as @e[type=minecraft:area_effect_cloud,tag=gm4_particles_pack_cloud_new] run function gm4_particles_pack:new_cloud


### PR DESCRIPTION
This is just about the idea, so I know parts of the code could be improved or removed, but the idea is that you can make any particle instead of just one from a predefined list.

In a written book:
- Page 1: `particle`
- Page 2: `<particle name>`
- Page 3 (optional): `small` or `big`

`<particle name>` can be any particle name in the game. For particles that require extra inputs, add it on the same page.
Examples for Page 2: `lava`, `dust 1 1 1 1`, `block diamond_block` , `item diamond`

Page 3 is to set the size of the particle cloud, where it defaults to a size of 1, `small` sets the size to 0 and `big` sets the size to 3. This size could be fully customizable too, but it shouldn't get much bigger than 3.