### PR TITLE
Particles Pack: Small update + fix for BAS update

### DIFF
--- a/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/apply_book.mcfunction
@@ -1,16 +1,15 @@
 # @s = armor_stand to be modified
-#run by the better armor stand base module
+# at @s
+# run from gm4_better_armour_stands/store_book_pages
 
-data modify entity @s[scores={gm4_particle=1..}] Invisible set value 0
-kill @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..1,limit=1,sort=nearest]
+scoreboard players operation $current gm4_particle = @s gm4_particle
 scoreboard players reset @s gm4_particle
+kill @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud,distance=..1,limit=1,sort=nearest]
 
 execute if data storage gm4_better_armour_stands:temp {pages:["heart"]} run scoreboard players set @s gm4_particle 1
 execute if data storage gm4_better_armour_stands:temp {pages:["flame"]} run scoreboard players set @s gm4_particle 2
 execute if data storage gm4_better_armour_stands:temp {pages:["barrier"]} run scoreboard players set @s gm4_particle 3
 execute if data storage gm4_better_armour_stands:temp {pages:["fireflies"]} run scoreboard players set @s gm4_particle 4
-execute if data storage gm4_better_armour_stands:temp {pages:["cloud"]} run scoreboard players set @s gm4_particle 5
-execute if data storage gm4_better_armour_stands:temp {pages:["bubbles"]} run scoreboard players set @s gm4_particle 6
 execute if data storage gm4_better_armour_stands:temp {pages:["growing"]} run scoreboard players set @s gm4_particle 7
 execute if data storage gm4_better_armour_stands:temp {pages:["drip"]} run scoreboard players set @s gm4_particle 8
 execute if data storage gm4_better_armour_stands:temp {pages:["winter"]} run scoreboard players set @s gm4_particle 9
@@ -22,9 +21,14 @@ execute if data storage gm4_better_armour_stands:temp {pages:["lava"]} run score
 execute if data storage gm4_better_armour_stands:temp {pages:["fiesta"]} run scoreboard players set @s gm4_particle 15
 execute if data storage gm4_better_armour_stands:temp {pages:["ender"]} run scoreboard players set @s gm4_particle 16
 execute if data storage gm4_better_armour_stands:temp {pages:["enchant"]} run scoreboard players set @s gm4_particle 17
+execute if data storage gm4_better_armour_stands:temp {pages:["note"]} run scoreboard players set @s gm4_particle 18
 
-execute if score @s gm4_particle matches 5 run summon area_effect_cloud ~ ~1 ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:cloud,Tags:["gm4_particles_pack_cloud"]}
-execute if score @s gm4_particle matches 6 run summon area_effect_cloud ~ ~1 ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:bubble,Tags:["gm4_particles_pack_cloud"]}
+execute if data storage gm4_better_armour_stands:temp {pages:["cloud"]} run scoreboard players set @s gm4_particle 100
+execute if data storage gm4_better_armour_stands:temp {pages:["bubbles"]} run scoreboard players set @s gm4_particle 101
 
-data modify entity @s[scores={gm4_particle=1..}] Invisible set value 1
+execute if score @s gm4_particle matches 100 run summon area_effect_cloud ~ ~ ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:cloud,Tags:["gm4_particles_pack_cloud"]}
+execute if score @s gm4_particle matches 101 run summon area_effect_cloud ~ ~ ~ {Duration:2147483647,Radius:1,RadiusOnUse:0,Particle:bubble,Tags:["gm4_particles_pack_cloud"]}
+
 tag @s[scores={gm4_particle=1..}] add gm4_bas_valid_code
+data merge entity @s[scores={gm4_particle=1..}] {Invisible:1b,NoGravity:1b}
+execute unless score @s gm4_particle matches 1.. run scoreboard players operation @s gm4_particle = $current gm4_particle

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/main.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/main.mcfunction
@@ -1,4 +1,4 @@
 execute as @e[type=armor_stand,scores={gm4_particle=1..}] at @s run function gm4_particles_pack:particle
