### PR TITLE
Zauber Cauldrons 1.18

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_trades/tags/functions/register_trades.json
+++ b/gm4_zauber_cauldrons/data/gm4_trades/tags/functions/register_trades.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_zauber_cauldrons:wandering_trader/register_trades"
+    ]
+}

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
@@ -14,7 +14,10 @@ execute store result storage gm4_zauber_cauldrons:temp/item/bottled_vex gm4_zaub
 execute store result storage gm4_zauber_cauldrons:temp/item/bottled_vex gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run scoreboard players get @e[type=marker,tag=gm4_dimension,distance=0..,limit=1] gm4_dimension
 
 # spawn item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:extra_items/bottled_vex
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:extra_items/bottled_vex
+
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
 
 # reset storage
 data remove storage gm4_zauber_cauldrons:temp/item/bottled_vex gm4_zauber_cauldrons

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/use_extra_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/use_extra_items.mcfunction
@@ -1,5 +1,5 @@
 # @s = zauber cauldron with overflow items
-# run in recipe functions
+# run from use_cauldron functions
 # at center of block
 
 # calculate how many excess items are in the recipe
@@ -7,7 +7,7 @@ scoreboard players operation @s gm4_zc_fullness -= $expected_item_amount gm4_zc_
 
 # absorb possessed items into a bottle if present
 scoreboard players set $bottled_possessed_items gm4_zc_data 0
-execute if score $has_bottle gm4_zc_fullness matches 1.. if score @s gm4_zc_fullness matches 2.. align xyz run function gm4_zauber_cauldrons:cauldron/extra_items/prepare_bottle
+execute if score $has_bottle gm4_zc_fullness matches 1.. if score @s gm4_zc_fullness matches 2.. align xyz positioned ~.5 ~.5 ~.5 run function gm4_zauber_cauldrons:cauldron/extra_items/prepare_bottle
 
 # summon possessed items if no bottle present
 execute if score $bottled_possessed_items gm4_zc_data matches 0 run function gm4_zauber_cauldrons:cauldron/extra_items/create_possessed_items

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/load.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/load.mcfunction
@@ -1,8 +1,9 @@
-execute if score gm4 load.status matches 1 if score gm4_forceload load.status matches 1 if score gm4_player_heads load.status matches 1 if score gm4_brewing load.status matches 1 run scoreboard players set gm4_zauber_cauldrons load.status 1
+execute if score gm4 load.status matches 1 if score gm4_forceload load.status matches 1 if score gm4_player_heads load.status matches 1 if score gm4_brewing load.status matches 1 if score gm4_trades load.status matches 1 run scoreboard players set gm4_zauber_cauldrons load.status 1
 execute unless score gm4 load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Zauber Cauldrons",require:"Gamemode 4"}
 execute unless score gm4_forceload load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Zauber Cauldrons",require:"lib_forceload"}
 execute unless score gm4_player_heads load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Zauber Cauldrons",require:"lib_player_heads"}
 execute unless score gm4_brewing load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Zauber Cauldrons",require:"lib_brewing"}
