### PR TITLE
[Guidebook] Future-Proof Technical Advancements

### DIFF
--- a/gm4_guidebook/data/gm4_guidebook/advancements/first_join.json
+++ b/gm4_guidebook/data/gm4_guidebook/advancements/first_join.json
@@ -1,7 +1,35 @@
 {
   "criteria": {
     "requirement": {
-      "trigger": "minecraft:tick"
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$giveNewPlayers"
+              },
+              "score": "gm4_guide_config"
+            },
+            "range": 1
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
+      }
     }
   },
   "rewards": {

--- a/gm4_guidebook/data/gm4_guidebook/advancements/loot_village_chest.json
+++ b/gm4_guidebook/data/gm4_guidebook/advancements/loot_village_chest.json
@@ -3,97 +3,321 @@
     "armorer": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_armorer"
+        "loot_table": "minecraft:chests/village/village_armorer",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "butcher": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_butcher"
+        "loot_table": "minecraft:chests/village/village_butcher",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "cartographer": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_cartographer"
+        "loot_table": "minecraft:chests/village/village_cartographer",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "desert_house": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_desert_house"
+        "loot_table": "minecraft:chests/village/village_desert_house",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "fisher": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_fisher"
+        "loot_table": "minecraft:chests/village/village_fisher",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "fletcher": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_fletcher"
+        "loot_table": "minecraft:chests/village/village_fletcher",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "mason": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_mason"
+        "loot_table": "minecraft:chests/village/village_mason",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "plains_house": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_plains_house"
+        "loot_table": "minecraft:chests/village/village_plains_house",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "savanna_house": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_savanna_house"
+        "loot_table": "minecraft:chests/village/village_savanna_house",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "shepherd": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_shepherd"
+        "loot_table": "minecraft:chests/village/village_shepherd",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "snowy_house": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_snowy_house"
+        "loot_table": "minecraft:chests/village/village_snowy_house",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "taiga_house": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_taiga_house"
+        "loot_table": "minecraft:chests/village/village_taiga_house",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "tannery": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_tannery"
+        "loot_table": "minecraft:chests/village/village_tannery",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "temple": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_temple"
+        "loot_table": "minecraft:chests/village/village_temple",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "toolsmith": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_toolsmith"
+        "loot_table": "minecraft:chests/village/village_toolsmith",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     },
     "weaponsmith": {
       "trigger": "minecraft:player_generates_container_loot",
       "conditions": {
-        "loot_table": "minecraft:chests/village/village_weaponsmith"
+        "loot_table": "minecraft:chests/village/village_weaponsmith",
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4_guidebook"
+              },
+              "score": "load.status"
+            },
+            "range": 1
+          }
+        ]
       }
     }
   },

--- a/gm4_guidebook/data/gm4_guidebook/functions/update_book/first_join.mcfunction
+++ b/gm4_guidebook/data/gm4_guidebook/functions/update_book/first_join.mcfunction
@@ -4,4 +4,4 @@
 # run from advancement gm4_guidebook:first_join
 
 # if the scoreboard is set to 1, give the player a book
-execute if score $giveNewPlayers gm4_guide_config matches 1 run loot give @s loot gm4_guidebook:items/guidebook
+loot give @s loot gm4_guidebook:items/guidebook


### PR DESCRIPTION
- adds conditional check for technical guidebook advancements which verifies `gm4_guidebook load.status` is 1, which allows for these advancements to be ignored if the load score has changed
- changes first join advancement to only be granted if `$giveNewPlayers gm4_guide_config` is 1, so if server admins decide that they _do_ want all players to receive a guidebook upon joining, then players who were online when the module was first installed will also get the guidebook