### PR TITLE
Xp Storage: Update sneaking check and fix visual bug

### DIFF
--- a/gm4_xp_storage/data/gm4_xp_storage/advancements/join.json
+++ b/gm4_xp_storage/data/gm4_xp_storage/advancements/join.json
@@ -1,0 +1,10 @@
+{
+    "criteria": {
+      "join": {
+        "trigger": "minecraft:location"
+      }
+    },
+    "rewards": {
+      "function": "gm4_xp_storage:init_xp"
+    }
+  }

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/deposit_mode_check.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/deposit_mode_check.mcfunction
@@ -1,15 +1,11 @@
-#@s = as [players on top of ender chests] at @s
-#run from main
+# Check if player dumps 1 or all levels
+# @s = players on top of ender chest
+# at @s
+# run from main
 
-#players who were not sneaking on an ender-chest last pulse and are now sneaking run dump-all
-execute if score @s[tag=gm4_was_on_ender_chest] gm4_xp_sneaking matches 1.. run scoreboard players set xp_dump_all_counter gm4_xp_calc 1
-execute if score @s[tag=gm4_was_on_ender_chest] gm4_xp_sneaking matches 1.. unless entity @s[level=0] run function gm4_xp_storage:dump_all
+# players who were not sneaking on an ender-chest last pulse and are now sneaking run dump-all
+execute if entity @s[predicate=gm4_xp_storage:sneaking] run scoreboard players set xp_dump_all_counter gm4_xp_calc 1
+execute if entity @s[predicate=gm4_xp_storage:sneaking,level=1..] run function gm4_xp_storage:dump_all
 
-#players who are not sneaking deposit a single level
-execute unless score @s gm4_xp_sneaking matches 1.. unless entity @s[level=0] run function gm4_xp_storage:dump_level
-
-tag @s[scores={gm4_xp_sneaking=0}] remove gm4_was_on_ender_chest
-
-#tag all players who are currently on e-chest but aren't sneaking
-tag @s[scores={gm4_xp_sneaking=0}] add gm4_was_on_ender_chest
-scoreboard players set @s gm4_xp_sneaking 0
+# players who are not sneaking deposit a single level
+execute if entity @s[predicate=!gm4_xp_storage:sneaking,level=1..] run function gm4_xp_storage:dump_level

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/dump_all.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/dump_all.mcfunction
@@ -1,10 +1,12 @@
-#@s = sneaking players on an ender chest
-#run from deposit_mode_check
+# Deposit all levels
+# @s = sneaking players on top of ender chest
+# at @s
+# run from deposit_mode_check and dump_all
 
 function gm4_xp_storage:dump_level
 
-#infinite recursion fail-safe
+# infinite recursion fail-safe
 scoreboard players add xp_dump_all_counter gm4_xp_calc 1
 
-#loop function until levels is 1
+# loop function until levels is 1
 execute if score xp_dump_all_counter gm4_xp_calc matches 1..50 unless entity @s[level=0] run function gm4_xp_storage:dump_all

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/dump_level.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/dump_level.mcfunction
@@ -1,6 +1,7 @@
-#dumps one level from player into e-chest
-#@s = players not sneaking on an ender chest
-#run from deposit_mode_check and dump_all
+# Deposit 1 level
+# @s = players on top of ender chest
+# at @s
+# run from deposit_mode_check and dump_all
 
 execute store result score @s gm4_xp_calc run xp query @s points
 execute unless entity @s[level=0] run scoreboard players add @s gm4_xp_calc 1

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/init.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/init.mcfunction
@@ -1,5 +1,4 @@
 scoreboard objectives add gm4_stored_xp dummy
