### PR TITLE
Change Soaring from CMD 1 to CMD 2

### DIFF
--- a/gm4_orb_of_ankou/data/gm4/advancements/soaring_pneuma.json
+++ b/gm4_orb_of_ankou/data/gm4/advancements/soaring_pneuma.json
@@ -2,7 +2,7 @@
   "display": {
     "icon": {
       "item": "elytra",
-      "nbt": "{CustomModelData:3420001,Enchantments:[{}]}"
+      "nbt": "{CustomModelData:3420002,Enchantments:[{}]}"
     },
     "title": {
       "translate": "%1$s%3427655$s",


### PR DESCRIPTION
There was a conflict with OoA Soaring Advancement and End Fishing's End Phantom Advancement. This PR fixes that.