### PR TITLE
[GitHub Actions] Upload module artifact for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build all modules
         if: github.event_name != 'pull_request'
-        run: beet build --set 'meta.patch=true'
+        run: beet --set 'meta.patch=true' build
 
       - name: Build modules from pull request
         if: github.event_name == 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
           ref: release
           path: release
 
+      - name: Fetch pull request base
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }}
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           source: base gm4_!(template_pack) lib_*
           version: '0.35.1'
 
-  release:
+  build:
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +72,8 @@ jobs:
           directory: release
           branch: release
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           name: 'Modules for pull request #${{github.event.number}}'
           path: out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build modules from pull request
         if: github.event_name == 'pull_request'
-        run: beet --set 'meta.pull_request_base=${{ github.base_ref }}' build
+        run: beet --set 'meta.pull_request_base=origin/${{ github.base_ref }}' build
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: mcbeet/check-commands@v1
         with:
           minecraft: ${{ env.VERSION }}
@@ -23,27 +24,37 @@ jobs:
 
   release:
     needs: test
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Checkout release branch
         uses: actions/checkout@v2
         with:
           ref: release
           path: release
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
           cache: pip
+
       - name: Install dependencies
         run: pip install -r requirements.txt
-      - name: Build modules
+
+      - name: Build all modules
+        if: github.event_name != 'pull_request'
+        run: beet build --set 'meta.patch=true'
+
+      - name: Build modules from pull request
+        if: github.event_name == 'pull_request'
         run: beet build
+
       - name: Commit release
+        if: github.event_name != 'pull_request'
         run: |
           git config --global user.email "${{ github.event.head_commit.author.email }}"
           git config --global user.name "${{ github.event.head_commit.author.username }}"
@@ -52,9 +63,16 @@ jobs:
           cd release
           git add .
           git commit -m "🚀 ${{ github.event.after }} ${{ github.event.head_commit.message }}"
+
       - name: Push release
+        if: github.event_name != 'pull_request'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           directory: release
           branch: release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: 'Modules for pull request #${{github.event.number}}'
+          path: out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,13 @@ jobs:
         if: github.event_name == 'pull_request'
         run: beet build
 
+      - name: Upload artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Modules for pull request #${{github.event.number}}'
+          path: ${{ github.workspace }}/out/
+
       - name: Commit release
         if: github.event_name != 'pull_request'
         run: |
@@ -71,9 +78,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           directory: release
           branch: release
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: 'Modules for pull request #${{github.event.number}}'
-          path: out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout release branch
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v2
         with:
           ref: release
@@ -47,17 +48,17 @@ jobs:
 
       - name: Build all modules
         if: github.event_name != 'pull_request'
-        run: beet --set 'meta.patch=true' build
+        run: beet build
 
       - name: Build modules from pull request
         if: github.event_name == 'pull_request'
-        run: beet build
+        run: beet --set 'meta.pull_request_base=${{ github.base_ref }}' build
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
-          name: 'Modules for pull request #${{github.event.number}}'
+          name: 'Modules for pull request #${{ github.event.number }}'
           path: ${{ github.workspace }}/out/
 
       - name: Commit release

--- a/gm4.py
+++ b/gm4.py
@@ -30,6 +30,9 @@ def build_modules(ctx: Context):
 	except:
 		released_modules = []
 		last_commit = None
+	
+	if 'pull_request_base' in ctx.meta:
+		last_commit = ctx.meta.get('pull_request_base')
 
 	with open("contributors.json", "r") as f:
 		contributors: dict[str, dict] = {entry["name"]: entry for entry in json.load(f)}
@@ -73,7 +76,7 @@ def build_modules(ctx: Context):
 			module["patch"] = released["patch"]
 		else:
 			patch = released["patch"] if released else prefix
-			if ctx.meta.get("patch"):
+			if not ctx.meta.get("pull_request_base"):
 				patch += 1
 				print(f"Updating {id} -> {patch}")
 			module["patch"] = patch
@@ -118,7 +121,7 @@ def build_modules(ctx: Context):
 			if not id:
 				continue
 
-			if not (ctx.meta.get("patch", False) or id in changed_modules):
+			if ctx.meta.get("pull_request_base") and id not in changed_modules:
 				continue
 
 			ctx.require(subproject({


### PR DESCRIPTION
This PR makes it so pull requests build the modules and upload them as artifacts, which can be downloaded from the GitHub website.

As an example, I created a [pull request](https://github.com/misode/GM4_Beet/pull/2) and by navigating to checks, you can find the [artifacts](https://github.com/misode/GM4_Beet/actions/runs/1786177809). Only the modified modules are zipped and included in the artifact.