### PR TITLE
Crossbow Cartridges: Tripwire hook endpoint

### DIFF
--- a/gm4_crossbow_cartridges/data/gm4/advancements/crossbow_cartridges_string.json
+++ b/gm4_crossbow_cartridges/data/gm4/advancements/crossbow_cartridges_string.json
@@ -1,7 +1,7 @@
 {
     "display": {
         "icon": {
-            "item": "string",
+            "item": "minecraft:tripwire_hook",
             "nbt": "{CustomModelData:3420001}"
         },
         "title": {
@@ -16,7 +16,7 @@
         "description": {
             "translate": "%1$s%3427655$s",
             "with": [
-                "Create a 40-block long tripwire line using a crossbow",
+                "Create a 40-block long tripwire circuit using a crossbow",
                 {
                     "translate": "advancement.gm4.crossbow_cartridges_string.description"
                 }

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/place_hook.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/place_hook.mcfunction
@@ -12,5 +12,8 @@ execute if block ~ ~ ~-1 minecraft:tripwire[north=true,attached=false] if block 
 playsound minecraft:block.stone.place block @a[distance=..15]
 clear @s[gamemode=!creative] minecraft:tripwire_hook 1
 
+# reset string count
+scoreboard players set @s gm4_cb_strcount 0
+
 # 40 block long tripwire advancement
 execute if score @s gm4_cb_strplace matches 40 run advancement grant @s only gm4:crossbow_cartridges_string

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/place_hook.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/place_hook.mcfunction
@@ -1,0 +1,16 @@
+# Place tripwire hook at end of tripwire
+# @s = player using the crossbow
+# at @s align xyz positioned ~0.5 ~ ~0.5, up to 40 blocks in one of the cardinal directions
+# run from cables/unspool_string
+
+# check direction and place tripwire hook
+execute if block ~1 ~ ~ minecraft:tripwire[east=true,attached=false] if block ~-1 ~ ~ #gm4:full_collision run setblock ~ ~ ~ minecraft:tripwire_hook[facing=east] destroy
+execute if block ~-1 ~ ~ minecraft:tripwire[west=true,attached=false] if block ~1 ~ ~ #gm4:full_collision run setblock ~ ~ ~ minecraft:tripwire_hook[facing=west] destroy
+execute if block ~ ~ ~1 minecraft:tripwire[south=true,attached=false] if block ~ ~ ~-1 #gm4:full_collision run setblock ~ ~ ~ minecraft:tripwire_hook[facing=south] destroy
+execute if block ~ ~ ~-1 minecraft:tripwire[north=true,attached=false] if block ~ ~ ~1 #gm4:full_collision run setblock ~ ~ ~ minecraft:tripwire_hook[facing=north] destroy
+
+playsound minecraft:block.stone.place block @a[distance=..15]
+clear @s[gamemode=!creative] minecraft:tripwire_hook 1
+
+# 40 block long tripwire advancement
+execute if score @s gm4_cb_strplace matches 40 run advancement grant @s only gm4:crossbow_cartridges_string

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/shoot_arrow.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/shoot_arrow.mcfunction
@@ -9,7 +9,10 @@ tag @s add gm4_cb_use
 execute store result score @s gm4_cb_strcount run clear @s minecraft:string 0
 execute if score @s gm4_cb_strcount matches 40.. run scoreboard players set @s gm4_cb_strcount 40
 
-# reset scoreboard to 0
+# check for tripwire hook on the player
+execute store success score @s gm4_cb_hookcount run clear @s minecraft:tripwire_hook 0
+
+# reset score for string placed 
 scoreboard players set @s gm4_cb_strplace 0
 
 # check direction if player is looking at horizon, with a tripwire hook at their feet or eye level

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/unspool_string.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/cables/unspool_string.mcfunction
@@ -15,8 +15,8 @@ scoreboard players add @s gm4_cb_strplace 1
 # kill arrow
 execute if score @s gm4_cb_strplace matches 1 run kill @e[type=minecraft:arrow,tag=gm4_cb_arrow,distance=..2,limit=1,sort=nearest]
 
-# 40 block long tripwire advancement
-execute if score @s gm4_cb_strplace matches 40 run advancement grant @s only gm4:crossbow_cartridges_string
+# place hook if possible
+execute if score @s gm4_cb_hookcount matches 1 if block ^ ^ ^2 #gm4:full_collision positioned ^ ^ ^1 if block ~ ~ ~ #gm4_crossbow_cartridges:string_replaceable run function gm4_crossbow_cartridges:cables/place_hook
 
 # recursion
-execute positioned ^ ^ ^1 if block ~ ~ ~ #gm4_crossbow_cartridges:string_replaceable unless score @s gm4_cb_strcount matches 0 run function gm4_crossbow_cartridges:cables/unspool_string
+execute unless score @s gm4_cb_strcount matches 0 positioned ^ ^ ^1 if block ~ ~ ~ #gm4_crossbow_cartridges:string_replaceable run function gm4_crossbow_cartridges:cables/unspool_string

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/init.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/functions/init.mcfunction
@@ -1,3 +1,4 @@
+scoreboard objectives add gm4_cb_hookcount dummy
 scoreboard objectives add gm4_cb_strcount dummy
 scoreboard objectives add gm4_cb_strplace dummy
 


### PR DESCRIPTION
A tripwire hook will be placed at the end of the tripwire, against a solid block, if the player has a tripwire hook in their inventory.
The advancement for placing 40 tripwire has been adjusted for this to include the tripwire hook.