### PR TITLE
Improved Metallurgy Band Recycling

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/finish_band.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/finish_band.mcfunction
@@ -1,16 +1,12 @@
 # @s = mould requesting a band
 # run from any function in casting/summon_band
 
+# tag available shamirs
 tag @e[type=item,distance=..0.1,nbt={Age:0s,Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}] add gm4_ml_band
 
-# kill the band that matches the recasted band
-execute store success score $has_recasted_band gm4_ml_data run data modify storage gm4_metallurgy:temp/item/cast stored_shamir set from entity @s ArmorItems[0].tag.gm4_metallurgy.stored_shamir
-execute if score $has_recasted_band gm4_ml_data matches 1 as @e[type=item,tag=gm4_ml_band] run function gm4_metallurgy:casting/prevent_duplicate_recast
-data remove storage gm4_metallurgy:temp/item/cast recasted_shamir
-data remove storage gm4_metallurgy:temp/item/cast stored_shamir
-
-#select a random item and kill others
-tag @e[type=item,tag=gm4_ml_band,sort=random,limit=1] add gm4_ml_selected_band
-kill @e[type=item,tag=!gm4_ml_selected_band,tag=gm4_ml_band]
-
-scoreboard players set $band_applied gm4_ml_data 1
+# check whether some available shamirs must be excluded due to a recast
+execute store success score $has_recasted_band gm4_ml_data run data modify storage gm4_metallurgy:temp/item/cast previous set from entity @s ArmorItems[0].tag.gm4_metallurgy
+# | recast detected, reduce the amount of available shamirs
+execute if score $has_recasted_band gm4_ml_data matches 1 run function gm4_metallurgy:casting/prevent_duplicate/prepare_memory
+# | no recast detected (ore-only cast), skip recast logic
+execute unless score $has_recasted_band gm4_ml_data matches 1 run function gm4_metallurgy:casting/select_shamir

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/compare_entry.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/compare_entry.mcfunction
@@ -2,7 +2,7 @@
 # @s = new obsidian cast that was created by a recasted band
 # at location of mold requesting a band
 # run from gm4_metallurgy:casting/prevent_duplicate/init_comparison and recursed from gm4_metallurgy:casting/prevent_duplicate/cycle_list
