### PR TITLE
Add Animi

### DIFF
--- a/gm4_animi_shamir/data/gm4_animi_shamir/advancements/death.json
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/advancements/death.json
@@ -1,0 +1,33 @@
+{
+  "criteria": {
+    "death": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_scores",
+            "entity": "this",
+            "scores": {
+              "gm4_animi_deaths": 1
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_animi_shamir"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "gm4_animi_shamir:player/upon_death"
+  }
+}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/advancements/death.json
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/advancements/death.json
@@ -5,6 +5,18 @@
       "conditions": {
         "player": [
           {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "player": {
+                  "gamemode": "spectator"
+                }
+              }
+            }
+          },
+          {
             "condition": "minecraft:entity_scores",
             "entity": "this",
             "scores": {

--- a/gm4_animi_shamir/data/gm4_animi_shamir/advancements/join.json
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/advancements/join.json
@@ -1,0 +1,21 @@
+{
+    "criteria": {
+        "join_world": {
+            "trigger": "minecraft:location",
+            "conditions": {
+                "player": [
+                    {
+                        "condition": "minecraft:entity_scores",
+                        "entity": "this",
+                        "scores": {
+                            "gm4_animi_leave": 1
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "rewards": {
+        "function": "gm4_animi_shamir:player/rejoin"
+    }
+}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/check_item_validity.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/check_item_validity.mcfunction
@@ -1,0 +1,4 @@
+#@s = band is trying to apply to
+#run from #gm4_metallurgy:check_item_validity
+
+execute if entity @e[type=item,tag=gm4_ml_source,dx=0,nbt={Item:{tag:{gm4_metallurgy:{stored_shamir:"animi"}}}}] run function gm4_animi_shamir:mark_item_validity

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/init.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/init.mcfunction
@@ -1,11 +1,10 @@
 scoreboard objectives add gm4_animi_deaths deathCount
+scoreboard objectives add gm4_animi_leave minecraft.custom:minecraft.leave_game
 
 execute unless score animi_shamir gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Animi Shamir"}
 scoreboard players set animi_shamir gm4_modules 1
 
 # register shamir with lib_player_heads
 execute unless data storage gm4_player_heads:register heads[{id:"gm4_animi_shamir:band/v0"}] run data modify storage gm4_player_heads:register heads append value {id:"gm4_animi_shamir:band/v1",name:"[Drop to Fix Item] gm4_animi_shamir:band/v0",item:{gm4_metallurgy:{has_shamir:1b,stored_shamir:"animi",metal:{type:"curies_bismium",amount:[9s,3s],castable:1b},item:"obsidian_cast"},SkullOwner:{Id:[I;-1332644679,659216762,2108439484,664728976],Properties:{textures:[{Value:"ewogICJ0aW1lc3RhbXAiIDogMTYyODAyOTI2NzM2NiwKICAicHJvZmlsZUlkIiA6ICI3ZmIyOGQ1N2FhZmQ0MmQ1YTcwNWNlZjE4YWI1MzEzZiIsCiAgInByb2ZpbGVOYW1lIiA6ICJjaXJjdWl0MTAiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2MzMTBmZDk3YjFhN2Q3MDkwOGExODc2N2FjZmRjYzYwZDJhMTU1NTY5Zjk0YThmYjZhZWUxYTMzMWE5MjM4IgogICAgfQogIH0KfQ=="}]}},CustomModelData:3420117,display:{Name:'{"italic":false,"translate":"%1$s%3427655$s","with":["Obsidian Cast",{"translate":"item.gm4.metallurgy.obsidian_cast"}]}',Lore:['{"italic":false,"color":"#467A1B","translate":"%1$s%3427655$s","with":["Curie\'s Bismium Band",{"translate":"item.gm4.metallurgy.band","with":[{"translate":"item.gm4.metallurgy.curies_bismium"}]}]}','{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}','{"italic":false,"color":"gray","translate":"%1$s%3427655$s","with":["Animi",{"translate":"item.gm4.shamir.animi"}]}']}}}
-
-schedule function gm4_animi_shamir:tick 4t
 
 #$moduleUpdateList

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/init.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/init.mcfunction
@@ -1,0 +1,11 @@
+scoreboard objectives add gm4_animi_deaths deathCount
+
+execute unless score animi_shamir gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Animi Shamir"}
+scoreboard players set animi_shamir gm4_modules 1
+
+# register shamir with lib_player_heads
+execute unless data storage gm4_player_heads:register heads[{id:"gm4_animi_shamir:band/v0"}] run data modify storage gm4_player_heads:register heads append value {id:"gm4_animi_shamir:band/v1",name:"[Drop to Fix Item] gm4_animi_shamir:band/v0",item:{gm4_metallurgy:{has_shamir:1b,stored_shamir:"animi",metal:{type:"curies_bismium",amount:[9s,3s],castable:1b},item:"obsidian_cast"},SkullOwner:{Id:[I;-1332644679,659216762,2108439484,664728976],Properties:{textures:[{Value:"ewogICJ0aW1lc3RhbXAiIDogMTYyODAyOTI2NzM2NiwKICAicHJvZmlsZUlkIiA6ICI3ZmIyOGQ1N2FhZmQ0MmQ1YTcwNWNlZjE4YWI1MzEzZiIsCiAgInByb2ZpbGVOYW1lIiA6ICJjaXJjdWl0MTAiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2MzMTBmZDk3YjFhN2Q3MDkwOGExODc2N2FjZmRjYzYwZDJhMTU1NTY5Zjk0YThmYjZhZWUxYTMzMWE5MjM4IgogICAgfQogIH0KfQ=="}]}},CustomModelData:3420117,display:{Name:'{"italic":false,"translate":"%1$s%3427655$s","with":["Obsidian Cast",{"translate":"item.gm4.metallurgy.obsidian_cast"}]}',Lore:['{"italic":false,"color":"#467A1B","translate":"%1$s%3427655$s","with":["Curie\'s Bismium Band",{"translate":"item.gm4.metallurgy.band","with":[{"translate":"item.gm4.metallurgy.curies_bismium"}]}]}','{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}','{"italic":false,"color":"gray","translate":"%1$s%3427655$s","with":["Animi",{"translate":"item.gm4.shamir.animi"}]}']}}}
+
+schedule function gm4_animi_shamir:tick 4t
+
+#$moduleUpdateList

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/initialize_item.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/initialize_item.mcfunction
@@ -1,0 +1,13 @@
+# sets the item's data from cache
+# @s = @e[type=item,tag=gm4_respawned_animi_item,limit=1]
+# at owner player location
+# run from gm4_animi_shamir:item_caching/unpack_entry
+
+# set owner
+data modify entity @s Owner set from storage gm4_animi_shamir:cache prepared_entry.owner
+
+# copy NBT
+data modify entity @s Item set from storage gm4_animi_shamir:cache prepared_entry.inventory[0]
+
+# remove tag
+tag @s remove gm4_respawned_animi_item

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/add_entry.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/add_entry.mcfunction
@@ -1,0 +1,15 @@
+# adds a prepared entry to the cache
+# @s = a player who has died whilst carrying animi items
+# run from gm4_animi_shamir:player/upon_death
+
+# read player data
+data modify storage gm4_animi_shamir:cache prepared_entry.owner set from entity @s UUID
+
+# read inventory
+data modify storage gm4_animi_shamir:cache inventories append from storage gm4_animi_shamir:cache prepared_entry
+
+# remember that this player died with animi items
+tag @s add gm4_animi_user
+
+# sound
+playsound minecraft:particle.soul_escape player @a[distance=..8] ~ ~ ~ 1 0.7

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/add_entry.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/add_entry.mcfunction
@@ -13,3 +13,6 @@ tag @s add gm4_animi_user
 
 # sound
 playsound minecraft:particle.soul_escape player @a[distance=..8] ~ ~ ~ 1 0.7
+
+# wait for respawn
+function gm4_animi_shamir:player/wait_for_respawn

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/prepare_entry.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/prepare_entry.mcfunction
@@ -1,0 +1,13 @@
+# copies item data of items with animi shamir into cache and deletes them from the world after they were dropped by a dying player
+# @s = item with animi shamir, just dropped by a dying player
+# at location of dying player
+# run from gm4_animi_shamir:player/upon_death
+
+# add this item nbt to storage
+data modify storage gm4_animi_shamir:cache prepared_entry.inventory append from entity @s Item
+
+# visuals
+particle minecraft:soul ~ ~0.9 ~ 0.2 0.6 0.2 0.04 1
+
+# remove this item from the world
+kill @s

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/search_entry.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/search_entry.mcfunction
@@ -1,0 +1,19 @@
+# searches for an entry with owner = prepared_entry.owner. Stores the last match into prepared_entry.inventory. Deletes all duplicates.
+# run from gm4_animi_shamir:player/respawn_inventory
+
+# load target UUID into temp field
+data modify storage gm4_animi_shamir:cache temp_entry.owner set from storage gm4_animi_shamir:cache prepared_entry.owner
+
+# compare against UUID from list
+execute store result score $success gm4_animi_deaths run data modify storage gm4_animi_shamir:cache temp_entry.owner set from storage gm4_animi_shamir:cache inventories[0].owner
+
+# store entry into named field if a match is detected
+execute if score $success gm4_animi_deaths matches 0 run data modify storage gm4_animi_shamir:cache prepared_entry.inventory set from storage gm4_animi_shamir:cache inventories[0].inventory
+
+# cycle entries and delete entry if UUID matched
+execute if score $success gm4_animi_deaths matches 1.. run data modify storage gm4_animi_shamir:cache inventories append from storage gm4_animi_shamir:cache inventories[0]
+data remove storage gm4_animi_shamir:cache inventories[0]
+
+# loop until all entries are checked
+scoreboard players remove $loop gm4_animi_deaths 1
+execute if score $loop gm4_animi_deaths matches 1.. run function gm4_animi_shamir:item_caching/search_entry

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/unpack_entry.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/item_caching/unpack_entry.mcfunction
@@ -1,0 +1,16 @@
+# unpacks prepared_entry into items by summoning one item for each elements in prepared_entry.inventory
+# @s = player who has died recently
+# at @s
+# run from gm4_animi_shamir:player/respawn_inventory
+
+# summon item and populate item NBT
+summon item ~ ~ ~ {Tags:["gm4_respawned_animi_item"],PickupDelay:0s,Item:{Count:1b,id:"minecraft:stone"}}
+execute as @e[type=item,tag=gm4_respawned_animi_item,limit=1] run function gm4_animi_shamir:initialize_item
+
+# visuals
+particle minecraft:soul ~ ~0.9 ~ 0.2 0.6 0.2 0.04 1
+
+# shift pointer forwards and loop
+data remove storage gm4_animi_shamir:cache prepared_entry.inventory[0]
+scoreboard players remove $loop gm4_animi_deaths 1
+execute if score $loop gm4_animi_deaths matches 1.. run function gm4_animi_shamir:item_caching/unpack_entry

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/load.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/load.mcfunction
@@ -3,4 +3,3 @@ execute unless score gm4 load.status matches 1 run data modify storage gm4:log q
 execute unless score gm4_metallurgy load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Animi Shamir",require:"Metallurgy"}
 
 execute if score gm4_animi_shamir load.status matches 1 run function gm4_animi_shamir:init
-execute unless score gm4_animi_shamir load.status matches 1 run schedule clear gm4_animi_shamir:tick

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/load.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/load.mcfunction
@@ -1,0 +1,6 @@
+execute if score gm4 load.status matches 1 if score gm4_metallurgy load.status matches 1 run scoreboard players set gm4_animi_shamir load.status 1
+execute unless score gm4 load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Animi Shamir",require:"Gamemode 4"}
+execute unless score gm4_metallurgy load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Animi Shamir",require:"Metallurgy"}
+
+execute if score gm4_animi_shamir load.status matches 1 run function gm4_animi_shamir:init
+execute unless score gm4_animi_shamir load.status matches 1 run schedule clear gm4_animi_shamir:tick

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
@@ -1,5 +1,5 @@
 #@s = band is trying to apply to
 #run from check_item_validity
 
-# allow other modules to register their own compatible items
+# allow other modules to register their own compatible items and register tools and armor by default
 function #gm4_animi_shamir:mark_item_validity

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
@@ -1,4 +1,5 @@
 #@s = band is trying to apply to
 #run from check_item_validity
 
-execute store success score valid_item gm4_ml_data if entity @s[nbt={Item:{Count:1b}}]
+# allow other modules to register their own compatible items
+function #gm4_animi_shamir:mark_item_validity

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/mark_item_validity.mcfunction
@@ -1,0 +1,4 @@
+#@s = band is trying to apply to
+#run from check_item_validity
+
+execute store success score valid_item gm4_ml_data if entity @s[nbt={Item:{Count:1b}}]

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/rejoin.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/rejoin.mcfunction
@@ -1,0 +1,11 @@
+# Revokes advancement and restarts wait_for_respawn clock
+# @s = player that has re-joined with a gm4_animi_deaths score
+# at @s
+# run from advancement gm4_animi_shamir:join
+
+# reset advancement and score
+advancement revoke @s only gm4_animi_shamir:join
+scoreboard players reset @s gm4_animi_leave
+
+# if the player has a gm4_animi_deaths score, restart waiting_for_respawn clock
+execute if score @s gm4_animi_deaths matches 1.. run schedule function gm4_animi_shamir:player/wait_for_respawn 1t

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/respawn_inventory.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/respawn_inventory.mcfunction
@@ -1,0 +1,19 @@
+# respawns an animi item
+# @s = player who has died recently
+# at @s
+# run from gm4_animi_shamir:player/upon_respawn
+
+# look for entries in cache
+data modify storage gm4_animi_shamir:cache prepared_entry.owner set from entity @s UUID
+execute store result score $loop gm4_animi_deaths run data get storage gm4_animi_shamir:cache inventories
+function gm4_animi_shamir:item_caching/search_entry
+
+# summon item(s)
+execute store result score $loop gm4_animi_deaths run data get storage gm4_animi_shamir:cache prepared_entry.inventory
+function gm4_animi_shamir:item_caching/unpack_entry
+
+# sound
+playsound minecraft:particle.soul_escape player @a[distance=..8] ~ ~ ~ 1 0.7
+
+# remove tag
+tag @s remove gm4_animi_user

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/respawn_inventory.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/respawn_inventory.mcfunction
@@ -10,7 +10,7 @@ function gm4_animi_shamir:item_caching/search_entry
 
 # summon item(s)
 execute store result score $loop gm4_animi_deaths run data get storage gm4_animi_shamir:cache prepared_entry.inventory
-function gm4_animi_shamir:item_caching/unpack_entry
+execute if score $loop gm4_animi_deaths matches 1.. run function gm4_animi_shamir:item_caching/unpack_entry
 
 # sound
 playsound minecraft:particle.soul_escape player @a[distance=..8] ~ ~ ~ 1 0.7

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_death.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_death.mcfunction
@@ -1,0 +1,10 @@
+# @s = player who has died
+# at @s
+# run from gm4_animi_shamir:death advancement
+
+# compile item list
+data remove storage gm4_animi_shamir:cache prepared_entry
+execute positioned ~ ~1.6 ~ as @e[type=item,distance=..0.5,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{active_shamir:'animi'}}}}] run function gm4_animi_shamir:item_caching/prepare_entry
+
+# add entry to chache if any animi items were found
+execute if data storage gm4_animi_shamir:cache prepared_entry.inventory run function gm4_animi_shamir:item_caching/add_entry

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_death.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_death.mcfunction
@@ -4,7 +4,7 @@
 
 # compile item list
 data remove storage gm4_animi_shamir:cache prepared_entry
-execute positioned ~ ~1.6 ~ as @e[type=item,distance=..0.5,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{active_shamir:'animi'}}}}] run function gm4_animi_shamir:item_caching/prepare_entry
+execute positioned ~ ~0.66 ~ as @e[type=item,distance=..0.67,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{active_shamir:'animi'}}}}] run function gm4_animi_shamir:item_caching/prepare_entry
 
 # add entry to chache if any animi items were found
 execute if data storage gm4_animi_shamir:cache prepared_entry.inventory run function gm4_animi_shamir:item_caching/add_entry

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
@@ -1,7 +1,7 @@
 # runs once a player has respawned
 # @s a player that died and has now respawned
 # at @s
