### PR TITLE
Prevents Desire Lines from breaking moss carpet

### DIFF
--- a/gm4_desire_lines/data/gm4_desire_lines/functions/path.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/functions/path.mcfunction
@@ -6,7 +6,7 @@ fill ~ ~-1 ~ ~ ~-1 ~ coarse_dirt replace dirt
 fill ~ ~-1 ~ ~ ~-1 ~ dirt replace grass_block
 fill ~ ~ ~ ~ ~ ~ air replace snow[layers=1]
 fill ~ ~ ~ ~ ~ ~ snow[layers=1] replace snow[layers=2]
-execute if block ~ ~ ~ #gm4:foliage run setblock ~ ~ ~ air destroy
+execute if block ~ ~ ~ #gm4:foliage unless block ~ ~ ~ moss_carpet run setblock ~ ~ ~ air destroy
 #advancement check
 execute if block ~ ~-1 ~ coarse_dirt run scoreboard players add @s gm4_dl_affcoarse 1
 advancement grant @s[scores={gm4_dl_affcoarse=8000}] only gm4:desire_lines_8000


### PR DESCRIPTION
This PR completely prevents Desire Lines from breaking moss carpet by adding an explicit exception for the block.