### PR TITLE
Fix wormhole tanks using wrong scoreboard names

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/player/wormhole_targeting/prepare_teleport.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/player/wormhole_targeting/prepare_teleport.mcfunction
@@ -6,7 +6,7 @@
 advancement revoke @s only gm4_zauber_cauldrons:use/wormhole
 
 # detect main or offhand warp and prepare target coordinates in fake players
-execute if predicate gm4_zauber_cauldrons:player/equipment/wormhole/in_mainhand run function gm4_zauber_cauldrons:player/wormhole_targeting/read_coordinates/mainhand
+execute unless score $read_coordinates gm4_zc_data matches 1 if predicate gm4_zauber_cauldrons:player/equipment/wormhole/in_mainhand run function gm4_zauber_cauldrons:player/wormhole_targeting/read_coordinates/mainhand
 execute unless score $read_coordinates gm4_zc_data matches 1 if predicate gm4_zauber_cauldrons:player/equipment/wormhole/in_offhand run function gm4_zauber_cauldrons:player/wormhole_targeting/read_coordinates/offhand
 scoreboard players reset $read_coordinates gm4_zc_data
 

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
@@ -8,7 +8,7 @@ scoreboard players operation $wormhole_x gm4_zc_data = @e[type=armor_stand,tag=g
 scoreboard players operation $wormhole_y gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cy
 scoreboard players operation $wormhole_z gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cz
 scoreboard players operation $wormhole_d gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cd
-scoreboard players set read_coordinates gm4_zc_data 1
+scoreboard players set $read_coordinates gm4_zc_data 1
 execute at @s run function gm4_zauber_cauldrons:player/wormhole_targeting/prepare_teleport
 
 scoreboard players remove @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_value 1

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
@@ -4,10 +4,10 @@
 # To work with non-player mobs, both versions require a change to @e from @a on line 14 of wormhole_targeting/set_dimension.mcfunction
 
 # Set coords
-scoreboard players operation wormhole_x gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cx
-scoreboard players operation wormhole_y gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cy
-scoreboard players operation wormhole_z gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cz
-scoreboard players operation wormhole_d gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cd
+scoreboard players operation $wormhole_x gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cx
+scoreboard players operation $wormhole_y gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cy
+scoreboard players operation $wormhole_z gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cz
+scoreboard players operation $wormhole_d gm4_zc_data = @e[type=armor_stand,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cd
 scoreboard players set read_coordinates gm4_zc_data 1
 execute at @s run function gm4_zauber_cauldrons:player/wormhole_targeting/prepare_teleport
 


### PR DESCRIPTION
Fixes a bug after the scoreboard names were changed in Zauber Cauldrons but not Zauber Liquids