-# run from gm4_animi_shamir:tick
+# run from gm4_animi_shamir:player/wait_for_respawn
 
 # reset score and advancement
 advancement revoke @s only gm4_animi_shamir:death

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
@@ -8,4 +8,4 @@ advancement revoke @s only gm4_animi_shamir:death
 scoreboard players reset @s gm4_animi_deaths
 
 # return animi item(s) if this player had at least one animi item
-execute if entity @s[tag=gm4_animi_user] run function gm4_animi_shamir:player/respawn_inventory
+execute if entity @s[tag=gm4_animi_user,gamemode=!spectator] run function gm4_animi_shamir:player/respawn_inventory

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/upon_respawn.mcfunction
@@ -1,0 +1,11 @@
+# runs once a player has respawned
+# @s a player that died and has now respawned
+# at @s
+# run from gm4_animi_shamir:tick
+
+# reset score and advancement
+advancement revoke @s only gm4_animi_shamir:death
+scoreboard players reset @s gm4_animi_deaths
+
+# return animi item(s) if this player had at least one animi item
+execute if entity @s[tag=gm4_animi_user] run function gm4_animi_shamir:player/respawn_inventory

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/wait_for_respawn.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/wait_for_respawn.mcfunction
@@ -1,0 +1,10 @@
+# Active if a player died with an animi item. Self-schedules until that player either logs out or respawns.
+# @s = none
+# at world spawn
+# self schduled or run from gm4_animi_shamir:item_caching/add_entry or gm4_animi_shamir:player/rejoin
+
+# look for players that just respawned (@e only selects living entities)
+execute as @e[type=player,scores={gm4_animi_deaths=1..}] at @s run function gm4_animi_shamir:player/upon_respawn
+
+# reschedule if there is a player (dead or alive) with a gm4_animi_deaths score (@a also selects dead players)
+execute if entity @p[scores={gm4_animi_deaths=1..}] run schedule function gm4_animi_shamir:player/wait_for_respawn 1t

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_17.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_17.mcfunction
@@ -1,0 +1,5 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_i_19
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:compass"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:trident"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_18.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_18.mcfunction
@@ -1,0 +1,7 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_i_19
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_axe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:crossbow"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:spyglass"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_19.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_19.mcfunction
@@ -1,0 +1,5 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_i_19
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_axe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_20.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_20.mcfunction
@@ -1,0 +1,9 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_20_22
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_axe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_axe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_sword"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_20_22.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_20_22.mcfunction
@@ -1,0 +1,7 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_start
+
+# split at ~25%
+execute if score $len gm4_animi_deaths matches 20 run function gm4_animi_shamir:smooshing/tree_20
+execute if score $len gm4_animi_deaths matches 21 run function gm4_animi_shamir:smooshing/tree_21
+execute if score $len gm4_animi_deaths matches 22 run function gm4_animi_shamir:smooshing/tree_22

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_21.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_21.mcfunction
@@ -2,6 +2,7 @@
 # run from gm4_animi_shamir:smooshing/tree_20_22
 
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_hoe"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_axe"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_sword"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_21.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_21.mcfunction
@@ -1,0 +1,8 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_20_22
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_axe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_sword"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:fishing_rod"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_22.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_22.mcfunction
@@ -1,0 +1,8 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_20_22
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_pickaxe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_sword"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_sword"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23.mcfunction
@@ -4,6 +4,7 @@
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_boots"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:turtle_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_shovel"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_shovel"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23.mcfunction
@@ -1,0 +1,13 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_23_24
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:turtle_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_hoe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:stone_pickaxe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_axe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_sword"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23_24.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_23_24.mcfunction
@@ -1,0 +1,6 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_start
+
+# split at ~25%
+execute if score $len gm4_animi_deaths matches 23 run function gm4_animi_shamir:smooshing/tree_23
+execute if score $len gm4_animi_deaths matches 24 run function gm4_animi_shamir:smooshing/tree_24

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
@@ -3,5 +3,6 @@
 
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_pickaxe"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_pickaxe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
@@ -1,0 +1,12 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_23_24
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_pickaxe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_pickaxe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_24.mcfunction
@@ -2,11 +2,6 @@
 # run from gm4_animi_shamir:smooshing/tree_23_24
 
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_shovel"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_pickaxe"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:wooden_pickaxe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25.mcfunction
@@ -1,0 +1,10 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_25_i
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:iron_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_boots"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_pickaxe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_sword"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:flint_and_steel"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25_i.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25_i.mcfunction
@@ -3,5 +3,6 @@
 
 # split at ~25%
 execute if score $len gm4_animi_deaths matches 25 run function gm4_animi_shamir:smooshing/tree_25
