### PR TITLE
Orb of Ankou 1.17

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_corripio_shamir/loot_tables/entities/husk.json
+++ b/gm4_orb_of_ankou/data/gm4_corripio_shamir/loot_tables/entities/husk.json
@@ -14,10 +14,10 @@
           "condition": "minecraft:table_bonus",
           "enchantment": "minecraft:looting",
           "chances": [
-            0.0001,
-            0.0004,
-            0.0025,
-            0.0082
+            0.0007,
+            0.0028,
+            0.0175,
+            0.0574
           ]
         }
       ]
@@ -35,10 +35,10 @@
           "condition": "minecraft:table_bonus",
           "enchantment": "minecraft:looting",
           "chances": [
-            0.00006,
-            0.00024,
-            0.0015,
-            0.00492
+            0.00012,
+            0.00048,
+            0.003,
+            0.00984
           ]
         }
       ]

--- a/gm4_orb_of_ankou/data/gm4_corripio_shamir/loot_tables/entities/stray.json
+++ b/gm4_orb_of_ankou/data/gm4_corripio_shamir/loot_tables/entities/stray.json
@@ -14,10 +14,10 @@
           "condition": "minecraft:table_bonus",
           "enchantment": "minecraft:looting",
           "chances": [
-            0.00016,
-            0.00064,
-            0.004,
-            0.01312
+            0.0007,
+            0.0028,
+            0.0175,
+            0.0574
           ]
         }
       ]
@@ -35,10 +35,10 @@
           "condition": "minecraft:table_bonus",
           "enchantment": "minecraft:looting",
           "chances": [
-            0.00009,
-            0.00036,
-            0.00225,
-            0.00738
+            0.0002,
+            0.0008,
+            0.005,
+            0.0164
           ]
         }
       ]
@@ -56,10 +56,10 @@
           "condition": "minecraft:table_bonus",
           "enchantment": "minecraft:looting",
           "chances": [
-            0.00006,
-            0.00024,
-            0.0015,
-            0.00492
+            0.00012,
+            0.00048,
+            0.003,
+            0.00984
           ]
         }
       ]

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/main.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/main.mcfunction
@@ -15,34 +15,22 @@ execute as @e[type=armor_stand,tag=gm4_soul_forge] at @s if predicate gm4_orb_of
 
 ## PNEUMA STUFF ##
 
-# bubbly
-execute as @a[tag=gm4_pneuma_bubbly] at @s anchored eyes unless block ^ ^ ^ #gm4:water unless block ^ ^ ^ #gm4:waterloggable[waterlogged=true] run effect give @s water_breathing 121 0
-
 # gliding
-effect give @a[tag=gm4_pneuma_gliding,scores={gm4_oa_swim=1..}] dolphins_grace 3 1 true
+effect give @a[gamemode=!spectator,tag=gm4_pneuma_gliding,scores={gm4_oa_swim=1..}] dolphins_grace 3 1 true
 scoreboard players reset @a gm4_oa_swim
 
-# synergetic
-execute at @a[tag=gm4_pneuma_synergetic] run function gm4_orb_of_ankou:pneumas/synergetic/apply
-
 # soaring
-tag @a[nbt={OnGround:1b}] remove gm4_oa_soaring_off_ground
-effect give @a[tag=gm4_oa_soaring_off_ground] jump_boost 2 255 true
-execute as @a[tag=gm4_oa_soaring_active] at @s run function gm4_orb_of_ankou:pneumas/soaring/apply
+tag @a[tag=gm4_oa_soaring_off_ground,nbt={OnGround:1b}] remove gm4_oa_soaring_off_ground
+effect give @a[gamemode=!spectator,tag=gm4_oa_soaring_off_ground] jump_boost 2 255 true
+
+# run player commands
+execute as @a[gamemode=!spectator,tag=gm4_has_pneuma] run function gm4_orb_of_ankou:player
 
 # sneaking stuff
-execute as @a[scores={gm4_oa_sneak=0},tag=gm4_oa_sneaking] run function gm4_orb_of_ankou:pneumas/sneak/stopped
-execute as @a[scores={gm4_oa_sneak=1..},tag=gm4_has_pneuma] run function gm4_orb_of_ankou:pneumas/sneak/check
 scoreboard players set @a gm4_oa_sneak 0
 
 # revert invulnerable item
 scoreboard players add @e[type=item,tag=gm4_oa_invulnerable] gm4_pneuma_data 1
 execute as @e[type=item,tag=gm4_oa_invulnerable,scores={gm4_pneuma_data=2..}] run function gm4_orb_of_ankou:pneumas/revert_invulnerable_item
