### PR TITLE
Reveal invisible armour stands with "glow"

### DIFF
--- a/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/holding_book.mcfunction
+++ b/gm4_better_armour_stands/data/gm4_better_armour_stands/functions/holding_book.mcfunction
@@ -3,7 +3,7 @@
 # run from main
 
 # Reveal invisible armor_stand
-effect give @e[type=armor_stand,tag=!gm4_no_edit,distance=..8,nbt={Invisible:1b}] glowing 2 0
+execute if predicate gm4_better_armour_stands:holding_book_glow run effect give @e[type=armor_stand,tag=!gm4_no_edit,distance=..8,nbt={Invisible:1b}] glowing 2 0
 
 # Give arms to nearby armor_stand if holding book with "arms"
 execute if predicate gm4_better_armour_stands:holding_book_arms as @e[type=armor_stand,tag=!gm4_bas_no_arms,tag=!gm4_no_edit,distance=..4,nbt={ShowArms:0b}] at @s run function gm4_better_armour_stands:toggle/arms_detection

--- a/gm4_better_armour_stands/data/gm4_better_armour_stands/predicates/holding_book_glow.json
+++ b/gm4_better_armour_stands/data/gm4_better_armour_stands/predicates/holding_book_glow.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "mainhand": {
+        "items": [
+          "minecraft:writable_book"
+        ],
+        "nbt": "{pages:[\"glow\"]}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Instead of revealing invisible armour stands when holding a book and quill, the book now requires a page with "glow" to avoid revealing their locations when it's not needed