### PR TITLE
Apple Trees Markers and Raycast Fix

### DIFF
--- a/gm4_apple_trees/data/gm4_apple_trees/functions/chunk/generate_seed.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/chunk/generate_seed.mcfunction
@@ -1,5 +1,5 @@
 # Generates tree seed based on world seed and location.
-# @s = @e[type=minecraft:area_effect_cloud,tag=gm4_apple_tree_new,limit=1]
+# @s = @e[type=minecraft:marker,tag=gm4_apple_tree_new,limit=1]
 # at tree spawn position
 # run from gm4_apple_trees:chunk/spawn_tree
 
@@ -29,5 +29,5 @@ scoreboard players operation $generated_seed gm4_tree_seed *= $loc_z_bits gm4_ap
 # spawn tree
 function gm4_fruiting_trees:tree/initialize
 
-# remove new tree marker (used for targeting of initialize onto freshly spawned AECs that should be grown instantly, e.g. in gm4_apple_trees:chunk/spawn_tree)
+# remove new tree marker (used for targeting of initialize onto freshly spawned markers that should be grown instantly, e.g. in gm4_apple_trees:chunk/spawn_tree)
 tag @s remove gm4_apple_tree_new

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/chunk/spawn_tree.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/chunk/spawn_tree.mcfunction
@@ -3,5 +3,5 @@
 # at tree spawn position
 # run from gm4_apple_trees:chunk/scan_column
 
-summon minecraft:area_effect_cloud ~ ~ ~ {Tags:["gm4_apple_tree_sapling","gm4_apple_tree_new"],Duration:1}
-execute as @e[type=minecraft:area_effect_cloud,tag=gm4_apple_tree_new,limit=1] at @s align xyz run function gm4_apple_trees:chunk/generate_seed
+summon minecraft:marker ~ ~ ~ {Tags:["gm4_apple_tree_sapling","gm4_apple_tree_new"]}
+execute as @e[type=minecraft:marker,tag=gm4_apple_tree_new,limit=1] at @s align xyz run function gm4_apple_trees:chunk/generate_seed

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
@@ -4,4 +4,4 @@
 # run from gm4_apple_trees:sapling/validate_species
 
 summon marker ~ ~ ~ {CustomName:'"Apple Tree Sapling"',Tags:["gm4_fruiting_sapling","gm4_apple_tree_sapling"]}
-scoreboard players set @e[type=marker,tag=gm4_apple_tree_sapling,dx=0] gm4_sap_growth 2
+scoreboard players set @e[type=marker,tag=gm4_apple_tree_sapling,distance=..0.1] gm4_sap_growth 2

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
@@ -1,7 +1,7 @@
-# initializes the apple tree's AEC marker
-# @s = raycast AEC
+# initializes the apple tree's marker marker
+# @s = raycast marker
 # at @s align xyz
 # run from gm4_apple_trees:sapling/validate_species
 
-summon area_effect_cloud ~0.5 ~ ~0.5 {Radius:0f,Age:-2147483648,Duration:2147483647,CustomName:'"Apple Tree Sapling"',Tags:["gm4_fruiting_sapling","gm4_apple_tree_sapling"],Particle:"block air"}
-scoreboard players set @e[type=area_effect_cloud,tag=gm4_apple_tree_sapling,dx=0] gm4_sap_growth 2
+summon marker ~0.5 ~ ~0.5 {CustomName:'"Apple Tree Sapling"',Tags:["gm4_fruiting_sapling","gm4_apple_tree_sapling"]}
+scoreboard players set @e[type=marker,tag=gm4_apple_tree_sapling,dx=0] gm4_sap_growth 2

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/initialize.mcfunction
@@ -1,7 +1,7 @@
 # initializes the apple tree's marker marker
 # @s = raycast marker
-# at @s align xyz
+# at @s align xyz positioned ~0.5 ~0.5 ~0.5
 # run from gm4_apple_trees:sapling/validate_species
 
-summon marker ~0.5 ~ ~0.5 {CustomName:'"Apple Tree Sapling"',Tags:["gm4_fruiting_sapling","gm4_apple_tree_sapling"]}
+summon marker ~ ~ ~ {CustomName:'"Apple Tree Sapling"',Tags:["gm4_fruiting_sapling","gm4_apple_tree_sapling"]}
 scoreboard players set @e[type=marker,tag=gm4_apple_tree_sapling,dx=0] gm4_sap_growth 2

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/restore_data/restore.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/restore_data/restore.mcfunction
@@ -1,7 +1,8 @@
 # restores the data of the sapling when breaking the block
