### PR TITLE
Better Armour Stands: Turn correct way

### DIFF
--- a/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/apply_book.mcfunction
+++ b/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/apply_book.mcfunction
@@ -25,10 +25,10 @@ execute if data storage gm4_better_armour_stands:temp {pages:["invisible"]} alig
 execute if data storage gm4_better_armour_stands:temp {pages:["visible"]} align xz as @s run data merge entity @s {Invisible:0b}
 
 # Rotate the armor stand by predefined intervals.
-execute if data storage gm4_better_armour_stands:temp {pages:["turn left"]} run tag @s add gm4_turn_clockwise
-execute if data storage gm4_better_armour_stands:temp {pages:["turn left"]} run tag @s remove gm4_turn_anticlockwise
-execute if data storage gm4_better_armour_stands:temp {pages:["turn right"]} run tag @s add gm4_turn_anticlockwise
-execute if data storage gm4_better_armour_stands:temp {pages:["turn right"]} run tag @s remove gm4_turn_clockwise
+execute if data storage gm4_better_armour_stands:temp {pages:["turn left"]} run tag @s add gm4_turn_anticlockwise
+execute if data storage gm4_better_armour_stands:temp {pages:["turn left"]} run tag @s remove gm4_turn_clockwise
+execute if data storage gm4_better_armour_stands:temp {pages:["turn right"]} run tag @s add gm4_turn_clockwise
+execute if data storage gm4_better_armour_stands:temp {pages:["turn right"]} run tag @s remove gm4_turn_anticlockwise
 execute if data storage gm4_better_armour_stands:temp {pages:["no turn"]} run tag @s remove gm4_turn_clockwise
 execute if data storage gm4_better_armour_stands:temp {pages:["no turn"]} run tag @s remove gm4_turn_anticlockwise
 


### PR DESCRIPTION
`turn left` was turning clockwise and `turn right` was turning anticlockwise.
It would make sense if left and right is relative to the armour stand or from a top view, so this corrects the rotation to that point of view