+execute unless score gm4_trades load.status matches 1 run data modify storage gm4:log queue append value {type:"missing",module:"Zauber Cauldrons",require:"lib_trades"}
 
 execute if score gm4_zauber_cauldrons load.status matches 1 run function gm4_zauber_cauldrons:init
 execute unless score gm4_zauber_cauldrons load.status matches 1 run schedule clear gm4_zauber_cauldrons:main

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/armor_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/armor_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/armor_boost CustomModelData set value 3420005
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/armor_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/armor_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/attack_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/attack_boost CustomModelData set value 3420003
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/attack_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/attack_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/health_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/health_boost CustomModelData set value 3420002
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/health_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/health_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/speed_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/speed_boost CustomModelData set value 3420004
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/speed_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/boots/speed_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/armor_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/armor_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/armor_boost CustomModelData set value 3420005
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/armor_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/armor_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/attack_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/attack_boost CustomModelData set value 3420003
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/attack_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/attack_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/health_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/health_boost CustomModelData set value 3420002
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/health_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/health_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/speed_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/speed_boost CustomModelData set value 3420004
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/speed_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/chestplate/speed_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/armor_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/armor_boost.mcfunction
@@ -9,6 +9,6 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/armor_boost CustomModelData set value 3420005
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/armor_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/armor_boost
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/attack_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/attack_boost CustomModelData set value 3420003
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/attack_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/attack_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/health_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/health_boost CustomModelData set value 3420002
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/health_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/health_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/speed_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/speed_boost CustomModelData set value 3420004
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/speed_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/helmet/speed_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/armor_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/armor_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/armor_boost CustomModelData set value 3420005
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/armor_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/armor_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/attack_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/attack_boost CustomModelData set value 3420003
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/attack_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/attack_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/health_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/health_boost CustomModelData set value 3420002
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/health_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/health_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/speed_boost.mcfunction
@@ -9,7 +9,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 data modify storage gm4_zauber_cauldrons:blueprint/item/zauber_armor/attribute/speed_boost CustomModelData set value 3420004
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/speed_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/armor/leggings/speed_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/use_cauldron.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/use_cauldron.mcfunction
@@ -5,6 +5,9 @@
 # calculate amount of vexes to spawn
 execute if score @s gm4_zc_fullness > $expected_item_amount gm4_zc_fullness run function gm4_zauber_cauldrons:cauldron/structure/use_extra_items
 
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
+
 # sounds and visuals
 particle entity_effect ~ ~.4 ~ .1 .1 .1 1 10
 playsound entity.player.levelup block @a[distance=..16] ~ ~ ~ 1 1.5

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/chorus/blurry_wormhole.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/chorus/blurry_wormhole.mcfunction
@@ -27,7 +27,10 @@ execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_za
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon wormhole
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/chorus/wormhole
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/chorus/wormhole
+
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
 
 # if one, popped or raw chorus, was more than required, turn those into vexes
 execute if score $raw_chorus_fullness gm4_zc_chorus matches 1.. run scoreboard players operation @s gm4_zc_fullness += $raw_chorus_fullness gm4_zc_chorus

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/chorus/precise_wormhole.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/chorus/precise_wormhole.mcfunction
@@ -9,7 +9,10 @@ data modify storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_caul
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon wormhole
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/chorus/wormhole
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/chorus/wormhole
+
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
 
 # cosmetics
 execute at @s run particle minecraft:witch ~ ~.3 ~ .1 .1 .1 1 17

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/instant_damage.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/instant_damage.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/instant_damage
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/instant_damage
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/instant_health.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/instant_health.mcfunction
@@ -6,6 +6,6 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/instant_health
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/instant_health
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/jump_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/jump_boost.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/jump_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/jump_boost
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/poison.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/poison.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/poison
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/poison
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/regeneration.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/regeneration.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/regeneration
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/regeneration
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/speed.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/speed.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/speed
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/speed
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/strength.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/effects/strength.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/crystals/strength
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/crystals/strength
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/use_cauldron.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/crystals/use_cauldron.mcfunction
@@ -5,6 +5,9 @@
 # calculate amount of vexes to spawn
 execute if score @s gm4_zc_fullness > $expected_item_amount gm4_zc_fullness run function gm4_zauber_cauldrons:cauldron/structure/use_extra_items
 
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
+
 # sounds and visuals
 particle entity_effect ~ ~.4 ~ .1 .1 .1 1 10
 playsound entity.player.levelup block @a[distance=..16] ~ ~ ~ 1 1.5

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/instant_damage.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/instant_damage.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_damage
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_damage
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_damage

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/instant_health.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/instant_health.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_health
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_health
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_health

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/jump_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/jump_boost.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/jump_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/jump_boost
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/jump_boost

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/poison.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/poison.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/poison
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/poison
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/poison

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/regeneration.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/regeneration.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/regeneration
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/regeneration
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/regeneration

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/speed.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/speed.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/speed
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/speed
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/strength.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/drinkable/strength.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/strength
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/drinkable/strength
 
 # visuals
 execute if score $has_water gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/environmental_effects/strength

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/environmental_effects/jump_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/environmental_effects/jump_boost.mcfunction
@@ -3,4 +3,6 @@
 # run from recipes/potions/ recipes
 # applies environmental effects caused by recipes
 
+particle minecraft:effect ~0.2 ~.7 ~ 0.2 0.2 0.2 0 30
 summon rabbit ~0.2 ~.7 ~ {RabbitType:99,Tags:["gm4_zc_killer_rabbit"],Attributes:[{Name:"generic.max_health",Base:31.0}],Health:31,ActiveEffects:[{Id:10,Amplifier:0,Duration:2147483647,ShowParticles:0b},{Id:5,Amplifier:3,Duration:2147483647,ShowParticles:0b}]}
+playsound minecraft:entity.illusioner.mirror_move block @a[distance=..16] ~0.2 ~.7 ~ 0.4 0.5

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/instant_damage.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/instant_damage.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/instant_damage
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/instant_damage
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_damage

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/instant_health.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/instant_health.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/instant_health
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/instant_health
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_health

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/jump_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/jump_boost.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/jump_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/jump_boost
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/jump_boost

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/poison.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/poison.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/poison
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/poison
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/poison

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/regeneration.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/regeneration.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/regeneration
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/regeneration
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/regeneration

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/speed.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/speed.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/speed
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/speed
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/strength.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/strength.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/strength
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/lingering/strength
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/strength

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/instant_damage.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/instant_damage.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/instant_damage
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/instant_damage
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_damage

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/instant_health.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/instant_health.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/instant_health
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/instant_health
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/instant_health

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/jump_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/jump_boost.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/jump_boost
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/jump_boost
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/jump_boost

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/poison.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/poison.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/poison
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/poison
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/poison

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/regeneration.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/regeneration.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/regeneration
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/regeneration
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/regeneration

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/speed.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/speed.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/speed
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/speed
 
 # set flag
 scoreboard players set $recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/strength.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/strength.mcfunction
