### PR TITLE
Added Glow Item Frame support for 1.17 HoloTags

### DIFF
--- a/gm4_holographic_tags/data/gm4_holographic_tags/functions/create_hologram.mcfunction
+++ b/gm4_holographic_tags/data/gm4_holographic_tags/functions/create_hologram.mcfunction
@@ -8,5 +8,8 @@ execute if block ^ ^ ^-0.75 #minecraft:wool as @e[type=area_effect_cloud,tag=gm4
 advancement grant @a[distance=..4,gamemode=!spectator] only gm4:holographic_tags
 playsound minecraft:entity.item_frame.remove_item block @a
 particle minecraft:block stripped_acacia_log ~ ~ ~ .2 .2 .2 .1 10
-summon item ~ ~ ~ {Item:{id:"minecraft:item_frame",Count:1b},PickupDelay:10s,Motion:[0.0,0.25,0.0]}
+
+execute if entity @s[type=item_frame] run summon item ~ ~ ~ {Item:{id:"minecraft:item_frame",Count:1b},PickupDelay:10s,Motion:[0.0,0.25,0.0]}
+execute if entity @s[type=glow_item_frame] run summon item ~ ~ ~ {Item:{id:"minecraft:glow_item_frame",Count:1b},PickupDelay:10s,Motion:[0.0,0.25,0.0]}
+
 kill @s

--- a/gm4_holographic_tags/data/gm4_holographic_tags/functions/destroy_hologram.mcfunction
+++ b/gm4_holographic_tags/data/gm4_holographic_tags/functions/destroy_hologram.mcfunction
@@ -3,5 +3,8 @@
 
 data merge entity @e[type=item_frame,limit=1,sort=nearest,distance=..0.1] {Tags:["gm4_hologram"],Item:{id:"minecraft:name_tag",Count:1b,tag:{RepairCost:0}}}
 data modify entity @e[type=item_frame,limit=1,sort=nearest,distance=..0.1] Item.tag.display.Name set from entity @s CustomName
+
+data merge entity @e[type=glow_item_frame,limit=1,sort=nearest,distance=..0.1] {Tags:["gm4_hologram"],Item:{id:"minecraft:name_tag",Count:1b,tag:{RepairCost:0}}}
+data modify entity @e[type=glow_item_frame,limit=1,sort=nearest,distance=..0.1] Item.tag.display.Name set from entity @s CustomName
 particle minecraft:block stripped_birch_log ~ ~ ~ .2 .2 .2 .1 10
 kill @s

--- a/gm4_holographic_tags/data/gm4_holographic_tags/functions/main.mcfunction
+++ b/gm4_holographic_tags/data/gm4_holographic_tags/functions/main.mcfunction
@@ -2,4 +2,8 @@ execute as @e[type=area_effect_cloud,tag=gm4_hologram] at @s positioned ^ ^ ^-0.
 execute as @e[type=item_frame,tag=!gm4_hologram] if data entity @s {Item:{id:"minecraft:name_tag",tag:{display:{}}}} at @s positioned ^ ^ ^0.3 positioned ~ ~-.3 ~ unless entity @e[type=area_effect_cloud,tag=gm4_hologram,distance=..0.1] run function gm4_holographic_tags:create_hologram
 tag @e[type=item_frame,tag=gm4_hologram,nbt=!{Item:{id:"minecraft:name_tag"}}] remove gm4_hologram
 
+execute as @e[type=area_effect_cloud,tag=gm4_hologram] at @s positioned ^ ^ ^-0.3 positioned ~ ~.3 ~ if entity @e[type=glow_item_frame,nbt=!{Item:{}},distance=..0.1,limit=1] run function gm4_holographic_tags:destroy_hologram
+execute as @e[type=glow_item_frame,tag=!gm4_hologram] if data entity @s {Item:{id:"minecraft:name_tag",tag:{display:{}}}} at @s positioned ^ ^ ^0.3 positioned ~ ~-.3 ~ unless entity @e[type=area_effect_cloud,tag=gm4_hologram,distance=..0.1] run function gm4_holographic_tags:create_hologram
+tag @e[type=glow_item_frame,tag=gm4_hologram,nbt=!{Item:{id:"minecraft:name_tag"}}] remove gm4_hologram
+
 schedule function gm4_holographic_tags:main 16t


### PR DESCRIPTION
Allows you to create Holographic Tags using Glow Item Frames

- separate entity checks are better than entity tags, with 2 entities.