-execute if score $len gm4_animi_deaths matches 26..27 run function gm4_animi_shamir:smooshing/tree_26_27
+execute if score $len gm4_animi_deaths matches 26 run function gm4_animi_shamir:smooshing/tree_26
+execute if score $len gm4_animi_deaths matches 27 run function gm4_animi_shamir:smooshing/tree_27
 execute if score $len gm4_animi_deaths matches 28.. run function gm4_animi_shamir:smooshing/tree_28_i

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25_i.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_25_i.mcfunction
@@ -1,0 +1,7 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_start
+
+# split at ~25%
+execute if score $len gm4_animi_deaths matches 25 run function gm4_animi_shamir:smooshing/tree_25
+execute if score $len gm4_animi_deaths matches 26..27 run function gm4_animi_shamir:smooshing/tree_26_27
+execute if score $len gm4_animi_deaths matches 28.. run function gm4_animi_shamir:smooshing/tree_28_i

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26.mcfunction
@@ -6,5 +6,3 @@ execute unless score valid_item gm4_ml_data matches 1 store success score valid_
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_shovel"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_chestplate"}
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_pickaxe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26_27.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26_27.mcfunction
@@ -1,0 +1,9 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_25_i
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_shovel"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_pickaxe"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26_27.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_26_27.mcfunction
@@ -2,6 +2,7 @@
 # run from gm4_animi_shamir:smooshing/tree_25_i
 
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_helmet"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_helmet"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_shovel"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_27.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_27.mcfunction
@@ -1,0 +1,6 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_25_i
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:golden_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_pickaxe"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:carrot_on_a_stick"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_28_i.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_28_i.mcfunction
@@ -6,3 +6,4 @@ execute unless score valid_item gm4_ml_data matches 1 store success score valid_
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_leggings"}
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:warped_fungus_on_a_stick"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_28_i.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_28_i.mcfunction
@@ -1,0 +1,8 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_25_i
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:diamond_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:leather_chestplate"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:netherite_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_leggings"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:chainmail_chestplate"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_i_16.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_i_16.mcfunction
@@ -1,0 +1,8 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_i_19
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:bow"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:clock"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:elytra"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:shears"}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data storage gm4_animi_shamir:smooshing/target_item {id:"minecraft:shield"}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_i_19.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_i_19.mcfunction
@@ -1,0 +1,8 @@
+# quaternary search tree based on string length
+# run from gm4_animi_shamir:smooshing/tree_start
+
+# split at ~25%
+execute if score $len gm4_animi_deaths matches ..16 run function gm4_animi_shamir:smooshing/tree_i_16
+execute if score $len gm4_animi_deaths matches 17 run function gm4_animi_shamir:smooshing/tree_17
+execute if score $len gm4_animi_deaths matches 18 run function gm4_animi_shamir:smooshing/tree_18
+execute if score $len gm4_animi_deaths matches 19 run function gm4_animi_shamir:smooshing/tree_19

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_start.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/smooshing/tree_start.mcfunction
@@ -1,0 +1,18 @@
+# start of a binary search tree based on string length
+# run from #gm4_animi_shamir:mark_item_validity
+
+# obtain item id
+data modify storage gm4_animi_shamir:smooshing/target_item id set from entity @s Item.id
+
+# obtain id length
+scoreboard players reset $len gm4_animi_deaths
+execute store result score $len gm4_animi_deaths run data get storage gm4_animi_shamir:smooshing/target_item id
+
+# split at ~25%
+execute if score $len gm4_animi_deaths matches ..19 run function gm4_animi_shamir:smooshing/tree_i_19
+execute if score $len gm4_animi_deaths matches 20..22 run function gm4_animi_shamir:smooshing/tree_20_22
+execute if score $len gm4_animi_deaths matches 23..24 run function gm4_animi_shamir:smooshing/tree_23_24
+execute if score $len gm4_animi_deaths matches 25.. run function gm4_animi_shamir:smooshing/tree_25_i
+
+# reset storage
+data remove storage gm4_animi_shamir:smooshing/target_item id

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/summon_band.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/summon_band.mcfunction
@@ -1,0 +1,4 @@
+# @s = a mould with matching metal inside
+#run from metallurgy:casting/summon_band/template via #gm4_metallurgy:summon_band/template
+
+loot spawn ~ ~ ~ loot gm4_animi_shamir:band

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/tick.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/tick.mcfunction
@@ -1,0 +1,4 @@
+schedule function gm4_animi_shamir:tick 1t
+
+# look for players that just respawned
+execute as @e[type=player,scores={gm4_animi_deaths=1..}] at @s run function gm4_animi_shamir:player/upon_respawn