-# @s apple tree sapling AEC
+# @s apple tree sapling marker
 # at @s align xyz
 # run from gm4_apple_trees:sapling/restore_data/validate_species
 
-kill @e[type=item,nbt={Item:{id:"minecraft:oak_sapling",Count:1b}},nbt=!{Item:{tag:{}}},limit=1,dx=0]
-loot spawn ~0.5 ~0.5 ~0.5 loot gm4_apple_trees:items/apple_tree_sapling
+execute store success score $kill_success gm4_apple_data run kill @e[type=item,nbt={Item:{id:"minecraft:oak_sapling",Count:1b}},nbt=!{Item:{tag:{}}},limit=1,dx=0]
+execute if score $kill_success gm4_apple_data matches 1.. run loot spawn ~0.5 ~0.5 ~0.5 loot gm4_apple_trees:items/apple_tree_sapling
+scoreboard players reset $kill_success gm4_apple_data

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/restore_data/validate_species.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/restore_data/validate_species.mcfunction
@@ -1,5 +1,5 @@
 # checks whether the sapling is an apple sapling, and if so allows further execution
-# @s apple tree sapling AEC
+# @s apple tree sapling marker
 # at @s align xyz
 # run from #gm4_fruiting_trees:sapling/restore_data
 

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/validate_species.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/sapling/validate_species.mcfunction
@@ -1,5 +1,5 @@
 # checks whether the placed sapling is an apple sapling, and if so allows further execution
-# @s raycast AEC
+# @s raycast marker
 # at @s align xyz
 # run from #gm4_fruiting_trees:sapling/initialize
 

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/check_clear_space.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/check_clear_space.mcfunction
@@ -1,5 +1,5 @@
 # recursively checks how much clear space there is above a sapling
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at positioned ~ ~n ~ where n is the current iteration of the recursion
 # run from gm4_apple_trees:tree/initialize
 

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/generate.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/generate.mcfunction
@@ -1,6 +1,6 @@
 # generates a layer of the tree
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_fruiting_trees:generate via #gm4_fruiting_trees:layer/generate
 
 # set target height and rotation from seed and environment

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/orientate.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/orientate.mcfunction
@@ -1,6 +1,6 @@
 # generates the 1st layer of this apple tree
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker
 # run from fruiting_trees:generate via #fruiting_trees:layer/generate
 
 # rotate tree depending on seed

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_0.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_0.mcfunction
@@ -1,6 +1,6 @@
 # generates first branched layer of this apple tree
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/generate
 
 # place trunk

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1.mcfunction
@@ -1,6 +1,6 @@
 # choses second branched layer of this apple tree
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/generate
 
 # chose branch style

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1a.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1a.mcfunction
@@ -1,6 +1,6 @@
 # generates second branched layer of this apple tree as style a
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/generate
 
 # branches

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1b.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/branch_1b.mcfunction
@@ -1,6 +1,6 @@
 # generates second branched layer of this apple tree as style b
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/generate
 
 # branches

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1aa.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1aa.mcfunction
@@ -1,6 +1,6 @@
 # generates leaves ontop of apple trees with branching style 1a
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/place/branch_1a
 
 # place leaves

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1ab.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1ab.mcfunction
@@ -1,6 +1,6 @@
 # generates leaves ontop of apple trees with branching style 1a
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/place/branch_1a
 
 # place leaves

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1ba.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1ba.mcfunction
@@ -1,6 +1,6 @@
 # generates leaves ontop of apple trees with branching style 1a
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/place/branch_1a
 
 # place leaves

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1bb.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/layer/place/leaves_1bb.mcfunction
@@ -1,6 +1,6 @@
 # generates leaves ontop of apple trees with branching style 1a
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/place/branch_1a
 
 # place leaves

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/check_leaf_validity.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/check_leaf_validity.mcfunction
@@ -1,5 +1,5 @@
 # positions the apple leaf
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at selected coordinate for leaf
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/set_coordinates
 

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/extract_coordinate.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/extract_coordinate.mcfunction
@@ -1,6 +1,6 @@
 # marks leaves as fruiting leaves
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/layer/generate
 
 # interpret bit 08 as radius and bits 09, 10, 11 as angles 0 to 7

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/0_1.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/0_1.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/0_3
 
 execute if score $angle gm4_apple_data matches 0 run tp @s ~ ~ ~ 0 0

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/0_3.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/0_3.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/position_apple_leaf
 
 execute if score $angle gm4_apple_data matches 0..3 run function gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/0_1

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/2_3.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/2_3.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/0_3
 
 execute if score $angle gm4_apple_data matches 2 run tp @s ~ ~ ~ 90 0

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/4_5.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/4_5.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/4_7
 
 execute if score $angle gm4_apple_data matches 4 run tp @s ~ ~ ~ 270 0

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/4_7.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/4_7.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/position_apple_leaf
 
 execute if score $angle gm4_apple_data matches 4..5 run function gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/4_5

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/6_7.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/select_angle/6_7.mcfunction
@@ -1,6 +1,6 @@
 # selects starting angle for leaf in a binary search
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/select_angle/4_7
 
 execute if score $angle gm4_apple_data matches 6 run tp @s ~ ~ ~ 315 0

