### PR TITLE
[Shroomites] Prevent Shrooms from Replacing Non-Full Blocks

### DIFF
--- a/gm4_shroomites/data/gm4_shroomites/functions/spore/die.mcfunction
+++ b/gm4_shroomites/data/gm4_shroomites/functions/spore/die.mcfunction
@@ -4,7 +4,7 @@
 # run from gm4_shroomites:spore/track_age
 
 # try to place new sporing shroom if there is mycelium below, unless the global cap has been reached
-execute if score $global_shroom_count gm4_shroom_data < #global_shroom_cap gm4_shroom_data if block ~ ~-1 ~ mycelium unless entity @e[type=marker,tag=gm4_shroomite_shroom,distance=..4.5] run function gm4_shroomites:shroom/create
+execute if score $global_shroom_count gm4_shroom_data < #global_shroom_cap gm4_shroom_data if block ~ ~-1 ~ mycelium if block ~ ~ ~ #gm4_shroomites:shroom_replacable unless entity @e[type=marker,tag=gm4_shroomite_shroom,distance=..4.5] run function gm4_shroomites:shroom/create
 
 # kill spore
 kill @s


### PR DESCRIPTION
- Fixes #736 
- checks that the spore is in a replaceable block before placing a new shroomite