-
-# mark players with tick pneumas
-execute store result score agile_player gm4_pneuma_data if entity @a[tag=gm4_pneuma_agile,limit=1]
-execute store result score hawkeye_player gm4_pneuma_data if entity @a[tag=gm4_pneuma_hawkeye,limit=1]
-execute store result score conjuring_fang gm4_pneuma_data if entity @e[type=armor_stand,tag=gm4_oa_fang_thrower,scores={gm4_pneuma_data=1..},limit=1]
-execute store result score striding_player gm4_pneuma_data if entity @a[tag=gm4_pneuma_striding,limit=1]
 
 schedule function gm4_orb_of_ankou:main 16t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/player.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/player.mcfunction
@@ -1,0 +1,15 @@
+# @s = all non-spectator players that has a pneuma equipped
+# run from main
+
+# bubbly
+execute at @s[tag=gm4_pneuma_bubbly] anchored eyes unless block ^ ^ ^ #gm4:water unless block ^ ^ ^ #gm4:waterloggable[waterlogged=true] run effect give @s water_breathing 121 0
+
+# synergetic
+execute at @s[tag=gm4_pneuma_synergetic] run function gm4_orb_of_ankou:pneumas/synergetic/apply
+
+# soaring
+execute at @s[tag=gm4_oa_soaring_active] run function gm4_orb_of_ankou:pneumas/soaring/apply
+
+# sneaking stuff
+execute if entity @s[scores={gm4_oa_sneak=0},tag=gm4_oa_sneaking] run function gm4_orb_of_ankou:pneumas/sneak/stopped
+execute if entity @s[scores={gm4_oa_sneak=1..},tag=gm4_has_pneuma] run function gm4_orb_of_ankou:pneumas/sneak/check

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_damaged_1.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_damaged_1.mcfunction
@@ -4,4 +4,4 @@
 advancement revoke @s only gm4_orb_of_ankou:triggers/magic_damaged_1
 tag @s add gm4_oa_magic_1
 tag @s add gm4_oa_magic_damaged
-scoreboard players set magic_damaged gm4_pneuma_data 1
+schedule function gm4_orb_of_ankou:pneumas/temp_tick/magic_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_damaged_2.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_damaged_2.mcfunction
@@ -4,4 +4,4 @@
 advancement revoke @s only gm4_orb_of_ankou:triggers/magic_damaged_2
 tag @s add gm4_oa_magic_2
 tag @s add gm4_oa_magic_damaged
-scoreboard players set magic_damaged gm4_pneuma_data 1
+schedule function gm4_orb_of_ankou:pneumas/temp_tick/magic_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_ignore.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/advancement_triggers/magic_ignore.mcfunction
@@ -4,4 +4,4 @@
 advancement revoke @s only gm4_orb_of_ankou:triggers/magic_evoker_fang
 tag @s add gm4_oa_magic_ignore
 tag @s add gm4_oa_magic_damaged
-scoreboard players set magic_damaged gm4_pneuma_data 1
+schedule function gm4_orb_of_ankou:pneumas/temp_tick/magic_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/agile.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/agile.mcfunction
@@ -1,5 +1,5 @@
 #@s = player with agile pneuma who is in the air
-#run from tick
+#run from pneumas/temp_tick/agile
 
 execute store result score @s gm4_pneuma_data run data get entity @s FallDistance
 effect give @s[scores={gm4_pneuma_data=1..}] jump_boost 1 255 true

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/prepare.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/prepare.mcfunction
@@ -10,3 +10,5 @@ scoreboard players set @s[scores={gm4_oa_snk_num=9..13}] gm4_pneuma_data 12
 scoreboard players set @s[scores={gm4_oa_snk_num=14..}] gm4_pneuma_data 15
 scoreboard players operation @e[type=armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] gm4_pneuma_data = @s gm4_pneuma_data
 tag @e[type=armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] remove gm4_oa_new_fang
