### PR TITLE
Fix CMD for (glow_)ink_bottle.

### DIFF
--- a/gm4_liquid_tanks/data/gm4_standard_liquids/loot_tables/glow_ink_bottle.json
+++ b/gm4_liquid_tanks/data/gm4_standard_liquids/loot_tables/glow_ink_bottle.json
@@ -1,20 +1,20 @@
 {
-    "type":"generic",
-    "pools":[
+    "type": "generic",
+    "pools": [
         {
-            "rolls":1,
-            "entries":[
+            "rolls": 1,
+            "entries": [
                 {
-                    "type":"item",
-                    "name":"potion",
-                    "functions":[
+                    "type": "item",
+                    "name": "potion",
+                    "functions": [
                         {
-                            "function":"set_nbt",
-                            "tag":"{Potion:\"standard_liquids:glowing\",CustomPotionEffects:[{Id:24b,Amplifier:0b,Duration:1200},{Id:16b,Amplifier:0b,Duration:1800}],CustomPotionColor:9828808,CustomModelData:3420004}"
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"standard_liquids:glowing\",CustomPotionEffects:[{Id:24b,Amplifier:0b,Duration:1200},{Id:16b,Amplifier:0b,Duration:1800}],CustomPotionColor:9828808,CustomModelData:3420008}"
                         },
                         {
-                            "function":"set_name",
-                            "name":{
+                            "function": "set_name",
+                            "name": {
                                 "translate": "%1$s%3427655$s",
                                 "with": [
                                     "Glow Ink Bottle",
@@ -24,7 +24,6 @@
                                 ],
                                 "italic": false
                             }
-
                         }
                     ]
                 }

--- a/gm4_liquid_tanks/data/gm4_standard_liquids/loot_tables/ink_bottle.json
+++ b/gm4_liquid_tanks/data/gm4_standard_liquids/loot_tables/ink_bottle.json
@@ -1,20 +1,20 @@
 {
-    "type":"generic",
-    "pools":[
+    "type": "generic",
+    "pools": [
         {
-            "rolls":1,
-            "entries":[
+            "rolls": 1,
+            "entries": [
                 {
-                    "type":"item",
-                    "name":"potion",
-                    "functions":[
+                    "type": "item",
+                    "name": "potion",
+                    "functions": [
                         {
-                            "function":"set_nbt",
-                            "tag":"{Potion:\"standard_liquids:blindness\",CustomPotionEffects:[{Id:15b,Amplifier:0b,Duration:2400}],CustomPotionColor:68378,CustomModelData:3420003}"
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"standard_liquids:blindness\",CustomPotionEffects:[{Id:15b,Amplifier:0b,Duration:2400}],CustomPotionColor:68378,CustomModelData:3420007}"
                         },
                         {
-                            "function":"set_name",
-                            "name":{
+                            "function": "set_name",
+                            "name": {
                                 "translate": "%1$s%3427655$s",
                                 "with": [
                                     "Ink Bottle",
@@ -24,7 +24,6 @@
                                 ],
                                 "italic": false
                             }
-
                         }
                     ]
                 }


### PR DESCRIPTION
Currently glow/regular ink bottles share their CMD with LiaB. Since these are less often used, I changed rather than changing LiaB