### PR TITLE
Some Fruiting Trees Parity Fixes

### DIFF
--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/analyze_seed.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/analyze_seed.mcfunction
@@ -94,6 +94,7 @@ scoreboard players operation $generated_seed gm4_tree_seed /= #2 gm4_tree_seed
 
 # start generating a tree
 setblock ~ ~ ~ air
+execute if block ~ ~-1 ~ #gm4_fruiting_trees:dirt_replaceable run setblock ~ ~-1 ~ dirt
 function gm4_fruiting_trees:tree/generate
 
 # kill marker after generation, reset seed

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/initialize.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/initialize.mcfunction
@@ -12,6 +12,6 @@ scoreboard players set $max_layer gm4_tree_layer -1
 function #gm4_fruiting_trees:tree/initialize
 
 # start generation, unless expansion force quit generation (e.g. due to missing dy).
-execute unless score $cancel_generation gm4_tree_layer matches 1.. run function gm4_fruiting_trees:tree/analyze_seed
+execute unless score $cancel_generation gm4_tree_layer matches 1.. at @s run function gm4_fruiting_trees:tree/analyze_seed
 # if generation force quit, remove 1 from the stage of the sapling to allow another growth attempt
 execute if score $cancel_generation gm4_tree_layer matches 1.. run scoreboard players remove @s gm4_sap_stage 1

--- a/gm4_apple_trees/data/gm4_fruiting_trees/tags/blocks/dirt_replaceable.json
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/tags/blocks/dirt_replaceable.json
@@ -1,0 +1,6 @@
+{
+    "values": [
+        "minecraft:grass_block",
+        "minecraft:mycelium"
+    ]
+}

--- a/gm4_apple_trees/data/gm4_fruiting_trees/tags/blocks/tree_replaceable.json
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/tags/blocks/tree_replaceable.json
@@ -1,6 +1,7 @@
 {
     "values": [
         "#gm4:air",
-        "#gm4:foliage"
+        "#gm4:foliage",
+        "#minecraft:leaves"
     ]
 }


### PR DESCRIPTION
- Leaves are replaceable when a new tree grows into them
- When a tree grows, it should replace grass_block and mycelium with dirt