+
+schedule function gm4_orb_of_ankou:pneumas/conjuring/temp_tick 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/temp_tick.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/temp_tick.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from pneumas/conjuring/prepare
+
+execute as @e[type=armor_stand,tag=gm4_oa_fang_thrower,scores={gm4_pneuma_data=1..}] at @s run function gm4_orb_of_ankou:pneumas/conjuring/throw
+
+execute if entity @e[type=armor_stand,tag=gm4_oa_fang_thrower,scores={gm4_pneuma_data=1..},limit=1] run schedule function gm4_orb_of_ankou:pneumas/conjuring/temp_tick 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/draining/search.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/draining/search.mcfunction
@@ -1,7 +1,7 @@
 #@s = player with draining pneuma who stopped sneaking
 #run from pneumas/sneak/stopped
 
-execute if score @s gm4_oa_snk_num matches 3..5 as @a[distance=0.001..16] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
-execute if score @s gm4_oa_snk_num matches 6..8 as @a[distance=0.001..32] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
-execute if score @s gm4_oa_snk_num matches 9..13 as @a[distance=0.001..48] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
-execute if score @s gm4_oa_snk_num matches 14.. as @a[distance=0.001..64] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
+execute if score @s gm4_oa_snk_num matches 3..5 as @a[gamemode=!spectator,distance=0.001..16] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
+execute if score @s gm4_oa_snk_num matches 6..8 as @a[gamemode=!spectator,distance=0.001..32] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
+execute if score @s gm4_oa_snk_num matches 9..13 as @a[gamemode=!spectator,distance=0.001..48] run function gm4_orb_of_ankou:pneumas/draining/apply_effect
+execute if score @s gm4_oa_snk_num matches 14.. as @a[gamemode=!spectator,distance=0.001..64] run function gm4_orb_of_ankou:pneumas/draining/apply_effect

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/expeditious/tp_player.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/expeditious/tp_player.mcfunction
@@ -5,3 +5,6 @@ particle minecraft:explosion ~ ~.3 ~ .3 .4 .3 2 0
 tp @s @e[type=area_effect_cloud,tag=gm4_oa_expeditious,limit=1]
 playsound minecraft:item.chorus_fruit.teleport player @a[distance=..30] ~ ~ ~ 1 1
 execute at @s run particle minecraft:portal ~ ~.2 ~ 0 -1 0 3 20
+
+# compatibility with teleportation anchors
+execute if score gm4_teleportation_anchors load matches 1.. run function gm4_teleportation_anchors:player/used_chorus

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/magic_damaged/check.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/magic_damaged/check.mcfunction
@@ -1,7 +1,5 @@
 #@s = player who took damage by magic
-#run from tick
-
-scoreboard players reset magic_damaged gm4_pneuma_data
+#run from pneumas/temp_tick/magic_damaged
 
 execute if entity @s[tag=gm4_has_pneuma,tag=!gm4_oa_magic_ignore,tag=gm4_oa_magic_1] run function gm4_orb_of_ankou:pneumas/magic_damaged/magic_1
 execute if entity @s[tag=gm4_has_pneuma,tag=!gm4_oa_magic_ignore,tag=!gm4_oa_magic_1,tag=gm4_oa_magic_2] run function gm4_orb_of_ankou:pneumas/magic_damaged/magic_2

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/check.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/check.mcfunction
@@ -1,16 +1,16 @@
 #@s = sneaking player with pneuma
-#run from main
+#run from player
 
 tag @s add gm4_oa_sneaking
 scoreboard players add @s gm4_oa_snk_num 1
 execute as @s[tag=gm4_sneak_pneuma] at @s run function gm4_orb_of_ankou:pneumas/sneak/sound
 
 effect give @s[tag=gm4_pneuma_vanishing] invisibility 90 0 true
-execute at @a[tag=gm4_pneuma_blinding] run effect give @a[distance=..6,tag=!gm4_pneuma_blinding] blindness 7 1 false
-effect give @a[tag=gm4_pneuma_feathery] slow_falling 7 0 true
-effect give @a[tag=gm4_pneuma_gazing] night_vision 30 0 true
+execute at @s[tag=gm4_pneuma_blinding] run effect give @a[distance=..6,tag=!gm4_pneuma_blinding] blindness 7 1 false
+effect give @s[tag=gm4_pneuma_feathery] slow_falling 7 0 true
+effect give @s[tag=gm4_pneuma_gazing] night_vision 30 0 true
 execute at @s[tag=gm4_pneuma_scaling] anchored eyes positioned ^ ^ ^1 align xyz unless block ~ ~ ~ #gm4:no_collision run effect give @s levitation 1 0 true
 
