### PR TITLE
Soul Glass: Consistent beacon behaviour

### DIFF
--- a/gm4_soul_glass/data/gm4_soul_glass/functions/beacon_clock.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/beacon_clock.mcfunction
@@ -1,8 +1,8 @@
 #@s = none
 #run from beacon_clock (on it's own clock)
 
-execute as @e[type=area_effect_cloud,tag=gm4_soul_glass] at @s run function gm4_soul_glass:process
+execute as @e[type=marker,tag=gm4_soul_glass] at @s run function gm4_soul_glass:process
 
-execute as @e[type=area_effect_cloud,tag=gm4_soul_glass] at @s if block ~ ~ ~ brown_stained_glass if predicate gm4_soul_glass:has_beam positioned ~-50 ~-51 ~-50 if entity @a[dx=100,dy=356,dz=100,limit=1] at @s run function gm4_soul_glass:effect/check
+execute as @e[type=marker,tag=gm4_soul_glass] at @s if block ~ ~ ~ brown_stained_glass if predicate gm4_soul_glass:has_beam positioned ~-50 ~-51 ~-50 if entity @a[dx=100,dy=356,dz=100,limit=1] at @s run function gm4_soul_glass:effect/check
 
 schedule function gm4_soul_glass:beacon_clock 80t

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/apply_normal_effect.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/apply_normal_effect.mcfunction
@@ -1,7 +1,0 @@
-#@s = soul glass AEC
-#run from effects/check
-
-execute if score @s gm4_sg_levels matches 1 positioned ~-20 ~-21 ~-20 run function gm4_soul_glass:effect/level_1
-execute if score @s gm4_sg_levels matches 2 positioned ~-30 ~-31 ~-30 run function gm4_soul_glass:effect/level_2
-execute if score @s gm4_sg_levels matches 3 positioned ~-40 ~-41 ~-40 run function gm4_soul_glass:effect/level_3
-execute if score @s gm4_sg_levels matches 4 positioned ~-50 ~-51 ~-50 run function gm4_soul_glass:effect/level_4

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/apply_strong_effect.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/apply_strong_effect.mcfunction
@@ -1,7 +1,0 @@
-#@s = soul glass AEC
-#run from effects/check
-
-execute if score @s gm4_sg_levels matches 1 positioned ~-20 ~-21 ~-20 run function gm4_soul_glass:effect/level_1_strong
-execute if score @s gm4_sg_levels matches 2 positioned ~-30 ~-31 ~-30 run function gm4_soul_glass:effect/level_2_strong
-execute if score @s gm4_sg_levels matches 3 positioned ~-40 ~-41 ~-40 run function gm4_soul_glass:effect/level_3_strong
-execute if score @s gm4_sg_levels matches 4 positioned ~-50 ~-51 ~-50 run function gm4_soul_glass:effect/level_4_strong

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/check.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/check.mcfunction
@@ -5,5 +5,8 @@ execute unless block ~ ~-1 ~ beacon{Primary:-1} run function gm4_soul_glass:effe
 
 execute store result score @s gm4_sg_levels run data get block ~ ~-1 ~ Levels
 
-execute if score @s gm4_sg_primary = @s gm4_sg_secondary run function gm4_soul_glass:effect/apply_strong_effect
-execute unless score @s gm4_sg_primary = @s gm4_sg_secondary run function gm4_soul_glass:effect/apply_normal_effect
+execute if score @s gm4_sg_levels matches 1 positioned ~-20 ~-21 ~-20 run function gm4_soul_glass:effect/level_1
+execute if score @s gm4_sg_levels matches 2 positioned ~-30 ~-31 ~-30 run function gm4_soul_glass:effect/level_2
+execute if score @s gm4_sg_levels matches 3 positioned ~-40 ~-41 ~-40 run function gm4_soul_glass:effect/level_3
+execute if score @s gm4_sg_levels matches 4 if score @s gm4_sg_primary = @s gm4_sg_secondary positioned ~-50 ~-51 ~-50 run function gm4_soul_glass:effect/level_4_strong
+execute if score @s gm4_sg_levels matches 4 unless score @s gm4_sg_primary = @s gm4_sg_secondary positioned ~-50 ~-51 ~-50 run function gm4_soul_glass:effect/level_4

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1.mcfunction
@@ -6,9 +6,3 @@ execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=40,dy=296,dz=
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=40,dy=296,dz=40] minecraft:weakness 11 0
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=40,dy=296,dz=40] minecraft:slow_falling 11 0
 execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=40,dy=296,dz=40] minecraft:glowing 11 0
-execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=40,dy=296,dz=40] minecraft:slowness 11 0
-execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=40,dy=296,dz=40] minecraft:mining_fatigue 11 0
-execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=40,dy=296,dz=40] minecraft:weakness 11 0
-execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=40,dy=296,dz=40] minecraft:slow_falling 11 0
-execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=40,dy=296,dz=40] minecraft:glowing 11 0
-execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=40,dy=296,dz=40] minecraft:poison 11 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1_strong.mcfunction
@@ -1,8 +1,0 @@
-#@s = soul glass AEC with level 1 beacon below it
-#run from effects/check
-
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=40,dy=296,dz=40] minecraft:slowness 11 1
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=40,dy=296,dz=40] minecraft:mining_fatigue 11 1
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=40,dy=296,dz=40] minecraft:weakness 11 1
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=40,dy=296,dz=40] minecraft:slow_falling 11 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=40,dy=296,dz=40] minecraft:glowing 11 1

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2.mcfunction
@@ -6,9 +6,3 @@ execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=60,dy=316,dz=
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=60,dy=316,dz=60] minecraft:weakness 13 0
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=60,dy=316,dz=60] minecraft:slow_falling 13 0
 execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=60,dy=316,dz=60] minecraft:glowing 13 0
-execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=60,dy=316,dz=60] minecraft:slowness 13 0
-execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=60,dy=316,dz=60] minecraft:mining_fatigue 13 0
-execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=60,dy=316,dz=60] minecraft:weakness 13 0
-execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=60,dy=316,dz=60] minecraft:slow_falling 13 0
-execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=60,dy=166,dz=60] minecraft:glowing 13 0
-execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=60,dy=316,dz=60] minecraft:poison 13 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2_strong.mcfunction
@@ -1,8 +1,0 @@
-#@s = soul glass AEC with level 1 beacon below it
-#run from effects/check
-
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=60,dy=316,dz=60] minecraft:slowness 13 1
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=60,dy=316,dz=60] minecraft:mining_fatigue 13 1
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=60,dy=316,dz=60] minecraft:weakness 13 1
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=60,dy=316,dz=60] minecraft:slow_falling 13 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=60,dy=316,dz=60] minecraft:glowing 13 1

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3.mcfunction
@@ -6,9 +6,3 @@ execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=80,dy=336,dz=
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=80,dy=336,dz=80] minecraft:weakness 15 0
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=80,dy=336,dz=80] minecraft:slow_falling 15 0
 execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=80,dy=336,dz=80] minecraft:glowing 15 0
-execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=80,dy=336,dz=80] minecraft:slowness 15 0
-execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=80,dy=336,dz=80] minecraft:mining_fatigue 15 0
-execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=80,dy=336,dz=80] minecraft:weakness 15 0
-execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=80,dy=336,dz=80] minecraft:slow_falling 15 0
-execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=80,dy=336,dz=80] minecraft:glowing 15 0
-execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=80,dy=336,dz=80] minecraft:poison 15 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3_strong.mcfunction
@@ -1,8 +1,0 @@
-#@s = soul glass AEC with level 1 beacon below it
-#run from effects/check
-
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=80,dy=336,dz=80] minecraft:slowness 15 1
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=80,dy=336,dz=80] minecraft:mining_fatigue 15 1
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=80,dy=336,dz=80] minecraft:weakness 15 1
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=80,dy=336,dz=80] minecraft:slow_falling 15 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=80,dy=336,dz=80] minecraft:glowing 15 1

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
@@ -6,9 +6,5 @@ execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 0
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
 execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
-execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=100,dy=356,dz=100] minecraft:slowness 17 0
-execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 0
-execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 0
-execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
-execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
+
 execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=100,dy=356,dz=100] minecraft:poison 17 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
@@ -7,4 +7,10 @@ execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
 execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
 
+execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=100,dy=356,dz=100] minecraft:slowness 17 0
+execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 0
+execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 0
+execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
+execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
+
 execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=100,dy=356,dz=100] minecraft:poison 17 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
@@ -5,4 +5,4 @@ execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz
 execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 1
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 1
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 1

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
@@ -5,4 +5,4 @@ execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz
 execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 1
 execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 1
 execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 1
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
@@ -2,7 +2,7 @@
 #run from effects/check
 
 execute store result score @s gm4_sg_primary run data get block ~ ~-1 ~ Primary
-execute store result score @s gm4_sg_secondary run data get block ~ ~-1 ~ Secondary
+execute unless block ~ ~-1 ~ beacon{Secondary:-1} store result score @s gm4_sg_secondary run data get block ~ ~-1 ~ Secondary
 
 data modify block ~ ~-1 ~ Primary set value -1
 data modify block ~ ~-1 ~ Secondary set value -1

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/furnace/check_finish_smelt.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/furnace/check_finish_smelt.mcfunction
@@ -1,6 +1,6 @@
 #@s = none
 #run from furnace/prep_finish_smelt
 
-execute as @e[type=area_effect_cloud,tag=gm4_sg_smelting] at @s if block ~ ~ ~ blast_furnace{CookTime:799s,Items:[{Slot:0b,id:"minecraft:soul_sand"}]} run function gm4_soul_glass:furnace/finish_smelt
+execute as @e[type=marker,tag=gm4_sg_smelting] at @s if block ~ ~ ~ blast_furnace{CookTime:799s,Items:[{Slot:0b,id:"minecraft:soul_sand"}]} run function gm4_soul_glass:furnace/finish_smelt
 
 execute if entity @e[tag=gm4_sg_smelting] run schedule function gm4_soul_glass:furnace/check_finish_smelt 1t

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/furnace/place_blast_furnace.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/furnace/place_blast_furnace.mcfunction
@@ -6,5 +6,5 @@ summon area_effect_cloud ~ ~ ~ {Tags:["gm4_furnace_ray"]}
 execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[tag=gm4_furnace_ray] ^ ^ ^ ~ ~
 scoreboard players set gm4_ray_counter gm4_count 0
 execute as @e[tag=gm4_furnace_ray] at @s run function gm4_soul_glass:furnace/ray
