### PR TITLE
Enderman Support Class: No effects in creative mode

### DIFF
--- a/gm4_enderman_support_class/data/gm4_enderman_support_class/functions/buff.mcfunction
+++ b/gm4_enderman_support_class/data/gm4_enderman_support_class/functions/buff.mcfunction
@@ -9,8 +9,8 @@ effect give @s[type=creeper] regeneration 4 0
 effect give @s[type=silverfish] resistance 4 1
 effect give @s[type=spider] jump_boost 4 1
 effect give @s[type=zombie] speed 4 1
-execute at @s[type=skeleton] run effect give @a[gamemode=!spectator,distance=..7] weakness 7 0
-execute at @s[type=shulker] run effect give @a[gamemode=!spectator,distance=..7] blindness 3 9
+execute at @s[type=skeleton] run effect give @a[gamemode=!spectator,gamemode=!creative,distance=..7] weakness 7 0
+execute at @s[type=shulker] run effect give @a[gamemode=!spectator,gamemode=!creative,distance=..7] blindness 3 9
 
 # display particle effect
 execute at @s[type=!player] run particle portal ~ ~.5 ~ 0.2 .5 0.2 .5 10


### PR DESCRIPTION
Shulker and skeletons give effects (blindness and weakness) to nearby players, but players in creative mode should be excluded