### PR TITLE
Animi Orbs Of Ankou

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
@@ -1,4 +1,4 @@
 # Marks Orbs of Ankou as tools for the animi shamir
 # run from #gm4_animi_shamir:mark_item_validity
 
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data entity @s Item{id: "minecraft:firework_star", tag: {gm4_orb_of_ankou: {item: "orb"}}}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data entity @s Item{id:"minecraft:firework_star",tag:{gm4_orb_of_ankou:{item:"orb"}}}

--- a/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
@@ -1,0 +1,4 @@
+# Marks Orbs of Ankou as tools for the animi shamir
+# run from #gm4_animi_shamir:mark_item_validity
+
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data entity @s Item{id: "minecraft:firework_star", tag: {gm4_orb_of_ankou: {pneumas: [{}]}}}

--- a/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_animi_shamir/functions/mark_orb_of_ankou.mcfunction
@@ -1,4 +1,4 @@
 # Marks Orbs of Ankou as tools for the animi shamir
 # run from #gm4_animi_shamir:mark_item_validity
 
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data entity @s Item{id: "minecraft:firework_star", tag: {gm4_orb_of_ankou: {pneumas: [{}]}}}
+execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if data entity @s Item{id: "minecraft:firework_star", tag: {gm4_orb_of_ankou: {item: "orb"}}}

--- a/gm4_orb_of_ankou/data/gm4_animi_shamir/tags/functions/mark_item_validity.json
+++ b/gm4_orb_of_ankou/data/gm4_animi_shamir/tags/functions/mark_item_validity.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "gm4_animi_shamir:mark_orb_of_ankou"
+    ]
+}


### PR DESCRIPTION
This only applies to the orb items, for:
- 'lore' reasons; the orb is a tool, whereas the shard is arguably not
- ease of implementation, as this would need to be very carefully special cased in the fusing ritual otherwise