### PR TITLE
Fulcio Raycast Fix

### DIFF
--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/4_tick.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/4_tick.mcfunction
@@ -1,3 +1,3 @@
-execute at @e[type=area_effect_cloud,tag=gm4_fulcio_block] align xyz run function gm4_fulcio_shamir:particles
+execute at @e[type=marker,tag=gm4_fulcio_block] align xyz run function gm4_fulcio_shamir:particles
 
 schedule function gm4_fulcio_shamir:4_tick 4t

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/active.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/active.mcfunction
@@ -1,4 +1,9 @@
 #run from main
-#@s = players holding a fulcio compass
+#@s = sneaking players holding a fulcio compass
 
-execute anchored eyes positioned ^ ^ ^3 align xyz if block ~ ~ ~ #gm4:air run function gm4_fulcio_shamir:create_block
+summon marker ~ ~ ~ {Tags:["gm4_fulcio_ray"]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[type=marker,tag=gm4_fulcio_ray] ^ ^ ^ ~ ~
+scoreboard players set gm4_ray_counter gm4_count 0
+execute as @e[type=marker,tag=gm4_fulcio_ray] at @s run function gm4_fulcio_shamir:ray
+execute as @e[type=marker,tag=gm4_fulcio_ray] at @s positioned ^ ^ ^-0.1 align xyz if block ~ ~ ~ #gm4:air run function gm4_fulcio_shamir:create_block
+kill @e[type=marker,tag=gm4_fulcio_ray]

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/create_block.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/create_block.mcfunction
@@ -2,4 +2,4 @@
 #@s = players holding a fulcio compass and looking at air positioned ^ ^ ^3 align xyz
 
 setblock ~ ~ ~ structure_void keep
-summon area_effect_cloud ~0.5 ~0.5 ~0.5 {Radius:0,Age:-2147483648,CustomName:'"gm4_fulcio_block"',Tags:["gm4_fulcio_block"],Particle:"block air"}
+summon marker ~0.5 ~0.5 ~0.5 {CustomName:'"gm4_fulcio_block"',Tags:["gm4_fulcio_block"]}

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/init.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/init.mcfunction
@@ -1,3 +1,4 @@
+scoreboard objectives add gm4_count dummy
 scoreboard objectives add gm4_fulcio_sneak minecraft.custom:minecraft.sneak_time
 
 execute unless score fulcio_shamir gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Fulcio Shamir"}

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/main.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/main.mcfunction
@@ -1,6 +1,6 @@
-execute as @e[type=area_effect_cloud,tag=gm4_fulcio_block] at @s run function gm4_fulcio_shamir:process_block
+execute as @e[type=marker,tag=gm4_fulcio_block] at @s run function gm4_fulcio_shamir:process_block
 
-execute as @a[gamemode=!spectator,predicate=gm4_fulcio_shamir:holding_fulcio,scores={gm4_fulcio_sneak=1..}] at @s run function gm4_fulcio_shamir:active
+execute as @a[gamemode=!spectator,scores={gm4_fulcio_sneak=1..},predicate=gm4_fulcio_shamir:holding_fulcio] at @s run function gm4_fulcio_shamir:active
 
 scoreboard players reset @a gm4_fulcio_sneak
 

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/ray.mcfunction
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/functions/ray.mcfunction
@@ -1,0 +1,6 @@
+# @s = area effect cloud ray used to find air
+# run from active
+
+scoreboard players add gm4_ray_counter gm4_count 1
+tp @s ^ ^ ^0.1
+execute if score gm4_ray_counter gm4_count matches 0..30 at @s positioned ^ ^ ^0.1 if block ~ ~ ~ #gm4:air positioned as @s run function gm4_fulcio_shamir:ray

--- a/gm4_fulcio_shamir/data/gm4_fulcio_shamir/predicates/holding_fulcio.json
+++ b/gm4_fulcio_shamir/data/gm4_fulcio_shamir/predicates/holding_fulcio.json
@@ -7,6 +7,7 @@
       "predicate": {
         "equipment": {
           "mainhand": {
+            "items": ["minecraft:compass"],
             "nbt": "{gm4_metallurgy:{has_shamir:1b,active_shamir:'fulcio'}}"
           }
         }
@@ -18,6 +19,7 @@
       "predicate": {
         "equipment": {
           "offhand": {
+            "items": ["minecraft:compass"],
             "nbt": "{gm4_metallurgy:{has_shamir:1b,active_shamir:'fulcio'}}"
           }
         }


### PR DESCRIPTION
- Fulcio uses a raycast instead of a hardcoded 3 blocks, so if there's a block in between the player and the 3rd block, it'll spawn the fulcio block in front of the block
- Fix the bug where you can drop an item and the predicate doesn't update
- converted AECs to markers