### PR TITLE
Chairs: Remove pig health display

### DIFF
--- a/gm4_chairs/data/gm4_chairs/functions/create_chair.mcfunction
+++ b/gm4_chairs/data/gm4_chairs/functions/create_chair.mcfunction
@@ -4,7 +4,7 @@
 # run from main
 
 # spawn chair
-summon minecraft:pig ~ ~-10000.39 ~ {Tags:["gm4_chairs"],Team:"gm4_chairs",NoAI:1b,Saddle:1b,NoGravity:1b,Silent:1b,DeathTime:19s,InLove:2147483647,Attributes:[{Name:"generic.movement_speed",Base:0.0}],ActiveEffects:[{Id:14,Amplifier:0,Duration:2147483647,ShowParticles:0b},{Id:11b,Amplifier:10b,Duration:2147483647,ShowParticles:0b}],DeathLootTable:"minecraft:empty"}
+summon minecraft:pig ~ ~-10000.39 ~ {Tags:["gm4_chairs"],Team:"gm4_chairs",NoAI:1b,Saddle:1b,NoGravity:1b,Silent:1b,DeathTime:19s,InLove:2147483647,Attributes:[{Name:"generic.max_health",Base:1.0},{Name:"generic.movement_speed",Base:0.0}],ActiveEffects:[{Id:14,Amplifier:0,Duration:2147483647,ShowParticles:0b},{Id:11b,Amplifier:10b,Duration:2147483647,ShowParticles:0b}],DeathLootTable:"minecraft:empty"}
 
 # set chair to orientation of stairs
 execute if block ~ ~ ~ #minecraft:stairs[facing=north] positioned ~ ~-10000 ~ as @e[type=minecraft:pig,tag=gm4_chairs,distance=..0.4,limit=1] at @s run tp @s ~ ~10000 ~.05 0 0

--- a/gm4_chairs/data/gm4_chairs/functions/kill.mcfunction
+++ b/gm4_chairs/data/gm4_chairs/functions/kill.mcfunction
@@ -10,5 +10,9 @@ tag @e[type=minecraft:item,distance=..1,limit=1,sort=nearest] add gm4_chairs_ign
 # dismount if sitting on chair
 execute align xyz positioned ~.5 ~ ~.5 as @a[predicate=gm4_chairs:sitting_in_chair,distance=..0.5] at @s align y run tp @s ~ ~1 ~
 
+# increase health to avoid visible death cloud
+attribute @s minecraft:generic.max_health base set 5
+data modify entity @s Health set value 5
+
 # remove chair
 tp @s ~ -10000 ~


### PR DESCRIPTION
Small oversight from the last update, which brought back the health of the pig to replace the hunger bar. This fix sets its health back to 1 (to stop health display).
To avoid the death cloud, the pig's health it increased just before killing it.