--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/tick.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/tick.mcfunction
@@ -1,4 +1,0 @@
-schedule function gm4_animi_shamir:tick 1t
-
-# look for players that just respawned
-execute as @e[type=player,scores={gm4_animi_deaths=1..}] at @s run function gm4_animi_shamir:player/upon_respawn

--- a/gm4_animi_shamir/data/gm4_animi_shamir/loot_tables/band.json
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/loot_tables/band.json
@@ -1,0 +1,36 @@
+{
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:loot_table",
+					"name": "gm4_metallurgy:curies_bismium_band",
+					"functions": [
+						{
+							"function": "minecraft:set_nbt",
+							"tag": "{CustomModelData:3420124,SkullOwner:{Name:\"[Drop to Fix Item] gm4_animi_shamir:band/v0\"},gm4_metallurgy:{stored_shamir:\"animi\"}}"
+						},
+						{
+							"function": "minecraft:set_lore",
+							"replace": false,
+							"lore": [
+								{
+									"translate": "%1$s%3427655$s",
+									"with": [
+										"Animi",
+										{
+											"translate": "item.gm4.shamir.animi"
+										}
+									],
+									"italic": false,
+									"color": "gray"
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/gm4_animi_shamir/data/gm4_animi_shamir/tags/functions/mark_item_validity.json
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/tags/functions/mark_item_validity.json
@@ -1,0 +1,5 @@
+{
+    "values":[
+        "gm4_animi_shamir:smooshing/tree_start"
+    ]
+}

--- a/gm4_animi_shamir/data/gm4_metallurgy/tags/functions/check_item_validity.json
+++ b/gm4_animi_shamir/data/gm4_metallurgy/tags/functions/check_item_validity.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"gm4_animi_shamir:check_item_validity"
+	]
+}

--- a/gm4_animi_shamir/data/gm4_metallurgy/tags/functions/summon_band/curies_bismium.json
+++ b/gm4_animi_shamir/data/gm4_metallurgy/tags/functions/summon_band/curies_bismium.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"gm4_animi_shamir:summon_band"
+	]
+}

--- a/gm4_animi_shamir/data/load/tags/functions/gm4_animi_shamir.json
+++ b/gm4_animi_shamir/data/load/tags/functions/gm4_animi_shamir.json
@@ -1,0 +1,6 @@
+{
+	"values": [
+		{ "id": "#load:gm4_metallurgy", "required": false },
+		"gm4_animi_shamir:load"
+	]
+}

--- a/gm4_animi_shamir/data/load/tags/functions/load.json
+++ b/gm4_animi_shamir/data/load/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"#load:gm4_animi_shamir"
+	]
+}

