### PR TITLE
Beehive Inspectors: Fix visual bug

### DIFF
--- a/gm4_beehive_inspector/data/gm4_beehive_inspector/functions/inspect.mcfunction
+++ b/gm4_beehive_inspector/data/gm4_beehive_inspector/functions/inspect.mcfunction
@@ -1,7 +1,14 @@
-# @s is a beehive item that was just mined
-# runs from main
+# Inspect beehive item
+# @s = beehive item
+# at @s
+# run from main
 
+# store bee count in scoreboard
 execute store result score #bees gm4_beehive_insp run data get entity @s Item.tag.BlockEntityTag.Bees
-loot spawn ~ ~-1024 ~ loot gm4_beehive_inspector:lore
 
+# set nbt if broken without silk touch
+execute unless data entity @s Item.tag run data modify entity @s Item.tag set value {BlockEntityTag:{Bees:[]},BlockStateTag:{honey_level:"0"}}
+
+# set bee/honey amount as lore
+loot spawn ~ ~-1024 ~ loot gm4_beehive_inspector:lore
 execute positioned ~ ~-1024 ~ run data modify entity @s Item.tag.display set from entity @e[type=item,distance=..0.1,limit=1] Item.tag.display


### PR DESCRIPTION
Fixed bug where the beehive lore would display "Honey: " without a number, if broken without silk touch, by setting this nbt if it's missing.

This also means that empty beehives will stack, mined with and without silk touch.