### PR TITLE
Vibro Multiplayer Fix

### DIFF
--- a/gm4_metallurgy/data/gm4_vibro_shamir/functions/shock/activate.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/functions/shock/activate.mcfunction
@@ -3,3 +3,4 @@
 # run from shockwave
 
 execute as @a[scores={gm4_vibro_shock=1..}] at @s run function gm4_vibro_shamir:shock/user
+scoreboard players reset @a gm4_vibro_shock


### PR DESCRIPTION
Vibro was broken for multiplayer use and would cause any player who ever used vibro to create a shockwave if another player uses vibro. This PR fixes that bug