--- a/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/set_coordiante.mcfunction
+++ b/gm4_apple_trees/data/gm4_apple_trees/functions/tree/leaf/fruiting/select_location/set_coordiante.mcfunction
@@ -1,6 +1,6 @@
 # creates refrence frame for apple placement and recurses fr future apple placement
-# @s = sapling marker area_effect_cloud
-# positioned ~ ~n ~ above the AEC rotated as @s
+# @s = sapling marker
+# positioned ~ ~n ~ above the marker rotated as @s
 # run from gm4_apple_trees:tree/leaf/fruiting/select_location/set_coordinate
 
 # set starting angle angle (binary search tree)

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/advance_stage.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/advance_stage.mcfunction
@@ -1,5 +1,5 @@
 # reverts the sapling to stage=0
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at @s align xyz
 # run from gm4_fruiting_trees:sapling/process
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/destroy.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/destroy.mcfunction
@@ -1,4 +1,4 @@
-# removes an fruiting sapling AEC if it is not inside a sapling anymore
+# removes an fruiting sapling marker if it is not inside a sapling anymore
 # @s = any gm4_fruiting_sapling
 # at @s align xyz
 # run from gm4_fruiting_trees:sapling/process

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
@@ -5,13 +5,15 @@ advancement revoke @s only gm4_fruiting_trees:sapling/place_fruiting_sapling
 
 summon marker ~ ~ ~ {Tags:["gm4_tree_ray"]}
 execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[type=marker,tag=gm4_tree_ray,limit=1] ^ ^ ^ ~ ~
-scoreboard players set gm4_ray_counter gm4_count 0
+scoreboard players set $ray gm4_count 0
 execute as @e[type=marker,tag=gm4_tree_ray,limit=1] at @s run function gm4_fruiting_trees:sapling/ray
+execute unless score $found gm4_count matches 1 anchored eyes positioned ^ ^ ^ anchored feet run tp @e[type=marker,tag=gm4_tree_ray,limit=1] ^ ^ ^ ~ ~
+execute unless score $found gm4_count matches 1 as @e[type=marker,tag=gm4_tree_ray,limit=1] at @s run function gm4_fruiting_trees:sapling/ray_backup
 
 data modify storage gm4_fruiting_trees:data Sapling.type set from entity @s SelectedItem.tag.gm4_fruiting_trees.item.type
 execute at @e[type=marker,tag=gm4_ray_loc,limit=1] if block ~ ~ ~ #minecraft:saplings run function #gm4_fruiting_trees:sapling/initialize
 
 kill @e[type=marker,tag=gm4_tree_ray]
 kill @e[type=marker,tag=gm4_ray_loc]
-scoreboard players reset gm4_ray_count gm4_count
+scoreboard players reset $ray gm4_count
 scoreboard players reset $found gm4_count

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
@@ -3,12 +3,15 @@
 
 advancement revoke @s only gm4_fruiting_trees:sapling/place_fruiting_sapling
 
