### PR TITLE
Vecto Shamir: Add mangrove boat and fix biome names

### DIFF
--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/functions/vehicle/spawn_boat.mcfunction
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/functions/vehicle/spawn_boat.mcfunction
@@ -21,6 +21,7 @@ execute if predicate gm4_vecto_shamir:biome/birch run data merge entity @e[type=
 execute if predicate gm4_vecto_shamir:biome/dark_oak run data merge entity @e[type=minecraft:boat,tag=gm4_vecto_new_vehicle,distance=..1,sort=nearest,limit=1] {Type:"dark_oak"}
 execute if predicate gm4_vecto_shamir:biome/jungle run data merge entity @e[type=minecraft:boat,tag=gm4_vecto_new_vehicle,distance=..1,sort=nearest,limit=1] {Type:"jungle"}
 execute if predicate gm4_vecto_shamir:biome/spruce run data merge entity @e[type=minecraft:boat,tag=gm4_vecto_new_vehicle,distance=..1,sort=nearest,limit=1] {Type:"spruce"}
+execute if predicate gm4_vecto_shamir:biome/mangrove run data merge entity @e[type=minecraft:boat,tag=gm4_vecto_new_vehicle,distance=..1,sort=nearest,limit=1] {Type:"mangrove"}
 
 # remove new tag
 tag @e[type=minecraft:boat,tag=gm4_vecto_new_vehicle,distance=..1,sort=nearest,limit=1] remove gm4_vecto_new_vehicle

--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/acacia.json
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/acacia.json
@@ -4,13 +4,7 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:shattered_savanna_plateau"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:shattered_savanna"
+        "biome": "minecraft:savanna"
       }
     },
     {
@@ -22,7 +16,7 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:savanna"
+        "biome": "minecraft:windswept_savanna"
       }
     }
   ]

--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/birch.json
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/birch.json
@@ -4,25 +4,13 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:tall_birch_hills"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:tall_birch_forest"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:birch_forest_hills"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
         "biome": "minecraft:birch_forest"
+      }
+    },
+    {
+      "condition": "minecraft:location_check",
+      "predicate": {
+        "biome": "minecraft:old_growth_birch_forest"
       }
     }
   ]

--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/jungle.json
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/jungle.json
@@ -4,43 +4,19 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:modified_jungle_edge"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:modified_jungle"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:jungle_hills"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:jungle_edge"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
         "biome": "minecraft:jungle"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:bamboo_jungle_hills"
+        "biome": "minecraft:bamboo_jungle"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:bamboo_jungle"
+        "biome": "minecraft:sparse_jungle"
       }
     }
   ]

--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/mangrove.json
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/mangrove.json
@@ -1,6 +1,6 @@
 {
   "condition": "minecraft:location_check",
   "predicate": {
-    "biome": "minecraft:dark_forest"
+    "biome": "minecraft:mangrove_swamp"
   }
 }

--- a/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/spruce.json
+++ b/gm4_vecto_shamir/data/gm4_vecto_shamir/predicates/biome/spruce.json
@@ -4,43 +4,7 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:wooded_mountains"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:taiga_mountains"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:taiga_hills"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
         "biome": "minecraft:taiga"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:snowy_tundra"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:snowy_taiga_mountains"
-      }
-    },
-    {
-      "condition": "minecraft:location_check",
-      "predicate": {
-        "biome": "minecraft:snowy_taiga_hills"
       }
     },
     {
@@ -52,55 +16,55 @@
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:snowy_mountains"
+        "biome": "minecraft:snowy_plains"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:mountains"
+        "biome": "minecraft:snowy_beach"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:mountain_edge"
+        "biome": "minecraft:snowy_slopes"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:modified_gravelly_mountains"
+        "biome": "minecraft:old_growth_pine_taiga"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:gravelly_mountains"
+        "biome": "minecraft:old_growth_spruce_taiga"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:giant_tree_taiga_hills"
+        "biome": "minecraft:windswept_forest"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:giant_tree_taiga"
+        "biome": "minecraft:windswept_hills"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:giant_spruce_taiga_hills"
+        "biome": "minecraft:windswept_gravelly_hills"
       }
     },
     {
       "condition": "minecraft:location_check",
       "predicate": {
-        "biome": "minecraft:giant_spruce_taiga"
+        "biome": "minecraft:grove"
       }
     }
   ]


### PR DESCRIPTION
- Mangrove boat added, by using vecto in a Mangrove Swamp
- Fixed list of biomes for each type of boat, as the 1.19 update removed and changed many biome names

Small known issue is that the boat can't be spawned when standing on a mud block because of its hitbox, but this can't really be fixed