### PR TITLE
Fix Versioning of Libraries

### DIFF
--- a/base/data/gm4-1.2/functions/enumerate.mcfunction
+++ b/base/data/gm4-1.2/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4 load.status matches 1.. run scoreboard players set gm4 load.status 1
 execute if score gm4 load.status matches 1 unless score gm4_minor load.status matches 2.. run scoreboard players set gm4_minor load.status 2
+
+execute unless score gm4 load.status matches 1.. run scoreboard players set gm4_minor load.status 2
+execute unless score gm4 load.status matches 1.. run scoreboard players set gm4 load.status 1

--- a/lib_brewing/data/gm4_brewing-1.0/functions/enumerate.mcfunction
+++ b/lib_brewing/data/gm4_brewing-1.0/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4_brewing load.status matches 1.. run scoreboard players set gm4_brewing load.status 1
 execute if score gm4_brewing load.status matches 1 unless score gm4_brewing_minor load.status matches 0.. run scoreboard players set gm4_brewing_minor load.status 0
+
+execute unless score gm4_brewing load.status matches 1.. run scoreboard players set gm4_brewing_minor load.status 0
+execute unless score gm4_brewing load.status matches 1.. run scoreboard players set gm4_brewing load.status 1

--- a/lib_forceload/data/gm4_forceload-1.1/functions/enumerate.mcfunction
+++ b/lib_forceload/data/gm4_forceload-1.1/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4_forceload load.status matches 1.. run scoreboard players set gm4_forceload load.status 1
 execute if score gm4_forceload load.status matches 1 unless score gm4_forceload_minor load.status matches 1.. run scoreboard players set gm4_forceload_minor load.status 1
+
+execute unless score gm4_forceload load.status matches 1.. run scoreboard players set gm4_forceload_minor load.status 1
+execute unless score gm4_forceload load.status matches 1.. run scoreboard players set gm4_forceload load.status 1

--- a/lib_lore/data/gm4_lore-1.0/functions/enumerate.mcfunction
+++ b/lib_lore/data/gm4_lore-1.0/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4_lore load.status matches 1.. run scoreboard players set gm4_lore load.status 1
 execute if score gm4_lore load.status matches 1 unless score gm4_lore_minor load.status matches 0.. run scoreboard players set gm4_lore_minor load.status 0
+
+execute unless score gm4_lore load.status matches 1.. run scoreboard players set gm4_lore_minor load.status 0
+execute unless score gm4_lore load.status matches 1.. run scoreboard players set gm4_lore load.status 1

--- a/lib_machines/data/gm4_custom_crafters-2.0/functions/enumerate.mcfunction
+++ b/lib_machines/data/gm4_custom_crafters-2.0/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute if score gm4_machines load.status matches 1 unless score gm4_custom_crafters load.status matches 2.. run scoreboard players set gm4_custom_crafters load.status 2
 execute if score gm4_custom_crafters load.status matches 2 unless score gm4_custom_crafters_minor load.status matches 0.. run scoreboard players set gm4_custom_crafters_minor load.status 0
+
+execute if score gm4_machines load.status matches 1 unless score gm4_custom_crafters load.status matches 0.. run scoreboard players set gm4_custom_crafters_minor load.status 0
+execute if score gm4_machines load.status matches 1 unless score gm4_custom_crafters load.status matches 2.. run scoreboard players set gm4_custom_crafters load.status 2

--- a/lib_machines/data/gm4_machines-1.1/functions/enumerate.mcfunction
+++ b/lib_machines/data/gm4_machines-1.1/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1 unless score gm4_machines load.status matches 1.. run scoreboard players set gm4_machines load.status 1
 execute if score gm4_machines load.status matches 1 unless score gm4_machines_minor load.status matches 1.. run scoreboard players set gm4_machines_minor load.status 1
+
+execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1.. unless score gm4_machines load.status matches 1.. run scoreboard players set gm4_machines_minor load.status 1
+execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1.. unless score gm4_machines load.status matches 1.. run scoreboard players set gm4_machines load.status 1

--- a/lib_player_heads/data/gm4_player_heads-1.1/functions/enumerate.mcfunction
+++ b/lib_player_heads/data/gm4_player_heads-1.1/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4_player_heads load.status matches 1.. run scoreboard players set gm4_player_heads load.status 1
 execute if score gm4_player_heads load.status matches 1 unless score gm4_player_heads_minor load.status matches 1.. run scoreboard players set gm4_player_heads_minor load.status 1
+
+execute unless score gm4_player_heads load.status matches 1.. run scoreboard players set gm4_player_heads_minor load.status 1
+execute unless score gm4_player_heads load.status matches 1.. run scoreboard players set gm4_player_heads load.status 1

--- a/lib_potion_tracking/data/gm4_potion_tracking-1.0/functions/enumerate.mcfunction
+++ b/lib_potion_tracking/data/gm4_potion_tracking-1.0/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1 unless score gm4_potion_tracking load.status matches 1.. run scoreboard players set gm4_potion_tracking load.status 1
 execute if score gm4_potion_tracking load.status matches 1 unless score gm4_potion_tracking_minor load.status matches 0.. run scoreboard players set gm4_potion_tracking_minor load.status 0
+
+execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1.. unless score gm4_potion_tracking load.status matches 1.. run scoreboard players set gm4_potion_tracking_minor load.status 0
+execute if score gm4_forceload load.status matches 1 if score gm4_forceload_minor load.status matches 1.. unless score gm4_potion_tracking load.status matches 1.. run scoreboard players set gm4_potion_tracking load.status 1

--- a/lib_trades/data/gm4_trades-1.0/functions/enumerate.mcfunction
+++ b/lib_trades/data/gm4_trades-1.0/functions/enumerate.mcfunction
@@ -1,2 +1,4 @@
-execute unless score gm4_trades load.status matches 1.. run scoreboard players set gm4_trades load.status 1
 execute if score gm4_trades load.status matches 1 unless score gm4_trades_minor load.status matches 0.. run scoreboard players set gm4_trades_minor load.status 0
+
+execute unless score gm4_trades load.status matches 1.. run scoreboard players set gm4_trades_minor load.status 0
+execute unless score gm4_trades load.status matches 1.. run scoreboard players set gm4_trades load.status 1


### PR DESCRIPTION
We did our versioning wrong because we never verify if the minor version matches the major version before changing the minor version.

Without this PR, when we bump the major version, the minor version can remain the same as the old minor version. E.g. base 1.2 would convert to base 2.2 instead of base 2.0 since minor version 2 is greater than minor version 0.

Once this PR is merged, the versioning will work properly and the minor version will always match its major version. Note that this is a non-breaking change and as long as this gets merged it will fix the mistakes of the old versioning