### PR TITLE
[Vibro Shamir] Increases timing between jump boost levels by 2t

### DIFF
--- a/gm4_metallurgy/data/gm4_vibro_shamir/functions/jump.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/functions/jump.mcfunction
@@ -5,10 +5,10 @@
 scoreboard players add @s gm4_vibro_sneak 1
 
 # apply jump boost based on sneak number
-effect give @s[scores={gm4_vibro_sneak=1..3}] jump_boost 1 3 false
-effect give @s[scores={gm4_vibro_sneak=4..6}] jump_boost 1 5 false
-effect give @s[scores={gm4_vibro_sneak=7..9}] jump_boost 1 6 false
-effect give @s[scores={gm4_vibro_sneak=10..}] jump_boost 1 9 false
+effect give @s[scores={gm4_vibro_sneak=1..5}] jump_boost 1 3 false
+effect give @s[scores={gm4_vibro_sneak=6..10}] jump_boost 1 5 false
+effect give @s[scores={gm4_vibro_sneak=11..15}] jump_boost 1 6 false
+effect give @s[scores={gm4_vibro_sneak=16..}] jump_boost 1 9 false
 
 # playsound (A Major Scale)
 execute if score @s gm4_vibro_sneak matches 1 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.189207

--- a/gm4_metallurgy/data/gm4_vibro_shamir/functions/jump.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/functions/jump.mcfunction
@@ -12,6 +12,6 @@ effect give @s[scores={gm4_vibro_sneak=10..}] jump_boost 1 9 false
 
 # playsound (A Major Scale)
 execute if score @s gm4_vibro_sneak matches 1 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.189207
-execute if score @s gm4_vibro_sneak matches 4 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.259921
-execute if score @s gm4_vibro_sneak matches 7 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.334840
-execute if score @s gm4_vibro_sneak matches 10 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.498307
+execute if score @s gm4_vibro_sneak matches 6 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.259921
+execute if score @s gm4_vibro_sneak matches 11 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.334840
+execute if score @s gm4_vibro_sneak matches 16 run playsound minecraft:block.stone.step block @a[distance=..8] ~ ~ ~ 0.6 1.498307


### PR DESCRIPTION
This PR increases the charge time between vibro jump boost levels by 2 ticks per level, putting the new maximum charge time to 16 ticks (0.8 seconds) from previously 10 ticks (0.5 seconds).

Tests had shown that timing jumps is harder on servers due to latency, this decrease in the temporal resolution should somewhat mitigate the issue and make jumps on servers easier to time.