-scoreboard objectives add gm4_xp_sneaking minecraft.custom:minecraft.sneak_time
 scoreboard objectives add gm4_xp_calc dummy
 
 execute unless score xp_storage gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"XP Storage"}

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/init_xp.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/init_xp.mcfunction
@@ -1,0 +1,6 @@
+# Set initial stored xp
+# @s = new player
+# at @s
+# run from advancement join
+
+execute unless score @s gm4_stored_xp matches 1.. run scoreboard players set @s gm4_stored_xp 0

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/main.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/main.mcfunction
@@ -1,10 +1,4 @@
-#deposit
 execute as @a[gamemode=!spectator] at @s if block ~ ~-0.1 ~ ender_chest run function gm4_xp_storage:deposit_mode_check
-
-execute as @a[gamemode=!spectator] at @s unless block ~ ~-0.1 ~ ender_chest run tag @s remove gm4_was_on_ender_chest
-
 execute as @a[gamemode=!spectator] at @s anchored eyes run function gm4_xp_storage:point_report_ray
-
-scoreboard players reset @a gm4_xp_end_chest
 
 schedule function gm4_xp_storage:main 16t

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/point_report.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/point_report.mcfunction
@@ -1,5 +1,7 @@
-#@s = player looking an ender_chest
-#run from point_report_ray
+# Show stored experience in actionbar
+# @s = players looking at ender chest
+# at @s
+# run from point_report_ray
 
 title @s actionbar [{"translate":"%1$s%3427655$s","with":["Stored Experience: ",{"translate":"text.gm4.xp_storage.stored_experience"}],"color":"green"},{"translate":"%1$s%3427655$s","with":[[{"score":{"name":"@s","objective":"gm4_stored_xp"}}," Points"],{"translate":"text.gm4.xp_storage.stored_experience.points","with":[{"score":{"name":"@s","objective":"gm4_stored_xp"}}]}],"color":"dark_green"}]
 

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/point_report_ray.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/point_report_ray.mcfunction
@@ -1,5 +1,7 @@
-#@s = all players
-#run from main
+# Find player looking at ender chest
+# @s = all players
+# at @s
+# run from main
 
 execute positioned ^ ^ ^.5 if block ~ ~ ~ ender_chest run function gm4_xp_storage:point_report
 execute positioned ^ ^ ^1.5 if block ~ ~ ~ ender_chest run function gm4_xp_storage:point_report

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/tick.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/tick.mcfunction
@@ -1,4 +1,3 @@
-#withdraw
 execute as @a[gamemode=!spectator] at @s if block ~ ~2 ~ ender_chest run function gm4_xp_storage:withdraw
 
 schedule function gm4_xp_storage:tick 1t

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/withdraw.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/withdraw.mcfunction
@@ -1,5 +1,7 @@
-#@s = player if block ~ ~2 ~ ender_chest
-#run from pulse_check
+# Withdraw xp
+# @s = players directly below ender chest
+# at @s
+# run from tick
 
 title @s actionbar [{"translate":"%1$s%3427655$s","with":["Stored Experience: ",{"translate":"text.gm4.xp_storage.stored_experience"}],"color":"green"},{"translate":"%1$s%3427655$s","with":[[{"score":{"name":"@s","objective":"gm4_stored_xp"}}," Points"],{"translate":"text.gm4.xp_storage.stored_experience.points","with":[{"score":{"name":"@s","objective":"gm4_stored_xp"}}]}],"color":"dark_green"}]
 execute if score @s gm4_stored_xp matches 5.. run experience add @s 5 points
@@ -7,5 +9,5 @@ execute if score @s gm4_stored_xp matches 5.. run scoreboard players remove @s g
 execute if score @s gm4_stored_xp matches 1..4 run experience add @s 1 points
 execute if score @s gm4_stored_xp matches 1..4 run scoreboard players remove @s gm4_stored_xp 1
 
-#play xp effect
+# play xp effect
 execute if score @s gm4_stored_xp matches 1.. run summon experience_orb ~ ~1.8 ~ {Age:5995,Value:0}

--- a/gm4_xp_storage/data/gm4_xp_storage/functions/xp_deposit_loop.mcfunction
+++ b/gm4_xp_storage/data/gm4_xp_storage/functions/xp_deposit_loop.mcfunction
@@ -1,47 +1,43 @@
-#@s =
-#run from dump_level
+# Calculate deposited xp
+# @s = players on top of ender chest
+# at @s
+# run from dump_level and xp_deposit_loop
 