-execute as @s[tag=gm4_pneuma_phasing] run function gm4_orb_of_ankou:pneumas/phasing/check_traversable
+execute if entity @s[tag=gm4_pneuma_phasing] run function gm4_orb_of_ankou:pneumas/phasing/check_traversable
 
 execute if entity @s[tag=gm4_pneuma_soaring,tag=!gm4_oa_soaring_toggled] run function gm4_orb_of_ankou:pneumas/soaring/toggle

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/stopped.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/stopped.mcfunction
@@ -1,5 +1,5 @@
 #@s = sneaking player with pneuma that stopped sneaking
-#run from main
+#run from player
 
 execute if score @s gm4_oa_snk_num matches 3.. as @s[tag=gm4_pneuma_bounding] run function gm4_orb_of_ankou:pneumas/bounding
 execute if score @s gm4_oa_snk_num matches 3.. as @s[tag=gm4_pneuma_rushing] run function gm4_orb_of_ankou:pneumas/rushing

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/soaring/damaged.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/soaring/damaged.mcfunction
@@ -4,4 +4,4 @@
 summon area_effect_cloud ~ ~ ~ {Duration:1,Particle:"block air",Tags:["gm4_oa_soaring_location"]}
 tp @e[tag=gm4_oa_soaring_location,limit=1,distance=..0.1] @s
 tag @s add gm4_oa_soaring_damaged
-scoreboard players set soaring_damaged gm4_pneuma_data 1
+schedule function gm4_orb_of_ankou:pneumas/temp_tick/soaring_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/striding.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/striding.mcfunction
@@ -1,5 +1,6 @@
 #@s = player with striding pneuma who is above lava
-#run from tick
+#run from pneumas/temp_tick/striding
 
-execute align xyz run summon area_effect_cloud ~0.5 ~-1 ~0.5 {Duration:5,Tags:["gm4_oa_striding_block"],Particle:"block air"}
+execute align xyz run summon area_effect_cloud ~0.5 ~-1 ~0.5 {Duration:9,Tags:["gm4_oa_striding_block"],Particle:"block air"}
 setblock ~ ~-1 ~ magma_block
+schedule function gm4_orb_of_ankou:pneumas/temp_tick/striding_revert 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/synergetic/apply.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/synergetic/apply.mcfunction
@@ -7,4 +7,4 @@ effect give @e[type=wolf,distance=..4,scores={gm4_pneuma_data=0}] strength 5 0
 scoreboard players reset @e[type=wolf,distance=..4] gm4_pneuma_data
 
 # apply strength to other synergetic players
