### PR TITLE
Ink Spitting Squid Disabled by Conduit Power

### DIFF
--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/functions/main.mcfunction
@@ -1,4 +1,4 @@
-execute at @e[type=squid] as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^ if predicate gm4_ink_spitting_squid:in_water run function gm4_ink_spitting_squid:squid_squirt
-execute at @e[type=glow_squid] as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^ if predicate gm4_ink_spitting_squid:in_water run function gm4_ink_spitting_squid:glow_squid_squirt
+execute at @e[type=squid] as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^ if predicate gm4_ink_spitting_squid:inkable run function gm4_ink_spitting_squid:squid_squirt
+execute at @e[type=glow_squid] as @a[gamemode=!spectator,distance=..3] at @s anchored eyes positioned ^ ^ ^ if predicate gm4_ink_spitting_squid:inkable run function gm4_ink_spitting_squid:glow_squid_squirt
 
 schedule function gm4_ink_spitting_squid:main 16t

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/predicates/in_water.json
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/predicates/in_water.json
@@ -1,8 +1,0 @@
-{
-  "condition": "minecraft:location_check",
-  "predicate": {
-    "fluid": {
-      "tag": "minecraft:water"
-    }
-  }
-}

--- a/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/predicates/inkable.json
+++ b/gm4_ink_spitting_squid/data/gm4_ink_spitting_squid/predicates/inkable.json
@@ -1,0 +1,26 @@
+[
+  {
+    "condition": "minecraft:inverted",
+    "term": {
+      "condition": "minecraft:entity_properties",
+      "entity": "this",
+      "predicate": {
+        "effects": {
+          "minecraft:conduit_power": {
+            "duration": {
+              "min": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "condition": "minecraft:location_check",
+    "predicate": {
+      "fluid": {
+        "tag": "minecraft:water"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Squids will no longer give affect players with the conduit power effect.

This is to improve the experience of underwater building, as many module encourage deep sea builds, but Ink Spitting Squid makes it very annoying to do so.