### PR TITLE
Re-Add Damage Sound for Sweethearts

### DIFF
--- a/gm4_sweethearts/data/gm4_sweethearts/functions/transfer_donor.mcfunction
+++ b/gm4_sweethearts/data/gm4_sweethearts/functions/transfer_donor.mcfunction
@@ -44,4 +44,5 @@ execute if score donor_lost_health gm4_sh_data = @s gm4_sh_data run advancement 
 tag @s add gm4_sh_transfered
 
 # visuals
-particle damage_indicator ~ ~2 ~ 0 0 0 .255 10
+particle damage_indicator ~ ~2 ~ 0 0 0 .255 5
+playsound minecraft:entity.player.hurt player @a[distance=..8] ~ ~ ~ 1 1


### PR DESCRIPTION
- forces the player hurt sound since MC fixed the fake deaths, thus the player hurt sound no longer naturally occurs when a player is transferring health
- reduced the number of particles for the donor