### PR TITLE
Reduce the time required for sneak charge pneumas

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/bounding.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/bounding.mcfunction
@@ -1,7 +1,7 @@
 # @s = player with bounding pneuma who stopped sneaking
 # run from pneumas/sneak/stopped
 
-effect give @s[scores={gm4_oa_snk_num=40..79}] jump_boost 30 3 true
-effect give @s[scores={gm4_oa_snk_num=80..159}] jump_boost 30 5 true
-effect give @s[scores={gm4_oa_snk_num=160..319}] jump_boost 30 7 true
-effect give @s[scores={gm4_oa_snk_num=320..}] jump_boost 30 9 true
+effect give @s[scores={gm4_oa_snk_num=10..19}] jump_boost 30 3 true
+effect give @s[scores={gm4_oa_snk_num=20..39}] jump_boost 30 5 true
+effect give @s[scores={gm4_oa_snk_num=40..59}] jump_boost 30 7 true
+effect give @s[scores={gm4_oa_snk_num=60..}] jump_boost 30 9 true

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/prepare.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/conjuring/prepare.mcfunction
@@ -4,10 +4,10 @@
 summon armor_stand ~ ~ ~ {Invisible:1b,NoGravity:1b,Marker:1b,Small:1b,CustomName:'"Fang Thrower"',Tags:["gm4_oa_fang_thrower","gm4_oa_new_fang"],ArmorItems:[{id:"minecraft:stick",Count:1b},{},{},{}]}
 data modify entity @e[type=minecraft:armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] ArmorItems[0].tag.gm4_oa_conjuring set from entity @s UUID
 tp @e[type=armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] ~ ~ ~ ~ 0
-scoreboard players set @s[scores={gm4_oa_snk_num=40..79}] gm4_pneuma_data 6
-scoreboard players set @s[scores={gm4_oa_snk_num=80..159}] gm4_pneuma_data 9
-scoreboard players set @s[scores={gm4_oa_snk_num=160..319}] gm4_pneuma_data 12
-scoreboard players set @s[scores={gm4_oa_snk_num=320..}] gm4_pneuma_data 15
+scoreboard players set @s[scores={gm4_oa_snk_num=10..19}] gm4_pneuma_data 6
+scoreboard players set @s[scores={gm4_oa_snk_num=20..39}] gm4_pneuma_data 9
+scoreboard players set @s[scores={gm4_oa_snk_num=40..59}] gm4_pneuma_data 12
+scoreboard players set @s[scores={gm4_oa_snk_num=60..}] gm4_pneuma_data 15
 scoreboard players operation @e[type=armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] gm4_pneuma_data = @s gm4_pneuma_data
 tag @e[type=armor_stand,tag=gm4_oa_new_fang,distance=..0.001,limit=1] remove gm4_oa_new_fang
 

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/expeditious/attempt.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/expeditious/attempt.mcfunction
@@ -4,10 +4,10 @@
 summon marker ~ ~ ~ {CustomName:'"Expeditious TP"',Tags:["gm4_oa_expeditious"]}
 tp @e[type=marker,tag=gm4_oa_expeditious,limit=1] @s
 
-scoreboard players set @s[scores={gm4_oa_snk_num=40..79}] gm4_pneuma_data 9
-scoreboard players set @s[scores={gm4_oa_snk_num=80..159}] gm4_pneuma_data 17
-scoreboard players set @s[scores={gm4_oa_snk_num=160..319}] gm4_pneuma_data 25
-scoreboard players set @s[scores={gm4_oa_snk_num=320..}] gm4_pneuma_data 33
+scoreboard players set @s[scores={gm4_oa_snk_num=10..19}] gm4_pneuma_data 9
+scoreboard players set @s[scores={gm4_oa_snk_num=20..39}] gm4_pneuma_data 17
+scoreboard players set @s[scores={gm4_oa_snk_num=40..59}] gm4_pneuma_data 25
+scoreboard players set @s[scores={gm4_oa_snk_num=60..}] gm4_pneuma_data 33
 
 execute if score @s gm4_pneuma_data matches 9 run tp @e[type=marker,tag=gm4_oa_expeditious,limit=1] ~-4 ~ ~-4
 execute if score @s gm4_pneuma_data matches 17 run tp @e[type=marker,tag=gm4_oa_expeditious,limit=1] ~-8 ~ ~-8

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/rushing.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/rushing.mcfunction
@@ -1,7 +1,7 @@
 # @s = player with rushing pneuma who stopped sneaking
 # run from pneumas/sneak/stopped
 
-effect give @s[scores={gm4_oa_snk_num=40..79}] speed 20 0 true
-effect give @s[scores={gm4_oa_snk_num=80..159}] speed 45 0 true
-effect give @s[scores={gm4_oa_snk_num=160..319}] speed 20 2 true
-effect give @s[scores={gm4_oa_snk_num=320..}] speed 45 2 true
+effect give @s[scores={gm4_oa_snk_num=10..19}] speed 20 0 true
+effect give @s[scores={gm4_oa_snk_num=20..39}] speed 45 0 true
+effect give @s[scores={gm4_oa_snk_num=40..59}] speed 20 2 true
+effect give @s[scores={gm4_oa_snk_num=60..}] speed 45 2 true

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/sound.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/pneumas/sneak/sound.mcfunction
@@ -1,7 +1,7 @@
 # @s = sneaking player with pneuma sneak ability
 # run from pneumas/sneak/check
 
-playsound minecraft:block.note_block.cow_bell player @s[scores={gm4_oa_snk_num=40}] ~ ~ ~ 0.7 0.3
-playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=80}] ~ ~ ~ 0.7 0.6
-playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=160}] ~ ~ ~ 0.7 0.8
-playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=320}] ~ ~ ~ 0.7 1.2
+playsound minecraft:block.note_block.cow_bell player @s[scores={gm4_oa_snk_num=10}] ~ ~ ~ 0.7 0.3
+playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=20}] ~ ~ ~ 0.7 0.6
+playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=40}] ~ ~ ~ 0.7 0.8
+playsound minecraft:block.note_block.cow_bell player @a[scores={gm4_oa_snk_num=60}] ~ ~ ~ 0.7 1.2


### PR DESCRIPTION
Without this change, it takes:
- 2 seconds for level 1
- 4 seconds for level 2
- 8 seconds for level 3
- 16 seconds for level 4

Compare e.g. to gliding, which gives dolphins grace 2 all the time, this makes e.g. rushing significantly less useful for travel, as a quarter of the time would be spent sneaking (it might turn out that level 2 is most efficient for travel, but it's non-trivial to calculate that)

After this change:
- 1 second for level 1
- 2 seconds for level 2
- 4 seconds for level 3
- 6 seconds for level 4

Note that I haven't touched draining, since that is based on its own seperate numbers, which is 3 ticks for level 1, 6 ticks for level 2, 9 ticks for level 3 and 14 ticks for level 4; presumably because no-one is going to use draining anyway, so it doesn't matter how 'OP' it is.