--- a/gm4_animi_shamir/pack.mcmeta
+++ b/gm4_animi_shamir/pack.mcmeta
@@ -1,0 +1,34 @@
+{
+	"pack": {
+		"pack_format": 7,
+		"description": [
+			"Animi Shamir",
+			"\n",
+			{
+				"text": "Gamemode 4 for 1.17",
+				"color": "#4AA0C7"
+			}
+		]
+	},
+	"module_name": "Animi Shamir",
+	"module_id": "animi_shamir",
+	"hidden": false,
+	"site_description": "Adds the Animi Shamir to Metallurgy. Items with Animi will persist through death.",
+	"site_categories": [
+		"Metallurgy"
+	],
+	"video_link": "",
+	"wiki_link": "https://wiki.gm4.co/wiki/Metallurgy/Vecto_Shamir",
+	"required_modules": [
+		"metallurgy"
+	],
+	"recommended_modules": [],
+	"credits": {
+		"Creator": [
+			[
+				"Bloo",
+				"https://www.twitter.com/Bloo_dev"
+			]
+		]
+	}
+}

--- a/gm4_animi_shamir/pack.mcmeta
+++ b/gm4_animi_shamir/pack.mcmeta
@@ -13,12 +13,12 @@
 	"module_name": "Animi Shamir",
 	"module_id": "animi_shamir",
 	"hidden": false,