-
-#deposit 64 points if possible
+# deposit 64 points if possible
 execute if score @s gm4_xp_calc matches 64.. run experience add @s -64 points
 execute if score @s gm4_xp_calc matches 64.. run scoreboard players add @s gm4_stored_xp 64
 execute if score @s gm4_xp_calc matches 64.. run scoreboard players remove @s gm4_xp_calc 64
 
-#deposit 32 points if possible
+# deposit 32 points if possible
 execute if score @s gm4_xp_calc matches 32.. run experience add @s -32 points
 execute if score @s gm4_xp_calc matches 32.. run scoreboard players add @s gm4_stored_xp 32
 execute if score @s gm4_xp_calc matches 32.. run scoreboard players remove @s gm4_xp_calc 32
 
-#deposit 16 points if possible
+# deposit 16 points if possible
 execute if score @s gm4_xp_calc matches 16.. run experience add @s -16 points
 execute if score @s gm4_xp_calc matches 16.. run scoreboard players add @s gm4_stored_xp 16
 execute if score @s gm4_xp_calc matches 16.. run scoreboard players remove @s gm4_xp_calc 16
 
-#deposit 8 points if possible
+# deposit 8 points if possible
 execute if score @s gm4_xp_calc matches 8.. run experience add @s -8 points
 execute if score @s gm4_xp_calc matches 8.. run scoreboard players add @s gm4_stored_xp 8
 execute if score @s gm4_xp_calc matches 8.. run scoreboard players remove @s gm4_xp_calc 8
 
-#deposit 4 points if possible
+# deposit 4 points if possible
 execute if score @s gm4_xp_calc matches 4.. run experience add @s -4 points
 execute if score @s gm4_xp_calc matches 4.. run scoreboard players add @s gm4_stored_xp 4
 execute if score @s gm4_xp_calc matches 4.. run scoreboard players remove @s gm4_xp_calc 4
 
-#deposit 2 points if possible
+# deposit 2 points if possible
 execute if score @s gm4_xp_calc matches 2.. run experience add @s -2 points
 execute if score @s gm4_xp_calc matches 2.. run scoreboard players add @s gm4_stored_xp 2
 execute if score @s gm4_xp_calc matches 2.. run scoreboard players remove @s gm4_xp_calc 2
 
-#deposit 1 points if possible
+# deposit 1 points if possible
 execute if score @s gm4_xp_calc matches 1.. run experience add @s -1 points
 execute if score @s gm4_xp_calc matches 1.. run scoreboard players add @s gm4_stored_xp 1
 execute if score @s gm4_xp_calc matches 1.. run scoreboard players remove @s gm4_xp_calc 1
 
-#deposit one point
-#experience add @s -1 points
-#scoreboard players remove @s gm4_xp_calc 1
-#scoreboard players add @s gm4_stored_xp 1
-
-
+# repeat loop
 execute unless score @s gm4_xp_calc matches 0 unless score loop_counter gm4_xp_calc matches 100.. run function gm4_xp_storage:xp_deposit_loop
 scoreboard players add loop_counter gm4_xp_calc 1

--- a/gm4_xp_storage/data/gm4_xp_storage/predicates/sneaking.json
+++ b/gm4_xp_storage/data/gm4_xp_storage/predicates/sneaking.json
@@ -1,0 +1,9 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "flags": {
+      "is_sneaking": true
+    }
+  }
+}


### PR DESCRIPTION
- Fixed bug where it displayed "Stored Experience:  Points" if no xp was stored yet, with `join` advancement that sets your score to 0 if needed
- Moved sneaking check to predicate instead of scoreboard
- Depositing all levels can be done instantly (without having to deposit 1 level first, so it would work when sneaking onto an ender chest without un-sneaking first)
- Updated all comments in right formatting