-execute at @e[tag=gm4_furnace_ray] align xyz unless entity @e[type=area_effect_cloud,dx=0,dy=0,dz=0,tag=gm4_sg_furnace] run summon area_effect_cloud ~0.5 ~0.5 ~0.5 {Radius:0,Age:-2147483648,CustomName:'"gm4_sg_furnace"',Tags:["gm4_sg_furnace"],Particle:"block air"}
+execute at @e[tag=gm4_furnace_ray] align xyz positioned ~0.5 ~0.5 ~0.5 unless entity @e[type=marker,distance=..0.1,tag=gm4_sg_furnace,limit=1] run summon marker ~ ~ ~ {CustomName:'"gm4_sg_furnace"',Tags:["gm4_sg_furnace"]}
 kill @e[tag=gm4_furnace_ray]

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/main.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/main.mcfunction
@@ -1,5 +1,9 @@
-execute as @e[type=area_effect_cloud,tag=gm4_sg_furnace] at @s run function gm4_soul_glass:furnace/process
+# upgrade area effect clouds to markers
+execute as @e[type=area_effect_cloud,tag=gm4_sg_furnace] at @s run function gm4_soul_glass:upgrade_marker_bf
+execute as @e[type=area_effect_cloud,tag=gm4_soul_glass] at @s run function gm4_soul_glass:upgrade_marker_sg
 
-execute as @e[type=area_effect_cloud,tag=gm4_soul_glass] at @s run function gm4_soul_glass:process
+# process soul glass and blast furnace
+execute as @e[type=marker,tag=gm4_sg_furnace] at @s run function gm4_soul_glass:furnace/process
+execute as @e[type=marker,tag=gm4_soul_glass] at @s run function gm4_soul_glass:process
 
 schedule function gm4_soul_glass:main 16t

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/place_soul_glass.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/place_soul_glass.mcfunction
@@ -2,9 +2,9 @@
 # run from advancement place_soul_glass
 
 advancement revoke @s only gm4_soul_glass:place_soul_glass
-summon area_effect_cloud ~ ~ ~ {Tags:["gm4_soul_glass_ray"]}
+summon marker ~ ~ ~ {Tags:["gm4_soul_glass_ray"]}
 execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[tag=gm4_soul_glass_ray] ^ ^ ^ ~ ~
 scoreboard players set gm4_ray_counter gm4_count 0
 execute as @e[tag=gm4_soul_glass_ray] at @s run function gm4_soul_glass:ray
-execute at @e[tag=gm4_soul_glass_ray] align xyz unless entity @e[type=area_effect_cloud,dx=0,dy=0,dz=0,tag=gm4_soul_glass] run summon area_effect_cloud ~0.5 ~0.5 ~0.5 {Radius:0,Age:-2147483648,CustomName:'"gm4_soul_glass"',Tags:["gm4_soul_glass"],Particle:"block air"}
+execute at @e[tag=gm4_soul_glass_ray] align xyz positioned ~0.5 ~0.5 ~0.5 unless entity @e[type=marker,distance=..0.1,tag=gm4_soul_glass,limit=1] run summon marker ~ ~ ~ {CustomName:'"gm4_soul_glass"',Tags:["gm4_soul_glass"]}
 kill @e[tag=gm4_soul_glass_ray]

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/upgrade_marker_bf.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/upgrade_marker_bf.mcfunction
@@ -1,0 +1,2 @@
+summon marker ~ ~ ~ {CustomName:'"gm4_sg_furnace"',Tags:["gm4_sg_furnace"]}
+kill @s

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/upgrade_marker_sg.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/upgrade_marker_sg.mcfunction
@@ -1,0 +1,5 @@
+summon marker ~ ~ ~ {CustomName:'"gm4_soul_glass"',Tags:["gm4_soul_glass"]}
+scoreboard players operation @e[type=minecraft:marker,distance=..0.1,tag=gm4_soul_glass,limit=1] gm4_sg_levels = @s gm4_sg_levels
+scoreboard players operation @e[type=minecraft:marker,distance=..0.1,tag=gm4_soul_glass,limit=1] gm4_sg_primary = @s gm4_sg_primary
+scoreboard players operation @e[type=minecraft:marker,distance=..0.1,tag=gm4_soul_glass,limit=1] gm4_sg_secondary = @s gm4_sg_secondary
+kill @s


### PR DESCRIPTION
These changes should make the soul glass beacons to give effects in the same way as vanilla beacons.
- Some seemingly unnecessary checks have been removed, as a beacon of level 1-3 shouldn't ever be able to apply the strong effects.
- Level 4 beacon can now have 2 level 1 effects
- ~~Glowing 2 is the same as Glowing 1, so this "strong" effect is changed to Glowing 1 instead~~