### PR TITLE
Fix Images/GIFs in readmes

### DIFF
--- a/gm4_chairs/README.md
+++ b/gm4_chairs/README.md
@@ -1,20 +1,20 @@
 # Chairs by Gamemode 4
 
 Since the dawn of Minecraft, stairs have been used as chairs in every house you've ever built. With this simple datapack, players can actually sit on stairs by throwing a saddle on them. 
-![Chairs Creation Example](./images/chairs_creation_example.webp)
+![Chairs Creation Example](https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/gm4_chairs/images/chairs_creation_example.webp)
 
 ### Features:
 - Throw a saddle on any stair block to turn it into a chair, which you can sit on
 - Adds two chair-related advancements
 - No texture pack required!
 
-![Chairs Any Stair Example](./images/chairs_any_stair_example.png)
+![Chairs Any Stair Example](https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/gm4_chairs/images/chairs_any_stair_example.png)
 
 ### More Info
-[<img src="../base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=7KbBw1hEKdY) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=7KbBw1hEKdY) 
 
-[<img src="../base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Chairs) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Chairs) 
 
 
-## About Gamemode 4 <img src="../base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
+## About Gamemode 4 <img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
 Gamemode 4 is a series of command-powered creations that are designed to change and enhance the survival experience. All of our modules are designed to work together flawlessly, and are balanced for usage in a survival setting. Pick and choose your favorites from our [website](https://gm4.co).

--- a/gm4_note_block_interface/README.md
+++ b/gm4_note_block_interface/README.md
@@ -6,13 +6,13 @@ Note Blocks have always been a bit... odd to use. Figuring out what note its set
 - The current pitch of a note block is displayed above it when struck or tuned by the player.
 - Enables tuning back down the scale by sneaking while tuning the note block
 
-![Note Block Interface Example](./images/note_block_interface_example.webp)
+![Note Block Interface Example](https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/gm4_note_block_interface/images/note_block_interface_example.webp)
 
 ### More Info
-[<img src="../base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=Kqrdy-8-sb8) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=Kqrdy-8-sb8) 
 
-[<img src="../base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Note_Block_Interface) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Note_Block_Interface) 
 
 
-## About Gamemode 4 <img src="../base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
+## About Gamemode 4 <img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
 Gamemode 4 is a series of command-powered creations that are designed to change and enhance the survival experience. All of our modules are designed to work together flawlessly, and are balanced for usage in a survival setting. Pick and choose your favorites from our [website](https://gm4.co).

--- a/gm4_ziprails/README.md
+++ b/gm4_ziprails/README.md
@@ -7,13 +7,13 @@ Everyone loves building minecart rail systems, but giant mono-rails across your 
 - Minecarts will travel down a ziprail until it reaches the other end, much like a gondola or cable-car
 - Adds a custom advancement for your first ride in the sky
 
-![Ziprails Example](./images/ziprails_example.webp)
+![Ziprails Example](https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/gm4_ziprails/images/ziprails_example.webp)
 
 ### More Info
-[<img src="../base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=QA7a5q2kVcg) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/youtube_logo.png" alt="Youtube Logo" width="40" align="center"/> **Watch on Youtube**](https://www.youtube.com/watch?v=QA7a5q2kVcg) 
 
-[<img src="../base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Ziprails) 
+[<img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_wiki_logo.png" alt="Gamemode 4 Wiki Logo" width="40" align="center"/> **Read the Wiki**](https://wiki.gm4.co/wiki/Ziprails) 
 
 
-## About Gamemode 4 <img src="../base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
+## About Gamemode 4 <img src="https://raw.githubusercontent.com/Gamemode4Dev/GM4_Datapacks/master/base/images/gm4_logo.png" alt="Gamemode 4 Logo" width="20"/>
 Gamemode 4 is a series of command-powered creations that are designed to change and enhance the survival experience. All of our modules are designed to work together flawlessly, and are balanced for usage in a survival setting. Pick and choose your favorites from our [website](https://gm4.co).


### PR DESCRIPTION
When published to Smithed (or technically any other site), references to images doesn't work with `./` and `../` since those paths don't exist anywhere outside of github. This PR updates the images to use the raw file from Github.