-tellraw @a ["",{"text":"    Step: ","color":"blue"},{"score":{"name":"$cycle_count","objective":"gm4_ml_data"},"color":"gray"},{"text":", Entry: ","color":"blue"},{"nbt":"previous.excluded_shamirs[0]","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
+
 # check whether currently target memorized shamir is this shamir option
 data modify storage gm4_metallurgy:temp/item/cast previous.target_shamir set from storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs[0]
 execute store result score $different_shamir gm4_ml_data run data modify storage gm4_metallurgy:temp/item/cast previous.target_shamir set from entity @s Item.tag.gm4_metallurgy.stored_shamir
@@ -10,4 +10,3 @@ execute store result score $different_shamir gm4_ml_data run data modify storage
 # decide whether to target the next memorized shamir or remove the duplicate if a match was found
 execute unless score $different_shamir gm4_ml_data matches 1 run function gm4_metallurgy:casting/prevent_duplicate/remove_entry
 execute if score $different_shamir gm4_ml_data matches 1 if score $cycle_count gm4_ml_data < $excluded_shamirs gm4_ml_data run function gm4_metallurgy:casting/prevent_duplicate/cycle_list
-execute if score $different_shamir gm4_ml_data matches 1 if score $cycle_count gm4_ml_data = $excluded_shamirs gm4_ml_data run tellraw @a ["",{"text":"      Allowed: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"green"}]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/compare_entry.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/compare_entry.mcfunction
@@ -1,0 +1,13 @@
+# Compares the currently targeted memorized shamir to this shamir option.
+# @s = new obsidian cast that was created by a recasted band
+# at location of mold requesting a band
+# run from gm4_metallurgy:casting/prevent_duplicate/init_comparison and recursed from gm4_metallurgy:casting/prevent_duplicate/cycle_list
+tellraw @a ["",{"text":"    Step: ","color":"blue"},{"score":{"name":"$cycle_count","objective":"gm4_ml_data"},"color":"gray"},{"text":", Entry: ","color":"blue"},{"nbt":"previous.excluded_shamirs[0]","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
+# check whether currently target memorized shamir is this shamir option
+data modify storage gm4_metallurgy:temp/item/cast previous.target_shamir set from storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs[0]
+execute store result score $different_shamir gm4_ml_data run data modify storage gm4_metallurgy:temp/item/cast previous.target_shamir set from entity @s Item.tag.gm4_metallurgy.stored_shamir
+
+# decide whether to target the next memorized shamir or remove the duplicate if a match was found
+execute unless score $different_shamir gm4_ml_data matches 1 run function gm4_metallurgy:casting/prevent_duplicate/remove_entry
+execute if score $different_shamir gm4_ml_data matches 1 if score $cycle_count gm4_ml_data < $excluded_shamirs gm4_ml_data run function gm4_metallurgy:casting/prevent_duplicate/cycle_list
+execute if score $different_shamir gm4_ml_data matches 1 if score $cycle_count gm4_ml_data = $excluded_shamirs gm4_ml_data run tellraw @a ["",{"text":"      Allowed: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"green"}]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/cycle_list.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/cycle_list.mcfunction
@@ -1,0 +1,12 @@
+# Cycles the list of memorized shamirs once, thereby decrementing the index of each element by 1. Element 0 becomes element -1.
+# @s = new obsidian cast that was created by a recasted band
+# at location of mold requesting a band
+# run from gm4_metallurgy:casting/prevent_duplicate/compare_entry
+
+# cycle storage
+data modify storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs append from storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs[0]
+data remove storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs[0]
+scoreboard players add $cycle_count gm4_ml_data 1
+
+# try to prevent duplicate recast on new targeted memorized shamir
+function gm4_metallurgy:casting/prevent_duplicate/compare_entry

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/inherit_memory.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/inherit_memory.mcfunction
@@ -1,0 +1,7 @@
+# Copys the list of memorized shamirs onto a new obsidian cast if recasting was used.
+# @s = new obsidian cast that was created by a recasted band
+# at location of mold requesting a band
+# run from any function in casting/finish_band
+
+data modify entity @e[type=item,tag=gm4_ml_selected_band,limit=1] Item.tag.gm4_metallurgy.memorized_shamirs set from storage gm4_metallurgy:temp/item/cast previous.memorized_shamirs
+data remove storage gm4_metallurgy:temp/item/cast previous

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/init_comparison.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/init_comparison.mcfunction
@@ -6,10 +6,6 @@
 # check length of excluded shamirs list (length changes as the shamir options remove themselves)
 execute store result score $excluded_shamirs gm4_ml_data run data get storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs
 scoreboard players set $cycle_count gm4_ml_data 1
-tellraw @a ["",{"text":"Comparing...","color":"gray"}]
-tellraw @a ["",{"text":"  Target: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"gray"}]
-tellraw @a ["",{"text":"  Exclude List: ","color":"blue"},{"nbt":"previous.excluded_shamirs","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
 
 # compare targeted memorized shamir if there are shamirs to exclude
 execute if score $excluded_shamirs gm4_ml_data matches 1.. run function gm4_metallurgy:casting/prevent_duplicate/compare_entry
-execute unless score $excluded_shamirs gm4_ml_data matches 1.. run tellraw @a ["",{"text":"  Allowed: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"green"}]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/init_comparison.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/init_comparison.mcfunction
@@ -1,0 +1,15 @@
+# Initializes some values required for the comparisons.
+# @s = new obsidian cast that was created by a recasted band
+# at location of mold requesting a band
+# run from any function in casting/finish_band
+
+# check length of excluded shamirs list (length changes as the shamir options remove themselves)
+execute store result score $excluded_shamirs gm4_ml_data run data get storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs
+scoreboard players set $cycle_count gm4_ml_data 1
+tellraw @a ["",{"text":"Comparing...","color":"gray"}]
+tellraw @a ["",{"text":"  Target: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"gray"}]
+tellraw @a ["",{"text":"  Exclude List: ","color":"blue"},{"nbt":"previous.excluded_shamirs","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
+
+# compare targeted memorized shamir if there are shamirs to exclude
+execute if score $excluded_shamirs gm4_ml_data matches 1.. run function gm4_metallurgy:casting/prevent_duplicate/compare_entry
+execute unless score $excluded_shamirs gm4_ml_data matches 1.. run tellraw @a ["",{"text":"  Allowed: ","color":"blue"},{"nbt":"Item.tag.gm4_metallurgy.stored_shamir","entity":"@s","color":"green"}]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/prepare_memory.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/prepare_memory.mcfunction
@@ -1,0 +1,17 @@
+# Prepares the list of memorized shamirs by adding the currenlty stored shamir to it. Starts the comparison process.
+# @s = mould requesting a band
+# at location of mold requesting a band
+# run from gm4_metallurgy:casting/finish_band
+
+# prepare storage with stored shamir of recast cast (memorized_shamirs never contains the current shamir on a obsidian cast)
+data modify storage gm4_metallurgy:temp/item/cast previous.memorized_shamirs prepend from storage gm4_metallurgy:temp/item/cast previous.stored_shamir
+
+# copy to new field to allow for search optimization via entry deletion
+data modify storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs set from storage gm4_metallurgy:temp/item/cast previous.memorized_shamirs
+tellraw @a ["",{"text":"Memorized Shamirs: ","color":"blue"},{"nbt":"previous.memorized_shamirs","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
+
+# remove shamirs that are included in the memorized shamirs from the shamir pool
+execute as @e[type=item,tag=gm4_ml_band] run function gm4_metallurgy:casting/prevent_duplicate/init_comparison
+
+# if there are any shamirs remaining, spawn the shamir, otherwise a mundane band is spawned as the flag $band_applied gm4_ml_data remains at 0
+execute if entity @e[type=item,tag=gm4_ml_band,limit=1] run function gm4_metallurgy:casting/select_shamir

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/prepare_memory.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/prepare_memory.mcfunction
@@ -8,7 +8,6 @@ data modify storage gm4_metallurgy:temp/item/cast previous.memorized_shamirs pre
 
 # copy to new field to allow for search optimization via entry deletion
 data modify storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs set from storage gm4_metallurgy:temp/item/cast previous.memorized_shamirs
-tellraw @a ["",{"text":"Memorized Shamirs: ","color":"blue"},{"nbt":"previous.memorized_shamirs","storage":"gm4_metallurgy:temp/item/cast","color":"gray"}]
 
 # remove shamirs that are included in the memorized shamirs from the shamir pool
 execute as @e[type=item,tag=gm4_ml_band] run function gm4_metallurgy:casting/prevent_duplicate/init_comparison

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/remove_entry.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/remove_entry.mcfunction
@@ -1,0 +1,11 @@
+# Removes a duplicate recast option from the pool of possible shamirs and the list of memorized shamirs. The latter being for performance reasons.
+# @s = new obsidian cast that was created by a recasted band
+# at location of mold requesting a band
+# run from gm4_metallurgy:casting/prevent_duplicate/compare_entry
+tellraw @a ["",{"text":"      Excluded: ","color":"blue"},{"nbt":"previous.excluded_shamirs[0]","storage":"gm4_metallurgy:temp/item/cast","color":"red"}]
+
+# kill item
+kill @s
+
+# remove entry in list of memorized shamirs
+data remove storage gm4_metallurgy:temp/item/cast previous.excluded_shamirs[0]

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/remove_entry.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate/remove_entry.mcfunction
@@ -2,7 +2,6 @@
 # @s = new obsidian cast that was created by a recasted band
 # at location of mold requesting a band
 # run from gm4_metallurgy:casting/prevent_duplicate/compare_entry
-tellraw @a ["",{"text":"      Excluded: ","color":"blue"},{"nbt":"previous.excluded_shamirs[0]","storage":"gm4_metallurgy:temp/item/cast","color":"red"}]
 
 # kill item
 kill @s

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate_recast.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/prevent_duplicate_recast.mcfunction
@@ -1,7 +1,0 @@
-# @s = new obsidian cast that was created by a recasted band
-# run from any function in casting/finish_band
-
-data modify storage gm4_metallurgy:temp/item/cast recasted_shamir set from storage gm4_metallurgy:temp/item/cast stored_shamir
-execute store result score $different_shamir gm4_ml_data run data modify storage gm4_metallurgy:temp/item/cast recasted_shamir set from entity @s Item.tag.gm4_metallurgy.stored_shamir
-
-execute unless score $different_shamir gm4_ml_data matches 1 run kill @s

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/casting/select_shamir.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/casting/select_shamir.mcfunction
@@ -1,0 +1,14 @@
+# Selects a shamir from the available options
+# @s = mould requesting a band
+# at location of mold requesting a band
+# run from gm4_metallurgy:casting/finish_band
+
+# select a random shamir item and kill others
+tag @e[type=item,tag=gm4_ml_band,sort=random,limit=1] add gm4_ml_selected_band
+kill @e[type=item,tag=!gm4_ml_selected_band,tag=gm4_ml_band]
+
+# copy memorized shamirs list to selected band if this was a recast
+execute if score $has_recasted_band gm4_ml_data matches 1 run function gm4_metallurgy:casting/prevent_duplicate/inherit_memory
+
+# set band applied to one if a band was applied, if not (too many exclusions) set flag to 0 (triggers creation of mundane band)
+scoreboard players set $band_applied gm4_ml_data 1

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/add_band/found_item.mcfunction
@@ -5,6 +5,7 @@
 # apply the shamir to the item, copying its tags in the process
 data merge entity @s {Tags:["gm4_ml_smooshed"],Item:{tag:{gm4_metallurgy:{has_shamir:1b}}}}
 data modify entity @s Item.tag.gm4_metallurgy.active_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.stored_shamir
+data modify entity @s Item.tag.gm4_metallurgy.memorized_shamirs set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.memorized_shamirs
 data modify entity @s Item.tag.gm4_metallurgy.metal.type set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.metal.type
 data modify entity @s Item.tag.display.Lore prepend from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.display.Lore[]
 execute as @e[type=item,tag=gm4_ml_source,dx=0,limit=1] if data entity @s Item.tag.gm4_metallurgy.custom_model_data run data modify entity @s Item.tag.CustomModelData set from entity @s Item.tag.gm4_metallurgy.custom_model_data

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/smooshing/remove_band/finish_item.mcfunction
@@ -11,6 +11,7 @@ function #gm4_lore:remove
 data modify entity @s Item.tag.display.Lore append from storage gm4_lore:temp Dump[]
 
 data modify entity @s Item.tag.gm4_metallurgy.stored_shamir set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.active_shamir
+data modify entity @s Item.tag.gm4_metallurgy.memorized_shamirs set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.memorized_shamirs
 data modify entity @s Item.tag.CustomModelData set from entity @e[type=item,tag=gm4_ml_source,dx=0,limit=1] Item.tag.gm4_metallurgy.custom_model_data
 
 data remove storage gm4_metallurgy:temp/shamir skull_owner


### PR DESCRIPTION
This PR expands on the duplicate protection currently in place when casting a Shamir by nudging the odds even more. This is of particular importance as the amount of Shamirs keeps on increasing, making for a rather frustrating casting experience.

### What is the current duplicate protection?
Currently, if a Obsidian Cast is recycled during casting (replacing some of the ores that would usually be required), the newly cast Shamir can not be the same as the one that was on the recycled Obsidian Cast.
Due to the amount of metal an Obsidian Cast contributes, only one Obsidian Cast can be recycled per successful Shamir cast.

Whilst this makes casting slightly less frustrating, it barely makes a difference as the amount of available Shamirs grows. I.e. if there are only two Shamirs installed (e.g. with base Metallurgy) this makes casting trivial, as you'll always get the Shamir you want after a maximum of two casts. However, if there are 20 Shamirs available for a metal the current system has practically no impact at all.

### How does this PR improve the system?
This PR introduces a memory of previous Shamirs on each metal band. Whenever an Obsidian Cast is recycled and turns into a new Obsidian Cast with another Shamir, the old Shamir is added to this memory/list. E.g. if an Arborenda Obsidian Cast is recycled and turns into a Sensus Obsidian Cast recycling that Sensus Obsidian Cast will yield neither Arborenda nor Sensus.
If no more Shamirs are available, a Mundane Band Obsidian Cast is created, otherwise another Shamir is created, e.g. Iacio.

**Notable Consequences**
- Using this system, an unlucky player must cast `<amount of Shamirs available on the metal>`-times to get the Shamir they want
- This makes Obsidian Casts less stackable, as the Memory of each is stored on the item. We could consider making Shamirs unstackable altogether by storing a UUID within the NBT, e.g. at `gm4.unstackable`.

**Footnote -- Metallurgy Codebase**
During the making of this PR I've noticed that Metallurgy could make further use of storage and reduce the amount of duplicate entity selectors in the process. A metallurgy rewrite or code-overhaul should be considered in the near future.
The NBT on metallurgy items could also use a cleanup, however, this would require complicated upgrade paths. E.g. the tags `gm4_metalllurgy.active_shamir`, `gm4_metalllurgy.stored_shamir`, and `gm4_metalllurgy.memorized_shamirs` could be moved to `gm4_metalllurgy.shamir` as `gm4_metalllurgy.shamir.active`, `gm4_metalllurgy.shamir.stored`, and `gm4_metalllurgy.shamir.memorized`.