### PR TITLE
Remove new mob tag from everstone converted mobs

### DIFF
--- a/gm4_everstone/data/gm4_everstone/functions/aging/update_age/check_mob.mcfunction
+++ b/gm4_everstone/data/gm4_everstone/functions/aging/update_age/check_mob.mcfunction
@@ -13,3 +13,5 @@ execute if entity @s[type=slime] run function gm4_everstone:aging/update_age/sli
 execute if entity @s[type=stray] run function gm4_everstone:aging/update_age/stray
 execute if entity @s[type=vindicator] run function gm4_everstone:aging/update_age/vindicator
 execute if entity @s[type=zombie] run function gm4_everstone:aging/update_age/zombie
+
+tag @e remove gm4_es_new_mob

--- a/gm4_everstone/data/gm4_everstone/functions/aging/update_age/check_mob.mcfunction
+++ b/gm4_everstone/data/gm4_everstone/functions/aging/update_age/check_mob.mcfunction
@@ -4,6 +4,8 @@
 # run from aging/multiple
 # and from aging/single
 
+tag @e remove gm4_es_new_mob
+
 function #gm4_everstone:update_age
 
 execute if entity @s[type=guardian] run function gm4_everstone:aging/update_age/guardian


### PR DESCRIPTION
There's a bug with Everstone due to an assumption I made involving tags and the data merge command.