-	"site_description": "Adds the Animi Shamir to Metallurgy. Items with Animi will persist through death.",
+	"site_description": "Adds the Animi Shamir to Metallurgy. Items with Animi will respawn with you after you died!",
 	"site_categories": [
 		"Metallurgy"
 	],
 	"video_link": "",
-	"wiki_link": "https://wiki.gm4.co/wiki/Metallurgy/Vecto_Shamir",
+	"wiki_link": "https://wiki.gm4.co/wiki/Metallurgy/Animi_Shamir",
 	"required_modules": [
 		"metallurgy"
 	],


### PR DESCRIPTION
### Features
Animi is a Shamir for Metallurgy that makes items "soulbound". Items with Animi behave differently upon the player's death:
- Instead of being dropped, they are respawned with the player.
- Animi can be applied to all tools and armor, and other modules may register their own items by use of the function tag `#gm4_animi_shamir:mark_item_validity`.

When a player dies carrying Animi items, a soul particle is played for each Animi item (technically stack) in the player's inventory.

### Technical Details
This implementation uses `storage` to cache the player's items between death and respawning. However, this means that player NBT has to be read to obtain the player's `UUID` to create an index list in storage. These reads are only executed if a player dies with an Animi item.
At the time of advancement execution the player's inventory is already dropped and no longer available in NBT form. This has two consequences:
   **1.** The items can not be read from player NBT and must therefore be targeted as entities.
   **2.** Targeting the items as entities could potentially be unsafe, however, I've never noticed an item escaping undetected.

On the topic of **2.**: An undetected item would not result in a duplication glitch, as undetected items never make it into the item cache in storage. This means an undetected Animi item will simply drop like normal instead of being respawned with the player.

### Limitations
Animi does not generally preserve inventory sorting, as the items are no longer available in the player's NBT upon advancement reward execution. This implementation can not be adjusted to preserve sorting as that information is lost upon the player's death (when the items are dropped in entity form).
However, upon death players naturally drop items in ordef of inventory slots. This results in a fixed pickup order due to `arbitrary` item selection. Hence items will somewhat respect inventory order but will not reassemble the pre-death layout completely.