### PR TITLE
Adjusts feathery pnuema to be more reliable

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/check.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/check.mcfunction
@@ -7,7 +7,6 @@ execute as @s[tag=gm4_sneak_pneuma] at @s run function gm4_orb_of_ankou:pneumas/
 
 effect give @s[tag=gm4_pneuma_vanishing] invisibility 90 0 true
 execute at @a[tag=gm4_pneuma_blinding] run effect give @a[distance=..6,tag=!gm4_pneuma_blinding] blindness 7 1 false
-effect give @a[tag=gm4_pneuma_feathery] slow_falling 7 0 true
 effect give @a[tag=gm4_pneuma_gazing] night_vision 30 0 true
 execute at @s[tag=gm4_pneuma_scaling] anchored eyes positioned ^ ^ ^1 align xyz unless block ~ ~ ~ #gm4:no_collision run effect give @s levitation 1 0 true
 

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/tick.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/tick.mcfunction
@@ -17,6 +17,9 @@ execute if score agile_player gm4_pneuma_data matches 1.. as @a[tag=gm4_pneuma_a
 execute at @e[type=area_effect_cloud,tag=gm4_oa_striding_block,nbt={Age:4}] if block ~ ~ ~ magma_block run setblock ~ ~ ~ lava
 execute if score striding_player gm4_pneuma_data matches 1.. as @a[tag=gm4_pneuma_striding] at @s if block ~ ~-1 ~ lava[level=0] run function gm4_orb_of_ankou:pneumas/striding
 
+# feathery
+execute as @a[tag=gm4_pneuma_feathery,scores={gm4_oa_sneak=1..}] run effect give @s slow_falling 1 0 true
+
 # evoker fangs
 execute if score conjuring_fang gm4_pneuma_data matches 1.. as @e[type=armor_stand,tag=gm4_oa_fang_thrower,scores={gm4_pneuma_data=1..}] at @s run function gm4_orb_of_ankou:pneumas/conjuring/throw
 


### PR DESCRIPTION
Being a sneak tap pnuema, it only makes sense for it to activate right when you sneak, but previously, it could take almost a second for the slow falling to kick in upon activation, which when falling from a high place, can quickly lead to unfair deaths.