-effect give @a[distance=0.1..8,tag=gm4_pneuma_synergetic] strength 5 0
+effect give @a[gamemode=!spectator,distance=0.1..8,tag=gm4_pneuma_synergetic] strength 5 0

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/agile.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/agile.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from update_tags/check_pneuma
+
+execute as @a[gamemode=!spectator,tag=gm4_pneuma_agile] at @s if block ~ ~-0.1 ~ #gm4:no_collision if block ~ ~-1.3 ~ #gm4:no_collision if block ~ ~-2.3 ~ #gm4:no_collision if block ~ ~-3.3 ~ #gm4:no_collision run function gm4_orb_of_ankou:pneumas/agile
+
+execute if entity @a[tag=gm4_pneuma_agile,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/agile 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/hawkeye.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/hawkeye.mcfunction
@@ -1,0 +1,9 @@
+# @s = none
+# run from update_tags/check_pneuma
+
+execute as @a[gamemode=!spectator,tag=gm4_pneuma_hawkeye,scores={gm4_oa_bow=1..}] at @s anchored eyes positioned ^ ^ ^2 run tag @e[type=arrow,distance=..2.5,limit=1] add gm4_oa_arrow
+execute as @e[type=arrow,tag=gm4_oa_arrow,limit=1] store result entity @s damage byte 2 run data get entity @s damage
+data merge entity @e[type=arrow,tag=gm4_oa_arrow,limit=1] {PierceLevel:1b}
+tag @e[type=arrow] remove gm4_oa_arrow
+
+execute if entity @a[tag=gm4_pneuma_hawkeye,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/hawkeye 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/magic_damaged.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/magic_damaged.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from pneumas/advancement_triggers/magic_damaged_1 and pneumas/advancement_triggers/magic_damaged_2 and pneumas/advancement_triggers/magic_ignore
+
+execute as @a[gamemode=!spectator,tag=gm4_oa_magic_damaged] run function gm4_orb_of_ankou:pneumas/magic_damaged/check
+
+execute if entity @a[tag=gm4_oa_magic_damaged,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/magic_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/soaring_damaged.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/soaring_damaged.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from pneumas/soaring/damaged
+
+execute as @a[gamemode=!spectator,tag=gm4_oa_soaring_damaged] run function gm4_orb_of_ankou:pneumas/soaring/back
+
+execute if entity @a[tag=gm4_oa_soaring_damaged,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/soaring_damaged 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/striding.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/striding.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from update_tags/check_pneuma
+
+execute as @a[gamemode=!spectator,tag=gm4_pneuma_striding] at @s if block ~ ~-1 ~ lava[level=0] run function gm4_orb_of_ankou:pneumas/striding
+
+execute if entity @a[tag=gm4_pneuma_striding,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/striding 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/striding_revert.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/temp_tick/striding_revert.mcfunction
@@ -1,0 +1,6 @@
+# @s = none
+# run from pneumas/striding
+
+execute at @e[type=area_effect_cloud,tag=gm4_oa_striding_block,nbt={Age:8}] if block ~ ~ ~ magma_block run setblock ~ ~ ~ lava
+
+execute if entity @e[type=area_effect_cloud,tag=gm4_oa_striding_block,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/striding_revert 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/volatile.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/volatile.mcfunction
@@ -2,6 +2,6 @@
 #run from advancement_triggers/player_damaged
 
 execute store result score @s gm4_pneuma_data run data get entity @s Health
-execute as @e[type=item,distance=..5,tag=!gm4_oa_invulnerable,nbt=!{Invulnerable:1b}] run data merge entity @s {Invulnerable:1b}
-tag @e[type=item,distance=..5] add gm4_oa_invulnerable
-execute unless entity @a[distance=..6,predicate=gm4_metallurgy:defuse_active] if score @s[gamemode=!adventure] gm4_pneuma_data matches ..3 run summon creeper ~ ~ ~ {ExplosionRadius:1b,ignited:1b,Fuse:0s,CustomName:'"Volatile Player"'}
+tag @e[type=item,distance=..5,nbt=!{Invulnerable:1b}] add gm4_oa_invulnerable
+execute as @e[type=item,distance=..5,tag=gm4_oa_invulnerable] run data merge entity @s {Invulnerable:1b}
+execute unless entity @a[gamemode=!spectator,distance=..6,predicate=gm4_metallurgy:defuse_active] if score @s[gamemode=!adventure] gm4_pneuma_data matches ..3 run summon creeper ~ ~ ~ {ExplosionRadius:1b,ignited:1b,Fuse:0s,CustomName:'"Volatile Player"'}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/soul_forge/create.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/soul_forge/create.mcfunction
@@ -2,7 +2,7 @@
 # located at fire block that player is looking at
 # run from soul_forge/used_flint_and_steel
 
-summon armor_stand ~ ~ ~ {CustomName:"\"gm4_soul_forge\"",Tags:["gm4_no_edit","gm4_soul_forge"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Pose:{Head:[200.0f,0.0f,0.0f]}}
+summon armor_stand ~ ~ ~ {CustomName:'"gm4_soul_forge"',Tags:["gm4_no_edit","gm4_soul_forge"],NoGravity:1,Marker:1,Invisible:1,Invulnerable:1,Small:1,DisabledSlots:2039552,Pose:{Head:[200.0f,0.0f,0.0f]}}
 
 playsound minecraft:entity.player.breath block @a[distance=..12] ~ ~0.5 ~ 1 0.5
 particle minecraft:campfire_signal_smoke ~ ~0.7 ~ 0 2 0 0.05 10 force

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/tick.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/tick.mcfunction
@@ -1,7 +1,7 @@
 ## SOUL FORGE ##
 
 #creation
-execute if score nether_player gm4_oa_forge matches 1.. as @a[tag=gm4_oa_in_nether,scores={gm4_oa_fns=1..}] at @s run function gm4_orb_of_ankou:soul_forge/used_flint_and_steel
+execute if score nether_player gm4_oa_forge matches 1.. as @a[gamemode=!spectator,tag=gm4_oa_in_nether,scores={gm4_oa_fns=1..}] at @s run function gm4_orb_of_ankou:soul_forge/used_flint_and_steel
 scoreboard players reset @a gm4_oa_fns
 
 #check item before it burns
@@ -10,24 +10,7 @@ execute if score loaded_forge gm4_oa_forge matches 1.. at @e[type=armor_stand,ta
 
 ## PNEUMA STUFF ##
 
-# agile
-execute if score agile_player gm4_pneuma_data matches 1.. as @a[tag=gm4_pneuma_agile] at @s if block ~ ~-0.1 ~ #gm4:no_collision if block ~ ~-1.3 ~ #gm4:no_collision if block ~ ~-2.3 ~ #gm4:no_collision if block ~ ~-3.3 ~ #gm4:no_collision run function gm4_orb_of_ankou:pneumas/agile
-
-# striding
-execute at @e[type=area_effect_cloud,tag=gm4_oa_striding_block,nbt={Age:4}] if block ~ ~ ~ magma_block run setblock ~ ~ ~ lava
-execute if score striding_player gm4_pneuma_data matches 1.. as @a[tag=gm4_pneuma_striding] at @s if block ~ ~-1 ~ lava[level=0] run function gm4_orb_of_ankou:pneumas/striding
-
-# evoker fangs
-execute if score conjuring_fang gm4_pneuma_data matches 1.. as @e[type=armor_stand,tag=gm4_oa_fang_thrower,scores={gm4_pneuma_data=1..}] at @s run function gm4_orb_of_ankou:pneumas/conjuring/throw
-
 # use bow
-execute if score hawkeye_player gm4_pneuma_data matches 1.. as @a[tag=gm4_pneuma_hawkeye,scores={gm4_oa_bow=1..}] at @s anchored eyes positioned ^ ^ ^2 run data merge entity @e[type=arrow,distance=..2.5,limit=1] {damage:4.0d,PierceLevel:1b}
 scoreboard players reset @a gm4_oa_bow
-
-# magic damage
-execute if score magic_damaged gm4_pneuma_data matches 1.. as @a[tag=gm4_oa_magic_damaged] run function gm4_orb_of_ankou:pneumas/magic_damaged/check
-
-# soaring damage
-execute if score soaring_damaged gm4_pneuma_data matches 1.. as @a[tag=gm4_oa_soaring_damaged] run function gm4_orb_of_ankou:pneumas/soaring/back
 
 schedule function gm4_orb_of_ankou:tick 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/update_tags/check_pneuma.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/update_tags/check_pneuma.mcfunction
@@ -3,36 +3,41 @@
 
 tag @s add gm4_has_pneuma
 
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"incombustible"}]}}}]}] add gm4_pneuma_incombustible
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"retreating"}]}}}]}] add gm4_pneuma_retreating
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"aggressive"}]}}}]}] add gm4_pneuma_aggressive
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"withering"}]}}}]}] add gm4_pneuma_withering
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"volatile"}]}}}]}] add gm4_pneuma_volatile
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"neutralizing"}]}}}]}] add gm4_pneuma_neutralizing
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"bubbly"}]}}}]}] add gm4_pneuma_bubbly
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"vanishing"}]}}}]}] add gm4_pneuma_vanishing
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"blinding"}]}}}]}] add gm4_pneuma_blinding
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"feathery"}]}}}]}] add gm4_pneuma_feathery
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"gazing"}]}}}]}] add gm4_pneuma_gazing
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"agile"}]}}}]}] add gm4_pneuma_agile
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"gliding"}]}}}]}] add gm4_pneuma_gliding
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"lifeless"}]}}}]}] add gm4_pneuma_lifeless
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"scaling"}]}}}]}] add gm4_pneuma_scaling
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"bounding"}]}}}]}] add gm4_pneuma_bounding
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"phasing"}]}}}]}] add gm4_pneuma_phasing
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"rushing"}]}}}]}] add gm4_pneuma_rushing
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"conjuring"}]}}}]}] add gm4_pneuma_conjuring
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"expeditious"}]}}}]}] add gm4_pneuma_expeditious
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"bargaining"}]}}}]}] add gm4_pneuma_bargaining
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"soaring"}]}}}]}] add gm4_pneuma_soaring
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"synergetic"}]}}}]}] add gm4_pneuma_synergetic
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"hawkeye"}]}}}]}] add gm4_pneuma_hawkeye
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"draining"}]}}}]}] add gm4_pneuma_draining
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"blasting"}]}}}]}] add gm4_pneuma_blasting
-tag @s[nbt={Inventory:[{Slot:-106b,tag:{gm4_orb_of_ankou:{pneumas:[{id:"striding"}]}}}]}] add gm4_pneuma_striding
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/aggressive] add gm4_pneuma_aggressive
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/agile] add gm4_pneuma_agile
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/bargaining] add gm4_pneuma_bargaining
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/blasting] add gm4_pneuma_blasting
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/blinding] add gm4_pneuma_blinding
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/bounding] add gm4_pneuma_bounding
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/bubbly] add gm4_pneuma_bubbly
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/conjuring] add gm4_pneuma_conjuring
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/draining] add gm4_pneuma_draining
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/expeditious] add gm4_pneuma_expeditious
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/feathery] add gm4_pneuma_feathery
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/gazing] add gm4_pneuma_gazing
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/gliding] add gm4_pneuma_gliding
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/hawkeye] add gm4_pneuma_hawkeye
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/incombustible] add gm4_pneuma_incombustible
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/lifeless] add gm4_pneuma_lifeless
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/neutralizing] add gm4_pneuma_neutralizing
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/phasing] add gm4_pneuma_phasing
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/retreating] add gm4_pneuma_retreating
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/rushing] add gm4_pneuma_rushing
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/scaling] add gm4_pneuma_scaling
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/soaring] add gm4_pneuma_soaring
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/striding] add gm4_pneuma_striding
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/synergetic] add gm4_pneuma_synergetic
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/vanishing] add gm4_pneuma_vanishing
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/volatile] add gm4_pneuma_volatile
+tag @s[predicate=gm4_orb_of_ankou:pneuma_equipped/withering] add gm4_pneuma_withering
 
 tag @s[tag=gm4_pneuma_bounding] add gm4_sneak_pneuma
 tag @s[tag=gm4_pneuma_rushing] add gm4_sneak_pneuma
 tag @s[tag=gm4_pneuma_conjuring] add gm4_sneak_pneuma
 tag @s[tag=gm4_pneuma_expeditious] add gm4_sneak_pneuma
 tag @s[tag=gm4_pneuma_draining] add gm4_sneak_pneuma