-summon area_effect_cloud ~ ~ ~ {Tags:["gm4_tree_ray"]}
-execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[tag=gm4_tree_ray] ^ ^ ^ ~ ~
+summon marker ~ ~ ~ {Tags:["gm4_tree_ray"]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run tp @e[type=marker,tag=gm4_tree_ray,limit=1] ^ ^ ^ ~ ~
 scoreboard players set gm4_ray_counter gm4_count 0
-execute as @e[tag=gm4_tree_ray] at @s run function gm4_fruiting_trees:sapling/ray
+execute as @e[type=marker,tag=gm4_tree_ray,limit=1] at @s run function gm4_fruiting_trees:sapling/ray
 
 data modify storage gm4_fruiting_trees:data Sapling.type set from entity @s SelectedItem.tag.gm4_fruiting_trees.item.type
-execute at @e[tag=gm4_tree_ray] align xyz unless entity @e[type=area_effect_cloud,dx=0,dy=0,dz=0,tag=gm4_fruiting_sapling] run function #gm4_fruiting_trees:sapling/initialize
+execute at @e[type=marker,tag=gm4_fruiting_sap_location,limit=1] run function #gm4_fruiting_trees:sapling/initialize
 
-kill @e[tag=gm4_tree_ray]
+kill @e[type=marker,tag=gm4_tree_ray]
+kill @e[type=marker,tag=gm4_fruiting_sap_location]
+scoreboard players reset gm4_ray_count gm4_count
+scoreboard players reset $found gm4_count

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/place_sapling.mcfunction
@@ -9,9 +9,9 @@ scoreboard players set gm4_ray_counter gm4_count 0
 execute as @e[type=marker,tag=gm4_tree_ray,limit=1] at @s run function gm4_fruiting_trees:sapling/ray
 
 data modify storage gm4_fruiting_trees:data Sapling.type set from entity @s SelectedItem.tag.gm4_fruiting_trees.item.type
-execute at @e[type=marker,tag=gm4_fruiting_sap_location,limit=1] run function #gm4_fruiting_trees:sapling/initialize
+execute at @e[type=marker,tag=gm4_ray_loc,limit=1] if block ~ ~ ~ #minecraft:saplings run function #gm4_fruiting_trees:sapling/initialize
 
 kill @e[type=marker,tag=gm4_tree_ray]
-kill @e[type=marker,tag=gm4_fruiting_sap_location]
+kill @e[type=marker,tag=gm4_ray_loc]
 scoreboard players reset gm4_ray_count gm4_count
 scoreboard players reset $found gm4_count

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/process.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/process.mcfunction
@@ -1,5 +1,5 @@
 # processes the sapling every tick for stage change or broken block
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at @s align xyz
 # run from gm4_fruiting_trees:tick
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
@@ -4,14 +4,8 @@
 # check blocks around the marker ray
 scoreboard players set $found gm4_count 0
 execute store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~1.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~-0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~1.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~-0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~1.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~-0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
 
 # move forward
-scoreboard players add gm4_ray_counter gm4_count 1
+scoreboard players add $ray gm4_count 1
 tp @s ^ ^ ^0.01
-execute if score gm4_ray_counter gm4_count matches 0..500 at @s unless score $found gm4_count matches 1 run function gm4_fruiting_trees:sapling/ray
+execute if score $ray gm4_count matches 0..500 at @s unless score $found gm4_count matches 1 run function gm4_fruiting_trees:sapling/ray

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
@@ -1,6 +1,17 @@
-# @s = area effect cloud ray used to detect the sapling
+# @s = marker ray used to detect the sapling
 # run from gm4_fruiting_trees:sapling/place_sapling
 
+# check blocks around the marker ray
+scoreboard players set $found gm4_count 0
+execute store success score $found gm4_count align xyz positioned ~ ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~1 ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~-1 ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~1 ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~-1 ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~ ~1 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~ ~-1 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+
+# move forward
 scoreboard players add gm4_ray_counter gm4_count 1
 tp @s ^ ^ ^0.01
-execute if score gm4_ray_counter gm4_count matches 0..500 at @s unless block ~ ~ ~ #minecraft:saplings run function gm4_fruiting_trees:sapling/ray
+execute if score gm4_ray_counter gm4_count matches 0..500 at @s unless score $found gm4_count matches 1 run function gm4_fruiting_trees:sapling/ray

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray.mcfunction
@@ -3,13 +3,13 @@
 
 # check blocks around the marker ray
 scoreboard players set $found gm4_count 0
-execute store success score $found gm4_count align xyz positioned ~ ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~1 ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~-1 ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~1 ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~-1 ~ ~ if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~ ~1 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
-execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~ ~ ~-1 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,dx=0,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_fruiting_sap_location"]}
+execute store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~1.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~-0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~1.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~-0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~1.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~-0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
 
 # move forward
 scoreboard players add gm4_ray_counter gm4_count 1

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray_backup.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/sapling/ray_backup.mcfunction
@@ -1,0 +1,17 @@
+# @s = marker ray used to detect the sapling
+# run from gm4_fruiting_trees:sapling/place_sapling
+
+# check blocks around the marker ray
+scoreboard players set $found gm4_count 0
+execute store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~1.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~-0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~1.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~-0.5 ~0.5 ~0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~1.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+execute if score $found gm4_count matches 0 store success score $found gm4_count align xyz positioned ~0.5 ~0.5 ~-0.5 if block ~ ~ ~ #minecraft:saplings unless entity @e[type=marker,distance=..0.1,tag=gm4_fruiting_sapling,limit=1] run summon marker ~ ~ ~ {Tags:["gm4_ray_loc"]}
+
+# move forward
+scoreboard players remove $ray gm4_count 1
+tp @s ^ ^ ^0.01
+execute if score $ray gm4_count matches 0..500 at @s unless score $found gm4_count matches 1 run function gm4_fruiting_trees:sapling/ray_backup

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tick.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tick.mcfunction
@@ -1,4 +1,4 @@
 # process saplings
-execute as @e[type=area_effect_cloud,tag=gm4_fruiting_sapling] at @s align xyz run function gm4_fruiting_trees:sapling/process
+execute as @e[type=marker,tag=gm4_fruiting_sapling] at @s align xyz run function gm4_fruiting_trees:sapling/process
 
 schedule function gm4_fruiting_trees:tick 1t

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tick.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tick.mcfunction
@@ -1,3 +1,6 @@
+# upgrade area effect clouds to markers
+execute as @e[type=area_effect_cloud,tag=gm4_fruiting_sapling] at @s run function gm4_fruiting_trees:upgrade_marker
+
 # process saplings
 execute as @e[type=marker,tag=gm4_fruiting_sapling] at @s align xyz run function gm4_fruiting_trees:sapling/process
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/analyze_seed.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/analyze_seed.mcfunction
@@ -1,5 +1,5 @@
 # splits the seed the tree was initialized with into bits used for tree generation
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at @s align xyz
 # run from gm4_fruiting_trees:tree/initialize
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/generate.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/generate.mcfunction
@@ -1,5 +1,5 @@
 # starts generating a tree layer by layer
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at @s align xyz
 # run from gm4_fruiting_trees:tree/initialize
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/initialize.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/tree/initialize.mcfunction
@@ -1,5 +1,5 @@
 # gets tree constants from the expansion
-# @s = sapling marker area_effect_cloud
+# @s = sapling marker
 # at @s align xyz
 # run from gm4_fruiting_trees:sapling/advance_stage
 

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/upgrade_marker.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/upgrade_marker.mcfunction
@@ -1,0 +1,4 @@
+summon marker ~ ~0.5 ~ {Tags:["gm4_sapling_new"]}
+data modify entity @e[type=marker,tag=gm4_sapling_new,limit=1] Tags set from entity @s Tags
+data modify entity @e[type=marker,tag=gm4_sapling_new,limit=1] CustomName set from entity @s CustomName
+kill @s

--- a/gm4_apple_trees/data/gm4_fruiting_trees/functions/upgrade_marker.mcfunction
+++ b/gm4_apple_trees/data/gm4_fruiting_trees/functions/upgrade_marker.mcfunction
@@ -1,4 +1,4 @@
 summon marker ~ ~0.5 ~ {Tags:["gm4_sapling_new"]}
-data modify entity @e[type=marker,tag=gm4_sapling_new,limit=1] Tags set from entity @s Tags
 data modify entity @e[type=marker,tag=gm4_sapling_new,limit=1] CustomName set from entity @s CustomName
+data modify entity @e[type=marker,tag=gm4_sapling_new,limit=1] Tags set from entity @s Tags
 kill @s


### PR DESCRIPTION
- area effect clouds replaced by markers
- raycasting checks the 6 adjacent blocks so if a player places it on a non-solid hitbox, it'll check surrounding blocks (thanks Epyon)
- apple tree saplings won't drop a sapling unless an oak sapling is actually dropped (usually only happens in creative)
- technically load score should go up since fruiting trees check for markers for the sapling instead of area effect clouds now, but there's no expansions or reliant modules yet?