### PR TITLE
Rewrite and enhance the Undead Players module

### DIFF
--- a/gm4_undead_players/data/gm4_undead_players/advancements/death.json
+++ b/gm4_undead_players/data/gm4_undead_players/advancements/death.json
@@ -1,0 +1,33 @@
+{
+  "criteria": {
+    "death": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_scores",
+            "entity": "this",
+            "scores": {
+              "gm4_undead": 1
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_undead_players"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "gm4_undead_players:died"
+  }
+}

--- a/gm4_undead_players/data/gm4_undead_players/functions/check_drowning.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/check_drowning.mcfunction
@@ -1,0 +1,6 @@
+#run from gm4_undead_players:main
+#@s = undead player being checked for drowned conversion
+
+# Store DrownedConversionTime in a temporary scoreboard to check its value.
+execute store result score #conversion_time gm4_undead_drown run data get entity @s DrownedConversionTime
+execute if score #conversion_time gm4_undead_drown matches 0.. run function gm4_undead_players:process_drowning

--- a/gm4_undead_players/data/gm4_undead_players/functions/check_drowning.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/check_drowning.mcfunction
@@ -1,6 +1,0 @@
-#run from gm4_undead_players:main
-#@s = undead player being checked for drowned conversion
-
-# Store DrownedConversionTime in a temporary scoreboard to check its value.
-execute store result score #conversion_time gm4_undead_drown run data get entity @s DrownedConversionTime
-execute if score #conversion_time gm4_undead_drown matches 0.. run function gm4_undead_players:process_drowning

--- a/gm4_undead_players/data/gm4_undead_players/functions/died.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/died.mcfunction
@@ -1,6 +1,9 @@
-#@s = @a[scores={gm4_undead=1..},gamemode=!creative,gamemode=!spectator] at @s
+#run from gm4_undead_players:death advancement
+#@s = player who took fatal damage
 
-execute if entity @s[tag=!gm4_undead_ignore,gamemode=!creative,gamemode=!spectator] run summon zombie ~ ~1 ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Undead Player",{"translate":"entity.gm4.undead_player"}]}',CustomNameVisible:1,CanPickUpLoot:1b,PersistenceRequired:1,IsBaby:0,HandItems:[],ArmorItems:[],Tags:["gm4_undead_player"]}
-execute if entity @s[tag=!gm4_undead_ignore,gamemode=!creative,gamemode=!spectator] run advancement grant @s only gm4:undead_players
-
+# Reset death tracking scoreboard and advancement to allow for the player to die again.
+advancement revoke @s only gm4_undead_players:death
 scoreboard players reset @s gm4_undead
+
+# Summon undead player unless player has ignore tag or is in creative/spectator.
+execute if entity @s[tag=!gm4_undead_ignore,gamemode=!creative,gamemode=!spectator] run function gm4_undead_players:summon_zombie

--- a/gm4_undead_players/data/gm4_undead_players/functions/init.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/init.mcfunction
@@ -1,4 +1,9 @@
+# Add death tracking scoreboard and reset in case player died while module was disabled.
 scoreboard objectives add gm4_undead minecraft.custom:minecraft.deaths
+scoreboard players reset * gm4_undead
+
+# Add scoreboard used to implement custom logic for undead player drowned conversion.
+scoreboard objectives add gm4_undead_drown dummy
 
 execute unless score undead_players gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Undead Players"}
 scoreboard players set undead_players gm4_modules 1

--- a/gm4_undead_players/data/gm4_undead_players/functions/init_drowned.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/init_drowned.mcfunction
@@ -1,0 +1,22 @@
+#run from gm4_undead_players:summon_drowned
+#@s = newly spawned drowned player
+
+# Copy the player name attribute from the undead player.
+data modify storage gm4_undead_players:temp name_attribute set from storage gm4_undead_players:temp zombie_data.Attributes[{Name:"minecraft:generic.movement_speed"}].Modifiers[{UUID:[I;-582529518,-1683337792,-1808566840,504901848]}]
+
+# If the undead player was from a previous version, it will not have the name attribute.
+execute unless data storage gm4_undead_players:temp name_attribute run data modify storage gm4_undead_players:temp drowned_data set value {CustomName:'{"translate":"%1$s%3427655$s","with":["Drowned Player",{"translate":"entity.gm4.drowned_player"}]}'}
+
+# Otherwise, generate the drowned name ("Drowned <Name>") based on the name attribute.
+execute if data storage gm4_undead_players:temp name_attribute run function gm4_undead_players:set_drowned_name
+
+# Copy other tags from the zombie to the drowned.
+data modify storage gm4_undead_players:temp drowned_data.ArmorItems set from storage gm4_undead_players:temp zombie_data.ArmorItems
+data modify storage gm4_undead_players:temp drowned_data.HandItems set from storage gm4_undead_players:temp zombie_data.HandItems
+
+# Update the drowned based on the contents of storage.
+data modify entity @s {} merge from storage gm4_undead_players:temp drowned_data
+data remove storage gm4_undead_players:temp drowned_data
+
+# Remove the temporary "new" tag from the drowned.
+tag @s remove gm4_undead_players_new

--- a/gm4_undead_players/data/gm4_undead_players/functions/init_drowned.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/init_drowned.mcfunction
@@ -19,4 +19,4 @@ data modify entity @s {} merge from storage gm4_undead_players:temp drowned_data
 data remove storage gm4_undead_players:temp drowned_data
 
 # Remove the temporary "new" tag from the drowned.
-tag @s remove gm4_undead_players_new
+tag @s remove gm4_undead_player_new

--- a/gm4_undead_players/data/gm4_undead_players/functions/init_zombie.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/init_zombie.mcfunction
@@ -1,0 +1,17 @@
+#run from gm4_undead_players:summon_zombie
+#@s = newly spawned undead player
+
+# Store the original player name in an attribute modifier to be referenced in generating a
+# drowned undead player name ("Drowned <Name>" rather than "Undead <Name>").
+data modify storage gm4_undead_players:temp name_attribute set value {UUID:[I;-582529518,-1683337792,-1808566840,504901848],Operation:0,Amount:0d}
+data modify storage gm4_undead_players:temp name_attribute.Name set from entity @s ArmorItems[3].tag.SkullOwner.Name
+data modify entity @s Attributes[{Name:"minecraft:generic.movement_speed"}].Modifiers append from storage gm4_undead_players:temp name_attribute
+
+# Use an item modifier to generate the undead player's CustomName ("Undead <Name>").
+item modify entity @s armor.head gm4_undead_players:zombie_name
+data modify entity @s CustomName set from entity @s ArmorItems[3].tag.display.Name
+data remove storage gm4_undead_players:temp name_attribute
+
+# Clear the temporary item from the undead player's hand and remove the temporary "new" tag.
+tag @s remove gm4_undead_player_new
+item replace entity @s armor.head with air

--- a/gm4_undead_players/data/gm4_undead_players/functions/main.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/main.mcfunction
@@ -1,3 +1,2 @@
-execute as @a[scores={gm4_undead=1..}] at @s run function gm4_undead_players:died
-
 schedule function gm4_undead_players:main 16t
+execute as @e[type=zombie,tag=gm4_undead_player] run function gm4_undead_players:check_drowning

--- a/gm4_undead_players/data/gm4_undead_players/functions/main.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/main.mcfunction
@@ -1,2 +1,2 @@
 schedule function gm4_undead_players:main 16t
-execute as @e[type=zombie,tag=gm4_undead_player] run function gm4_undead_players:check_drowning
+execute as @e[type=zombie,tag=gm4_undead_player,nbt=!{DrownedConversionTime:-1}] run function gm4_undead_players:process_drowning

--- a/gm4_undead_players/data/gm4_undead_players/functions/process_drowning.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/process_drowning.mcfunction
@@ -1,5 +1,8 @@
-#run from gm4_undead_players:check_drowning
+#run from gm4_undead_players:main
 #@s = undead player who is undergoing drowned conversion
+
+# Store DrownedConversionTime in a temporary scoreboard to use in calculations.
+execute store result score #conversion_time gm4_undead_drown run data get entity @s DrownedConversionTime
 
 # Initialize drowning score to (15s * 20t/s) if the zombie just started drowning.
 execute unless score @s gm4_undead_drown = @s gm4_undead_drown run scoreboard players set @s gm4_undead_drown 300

--- a/gm4_undead_players/data/gm4_undead_players/functions/process_drowning.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/process_drowning.mcfunction
@@ -1,0 +1,16 @@
+#run from gm4_undead_players:check_drowning
+#@s = undead player who is undergoing drowned conversion
+
+# Initialize drowning score to (15s * 20t/s) if the zombie just started drowning.
+execute unless score @s gm4_undead_drown = @s gm4_undead_drown run scoreboard players set @s gm4_undead_drown 300
+
+# Calculate how much the zombie has drowned since the last call to this function.
+scoreboard players set #conversion_diff gm4_undead_drown 300
+scoreboard players operation #conversion_diff gm4_undead_drown -= #conversion_time gm4_undead_drown
+scoreboard players operation @s gm4_undead_drown -= #conversion_diff gm4_undead_drown
+
+# Reset the zombie's DrownedConversionTime so it doesn't drown naturally.
+execute if score @s gm4_undead_drown matches 0.. run data modify entity @s DrownedConversionTime set value 300
+
+# The conversion is now complete; spawn a new drowned and copy the zombie's data.
+execute if score @s gm4_undead_drown matches ..-1 at @s run function gm4_undead_players:summon_drowned

--- a/gm4_undead_players/data/gm4_undead_players/functions/set_drowned_name.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/set_drowned_name.mcfunction
@@ -1,0 +1,13 @@
+#run from gm4_undead_players:init_drowned
+#@s = newly spawned drowned player
+
+# Generate name for entity ("Drowned <Name>") based on the contents of the name attribute.
+loot replace entity @s armor.head loot gm4_undead_players:drowned_name
+data modify storage gm4_undead_players:temp drowned_data.CustomName set from entity @s ArmorItems[3].tag.display.Name
+
+# Copy player name attribute to the drowned (just in case it is needed for future update).
+data modify entity @s Attributes[{Name:"minecraft:generic.movement_speed"}].Modifiers append from storage gm4_undead_players:temp name_attribute
+data remove storage gm4_undead_players:temp name_attribute
+
+# Clear the temporary item from the drowned.
+item replace entity @s armor.head with air

--- a/gm4_undead_players/data/gm4_undead_players/functions/summon_drowned.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/summon_drowned.mcfunction
@@ -1,0 +1,13 @@
+#run from gm4_undead_players:process_drowning
+#@s = undead player who is being converted into a drowned
+
+# Copy the zombie's NBT to storage, then kill the zombie instantly and without drops.
+data modify storage gm4_undead_players:temp zombie_data set from entity @s
+data merge entity @s {Health:0f,DeathTime:19s}
+
+# Summon the drowned and initialize it based on the contents of storage. 
+summon drowned ~ ~ ~ {Tags:["gm4_undead_player","gm4_undead_player_new"],PersistenceRequired:1b,CustomNameVisible:1b,ArmorDropChances:[1f,1f,1f,1f],HandDropChances:[1f,1f]}
+execute as @e[type=drowned,tag=gm4_undead_player_new,distance=0,limit=1] run function gm4_undead_players:init_drowned
+
+# Clear storage to avoid deep comparison when this function is next called.
+data remove storage gm4_undead_players:temp zombie_data

--- a/gm4_undead_players/data/gm4_undead_players/functions/summon_drowned.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/summon_drowned.mcfunction
@@ -3,6 +3,7 @@
 
 # Copy the zombie's NBT to storage, then kill the zombie instantly and without drops.
 data modify storage gm4_undead_players:temp zombie_data set from entity @s
+teleport @s ~ -10000 ~
 data merge entity @s {Health:0f,DeathTime:19s}
 
 # Summon the drowned and initialize it based on the contents of storage. 

--- a/gm4_undead_players/data/gm4_undead_players/functions/summon_zombie.mcfunction
+++ b/gm4_undead_players/data/gm4_undead_players/functions/summon_zombie.mcfunction
@@ -1,0 +1,14 @@
+#run from gm4_undead_players:died
+#@s = player who has died and is not excluded from undead player spawning (via tag or gamemode)
+
+# Summon zombie to be initialized.
+summon zombie ~ ~1 ~ {CustomNameVisible:1,CanPickUpLoot:1b,PersistenceRequired:1b,Tags:["gm4_undead_player","gm4_undead_player_new"]}
+
+# Use a loot table to extract the player's username.
+loot replace entity @e[type=zombie,tag=gm4_undead_player_new,dy=2,limit=1] armor.head loot gm4_undead_players:player_head
+
+# Run a function as the zombie to initialize its NBT.
+execute as @e[type=zombie,tag=gm4_undead_player_new,dy=1,limit=1] run function gm4_undead_players:init_zombie
+
+# Grant the "Risen" advancement to the player.
+advancement grant @s only gm4:undead_players

--- a/gm4_undead_players/data/gm4_undead_players/item_modifiers/zombie_name.json
+++ b/gm4_undead_players/data/gm4_undead_players/item_modifiers/zombie_name.json
@@ -1,0 +1,27 @@
+{
+  "function": "minecraft:set_name",
+  "entity": "this",
+  "name": {
+    "translate": "%1$s%3427655$s",
+    "with": [
+      {
+        "text": "Undead ",
+        "extra": [
+          {
+            "storage": "gm4_undead_players:temp",
+            "nbt": "name_attribute.Name"
+          }
+        ]
+      },
+      {
+        "translate": "entity.gm4.undead_player_name",
+        "with": [
+          {
+            "storage": "gm4_undead_players:temp",
+            "nbt": "name_attribute.Name"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gm4_undead_players/data/gm4_undead_players/loot_tables/drowned_name.json
+++ b/gm4_undead_players/data/gm4_undead_players/loot_tables/drowned_name.json
@@ -1,0 +1,43 @@
+{
+  "type": "minecraft:generic",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:bow",
+          "functions": [
+            {
+              "function": "minecraft:set_name",
+              "entity": "this",
+              "name": {
+                "translate": "%1$s%3427655$s",
+                "with": [
+                  {
+                    "text": "Drowned ",
+                    "extra": [
+                      {
+                        "storage": "gm4_undead_players:temp",
+                        "nbt": "name_attribute.Name"
+                      }
+                    ]
+                  },
+                  {
+                    "translate": "entity.gm4.drowned_player_name",
+                    "with": [
+                      {
+                        "storage": "gm4_undead_players:temp",
+                        "nbt": "name_attribute.Name"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_undead_players/data/gm4_undead_players/loot_tables/player_head.json
+++ b/gm4_undead_players/data/gm4_undead_players/loot_tables/player_head.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:generic",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head",
+          "functions": [
+            {
+              "function": "minecraft:fill_player_head",
+              "entity": "this"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Bugfixes:
 - Undead player will no longer spawn in unusual locations (such as player respawn point). Using advancement triggers, it will now spawn *immediately* instead of up to 16 ticks late.

Enhancements:
 - Undead player name now includes the player name ("Undead Sparks").
 - Undead player that drowns will now keep armor and weapon.