### PR TITLE
Remove trailing spaces

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/feigning/move_away.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/feigning/move_away.mcfunction
@@ -9,9 +9,9 @@ execute store result score $target_z gm4_pneuma_data run data get storage gm4_or
 
 # get vector
 data modify storage gm4_orb_of_ankou:temp Pos set from entity @s Pos
-execute store result score $motion_x gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[0] 
-execute store result score $motion_y gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[1] 
-execute store result score $motion_z gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[2] 
+execute store result score $motion_x gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[0]
+execute store result score $motion_y gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[1]
+execute store result score $motion_z gm4_pneuma_data run data get storage gm4_orb_of_ankou:temp Pos[2]
 
 scoreboard players operation $motion_x gm4_pneuma_data -= $target_x gm4_pneuma_data
 scoreboard players operation $motion_y gm4_pneuma_data -= $target_y gm4_pneuma_data


### PR DESCRIPTION
This PR removes three trailing spaces from a mcfunction. They are removed because they are trailing spaces. Trailing spaces aren't meaningful and take up our precious disk space, which is why those trailing spaces are removed in this PR. It's fine to remove them because they are trailing spaces. The game doesn't care about trailing spaces. This PR removes them because the game doesn't care about them. They are trailing spaces which means they are trailing spaces. Those trailing spaces are removed by this PR. Removing trailing spaces doesn't affect the functionality of the mcfunction. They are removed because they are trailing spaces. Three trailing spaces in the `gm4_orb_of_ankou:pneumas/feigning/move_away` function are removed. It shouldn't break anything because they are trailing spaces.