@@ -6,7 +6,7 @@
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # summon item
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/strength
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/potions/splash/strength
 
 # visuals
 function gm4_zauber_cauldrons:recipes/potions/environmental_effects/strength

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/use_cauldron.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/use_cauldron.mcfunction
@@ -5,6 +5,9 @@
 # calculate amount of vexes to spawn
 execute if score @s gm4_zc_fullness > $expected_item_amount gm4_zc_fullness run function gm4_zauber_cauldrons:cauldron/structure/use_extra_items
 
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
+
 # sounds and visuals
 playsound entity.fishing_bobber.splash block @a[distance=..16] ~ ~ ~ 0.3 1
 

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/precursors/enchanted_prismarine_shard.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/precursors/enchanted_prismarine_shard.mcfunction
@@ -10,7 +10,7 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # recipe
 loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/precursors/enchanted_prismarine_shard
-experience add @a[level=30..,distance=..2,limit=1,sort=nearest] -30 levels
+execute as @a[level=30..,distance=..2,limit=1,sort=nearest,gamemode=!spectator] run experience add @s[gamemode=!creative] -30 levels
 
 # sounds and visuals
 playsound block.portal.travel block @a[distance=..16] ~ ~ ~ .2 1.2

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/precursors/enchanted_prismarine_shard.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/precursors/enchanted_prismarine_shard.mcfunction
@@ -9,7 +9,12 @@ scoreboard players set $expected_item_amount gm4_zc_fullness 1
 execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 
 # recipe
-loot spawn ~ ~.1 ~ loot gm4_zauber_cauldrons:recipes/precursors/enchanted_prismarine_shard
+loot spawn ~ ~.2 ~ loot gm4_zauber_cauldrons:recipes/precursors/enchanted_prismarine_shard
+
+# make items in cauldron pickup-able instantly
+execute align xyz as @e[type=item,dx=0,dy=0,dz=0] run data modify entity @s PickupDelay set value 0s
+
+# use xp
 execute as @a[level=30..,distance=..2,limit=1,sort=nearest,gamemode=!spectator] run experience add @s[gamemode=!creative] -30 levels
 
 # sounds and visuals

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/wandering_trader/register_trades.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/wandering_trader/register_trades.mcfunction
@@ -1,0 +1,8 @@
+# Adds trades to be added to wandering traders via lib_trades
+# @s = a wandering trader
+# at @s
+# called via function tag #gm4_trades:register_trades
+
+summon trader_llama ~ 0 ~ {Silent:1b,NoGravity:1b,Invulnerable:1b,ChestedHorse:1b,Variant:0,Strength:1,DespawnDelay:1,Tags:["gm4_trade_option","gm4_new_trade_option"],Items:[{},{},{}],DecorItem:{id:"minecraft:light_blue_carpet",Count:1b,tag:{gm4_trades:{pool:"gm4_zauber_cauldrons:precursors",options:{maxUses:4,rewardXp:1b,xp:1,priceMultiplier:0.05f}}}}}
+loot replace entity @e[type=trader_llama,limit=1,tag=gm4_new_trade_option] horse.0 loot gm4_zauber_cauldrons:wandering_trader/enchanted_prismarine_shard
+tag @e[type=trader_llama] remove gm4_new_trade_option

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/loot_tables/wandering_trader/enchanted_prismarine_shard.json
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/loot_tables/wandering_trader/enchanted_prismarine_shard.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "name": "gm4_zauber_cauldrons:recipes/precursors/enchanted_prismarine_shard",
+                    "weight": 10
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:prismarine_crystals",
+                    "weight": 6,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 4,
+                                "max": 16
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:prismarine_shard",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 8
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:golden_apple"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:emerald",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 24,
+                                "max": 47
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/gm4_zauber_cauldrons/data/load/tags/functions/gm4_zauber_cauldrons.json
+++ b/gm4_zauber_cauldrons/data/load/tags/functions/gm4_zauber_cauldrons.json
@@ -3,6 +3,7 @@
 		{ "id": "#load:gm4_forceload", "required": false },
 		{ "id": "#load:gm4_player_heads", "required": false },
         { "id": "#load:gm4_brewing", "required": false },
+        { "id": "#load:gm4_trades", "required": false },
         "gm4_zauber_cauldrons:load"
     ]
 }

--- a/gm4_zauber_cauldrons/pack.mcmeta
+++ b/gm4_zauber_cauldrons/pack.mcmeta
@@ -15,7 +15,8 @@
     "libraries": [
         "lib_forceload",
         "lib_player_heads",
-        "lib_brewing"
+        "lib_brewing",
+        "lib_trades"
     ],
     "site_description": "Brew potions, special armour and attribute crystals in any cauldron!",
     "site_categories": [],


### PR DESCRIPTION
This is minor update to Zauber Cauldrons introduces some quality of life improvements:
- Introduces a set of Wandering Trader trades for Zauber Cauldrons. Wandering Traders can now sell Prismarine Crystals, Prismarine Shards, Enchanted Prismarine Shards, or Golden Apples
- Adds some sound & particle effects when the killer bunny is spawned during the Leaping IV recipe
- Creating an Enchanted Prismarine Shard can no longer accidentally remove experience points from a creative player
- Items created in a Zauber Cauldron now spawn slightly higher and can be picked up immediately once the recipe is complete 