-execute as @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud] at @s unless entity @e[type=armor_stand,scores={gm4_particle=1..},distance=..1] run kill @s
+execute as @e[type=area_effect_cloud,tag=gm4_particles_pack_cloud] at @s unless entity @e[type=armor_stand,scores={gm4_particle=100..},distance=..1] run kill @s
 
 schedule function gm4_particles_pack:main 16t

--- a/gm4_particles_pack/data/gm4_particles_pack/functions/particle.mcfunction
+++ b/gm4_particles_pack/data/gm4_particles_pack/functions/particle.mcfunction
@@ -1,11 +1,13 @@
 # @s = armorstand with a particle score
+# at @s
 # run from main
-execute if score @s gm4_particle matches 1 run particle minecraft:heart ~ ~2.0 ~ .2 0 .2 0 1
-execute if score @s gm4_particle matches 2 run particle minecraft:flame ~ ~.5 ~ 0 0 0 0 1 force
+
+execute if score @s gm4_particle matches 1 run particle minecraft:heart ~ ~.2 ~ .2 0 .2 0 1
+execute if score @s gm4_particle matches 2 run particle minecraft:flame ~ ~.15 ~ 0 0 0 0 1 force
 execute if score @s gm4_particle matches 3 run particle minecraft:barrier ~ ~.5 ~ 0 0 0 0 1
-execute if score @s gm4_particle matches 4 run particle minecraft:end_rod ~ ~.5 ~ 10 10 10 0 8 force
-execute if score @s gm4_particle matches 7 run particle minecraft:happy_villager ~ ~.5 ~ 2 0 2 0 1
-execute if score @s gm4_particle matches 8 run particle minecraft:dripping_water ~ ~.5 ~ 0.04 0 0.04 1 1
+execute if score @s gm4_particle matches 4 run particle minecraft:end_rod ~ ~ ~ 10 10 10 0 8 force
+execute if score @s gm4_particle matches 7 run particle minecraft:happy_villager ~ ~.3 ~ 2 .2 2 0 1
+execute if score @s gm4_particle matches 8 run particle minecraft:dripping_water ~ ~1 ~ 0.04 0 0.04 1 1
 execute if score @s gm4_particle matches 9 run particle minecraft:falling_dust minecraft:snow ~ ~4 ~ 2 1 2 0 5
 execute if score @s gm4_particle matches 10 run particle minecraft:falling_dust minecraft:pink_wool ~ ~4 ~ 2 1 2 0 5
 execute if score @s gm4_particle matches 11 run particle minecraft:falling_dust minecraft:orange_wool ~ ~4 ~ 2 1 2 0 2
@@ -14,5 +16,6 @@ execute if score @s gm4_particle matches 12 run particle minecraft:falling_dust 
 execute if score @s gm4_particle matches 13 run particle minecraft:falling_dust minecraft:black_wool ~ ~4 ~ 2 1 2 0 5
 execute if score @s gm4_particle matches 14 run particle minecraft:lava ~ ~ ~ 2 0 2 0 5
 execute if score @s gm4_particle matches 15 run particle minecraft:totem_of_undying ~ ~4 ~ 2 1 2 0 5
-execute if score @s gm4_particle matches 16 run particle minecraft:portal ~ ~1 ~ 0 0 0 1 5
-execute if score @s gm4_particle matches 17 run particle minecraft:enchant ~ ~1 ~ 0 0 0 1 5
+execute if score @s gm4_particle matches 16 run particle minecraft:portal ~ ~ ~ 0 0 0 1 5
+execute if score @s gm4_particle matches 17 run particle minecraft:enchant ~ ~ ~ 0 0 0 1 5
+execute if score @s gm4_particle matches 18 run particle minecraft:note ~ ~.5 ~ .2 .2 .2 1 1


### PR DESCRIPTION
- New particle: `note`.
- Editing the armour stand does not remove the particle anymore, to allow editing of the armour stand while keeping the particles, which is mostly useful while moving the armour stand, to position the particle more accurately.
- Changed some of the particle positions relative to the armour stand to keep them more consistently near the armour stand's feet.
- Particle clouds using AECs moved to a different scoreboard value to separate them from the "normal" particles.