### PR TITLE
Add Book Binders to Relocators Complementary Modules

### DIFF
--- a/gm4_relocators/pack.mcmeta
+++ b/gm4_relocators/pack.mcmeta
@@ -24,6 +24,7 @@
     ],
     "recommended_modules": [
         "block_compressors",
+        "book_binders",
         "master_crafting",
         "disassemblers",
         "enchantment_extractors",


### PR DESCRIPTION
- add Book Binders as a recommended module to Relocators, since the relocator recipe accepts enchanted pages