+
+# run tick functions
+execute if entity @a[gamemode=!spectator,tag=gm4_pneuma_agile,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/agile 1t
+execute if entity @a[gamemode=!spectator,tag=gm4_pneuma_hawkeye,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/hawkeye 1t
+execute if entity @a[gamemode=!spectator,tag=gm4_pneuma_striding,limit=1] run schedule function gm4_orb_of_ankou:pneumas/temp_tick/striding 1t

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/update_tags/remove_tags.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/update_tags/remove_tags.mcfunction
@@ -1,34 +1,35 @@
 #@s = any player who has changed their inventory and has a pneuma tag
 #run from update_tags/check_offhand
 
-tag @s remove gm4_pneuma_incombustible
-tag @s remove gm4_pneuma_retreating
 tag @s remove gm4_pneuma_aggressive
-tag @s remove gm4_pneuma_withering
-tag @s remove gm4_pneuma_volatile
-tag @s remove gm4_pneuma_neutralizing
-tag @s remove gm4_pneuma_bubbly
-tag @s remove gm4_pneuma_vanishing
+tag @s remove gm4_pneuma_agile
+tag @s remove gm4_pneuma_bargaining
+tag @s remove gm4_pneuma_blasting
 tag @s remove gm4_pneuma_blinding
+tag @s remove gm4_pneuma_bounding
+tag @s remove gm4_pneuma_bubbly
+tag @s remove gm4_pneuma_conjuring
+tag @s remove gm4_pneuma_draining
+tag @s remove gm4_pneuma_expeditious
 tag @s remove gm4_pneuma_feathery
 tag @s remove gm4_pneuma_gazing
-tag @s remove gm4_pneuma_agile
 tag @s remove gm4_pneuma_gliding
-tag @s remove gm4_pneuma_lifeless
-tag @s remove gm4_pneuma_scaling
-tag @s remove gm4_pneuma_bounding
-tag @s remove gm4_pneuma_phasing
-tag @s remove gm4_pneuma_rushing
-tag @s remove gm4_pneuma_conjuring
-tag @s remove gm4_pneuma_expeditious
-tag @s remove gm4_pneuma_bargaining
-tag @s remove gm4_pneuma_soaring
-tag @s remove gm4_pneuma_synergetic
 tag @s remove gm4_pneuma_hawkeye
-tag @s remove gm4_pneuma_draining
-tag @s remove gm4_pneuma_blasting
+tag @s remove gm4_pneuma_incombustible
+tag @s remove gm4_pneuma_lifeless
+tag @s remove gm4_pneuma_neutralizing
+tag @s remove gm4_pneuma_phasing
+tag @s remove gm4_pneuma_retreating
+tag @s remove gm4_pneuma_rushing
+tag @s remove gm4_pneuma_scaling
+tag @s remove gm4_pneuma_soaring
 tag @s remove gm4_pneuma_striding
+tag @s remove gm4_pneuma_synergetic
+tag @s remove gm4_pneuma_vanishing
+tag @s remove gm4_pneuma_volatile
+tag @s remove gm4_pneuma_withering
 
 tag @s remove gm4_sneak_pneuma
-tag @s remove gm4_oa_soaring_active
 tag @s remove gm4_has_pneuma
+
+tag @s remove gm4_oa_soaring_active

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/has_pneuma.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/has_pneuma.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/aggressive.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/aggressive.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'aggressive'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/agile.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/agile.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'agile'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bargaining.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bargaining.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'bargaining'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/blasting.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/blasting.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'blasting'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/blinding.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/blinding.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'blinding'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bounding.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bounding.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'bounding'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bubbly.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/bubbly.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'bubbly'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/conjuring.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/conjuring.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'conjuring'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/draining.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/draining.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'draining'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/expeditious.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/expeditious.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'expeditious'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/feathery.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/feathery.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'feathery'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/gazing.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/gazing.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'gazing'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/gliding.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/gliding.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'gliding'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/hawkeye.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/hawkeye.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'hawkeye'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/incombustible.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/incombustible.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'incombustible'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/lifeless.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/lifeless.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'lifeless'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/neutralizing.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/neutralizing.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'neutralizing'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/phasing.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/phasing.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'phasing'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/retreating.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/retreating.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'retreating'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/rushing.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/rushing.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'rushing'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/scaling.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/scaling.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'scaling'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/soaring.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/soaring.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'soaring'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/striding.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/striding.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'striding'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/synergetic.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/synergetic.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'synergetic'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/vanishing.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/vanishing.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'vanishing'}]}}"
+      }
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/volatile.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/volatile.json
@@ -1,0 +1,12 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'volatile'}]}}"
+      }
+    }
+  }
+}
+  

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/withering.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/predicates/pneuma_equipped/withering.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "offhand": {
+        "nbt": "{gm4_orb_of_ankou:{pneumas:[{id:'withering'}]}}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
From #532
- [X] spectators no longer activate OoA
- [X] predicate checks are used instead of data checks when checking the player's offhand
- [X] functions running every tick were moved to a dedicated function clock
- [X] add player-based commands to limit duplicate function calls
- [X] Husk and Stray drops increased significantly due to low ability to farm them
- [X] Hawkeye doubles arrow damage to stack with Power
- [X] add compatibility with TP Anchors

1.17 Update
- [ ] New pneuma: Feigning - Gains Invisibility, Regeneration I, Slowness 255, and Weakness 255 for 10 seconds when player takes damage and is below 8 health
- [ ] Add Axolotl, Glow Squid, and Goat Soul Essence Drops
- [ ] Use `data storage`
- [ ] Replace Area Effect Clouds with Markers
- [ ] Improve raycasting
- [ ] Improve Reliability of Sneak-Tap Pneumas