### PR TITLE
Update Forterra to 1.19

### DIFF
--- a/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/deepslate.json
+++ b/gm4_metallurgy/data/gm4_forterra_shamir/loot_tables/deepslate.json
@@ -5,7 +5,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:cobblestone"
+          "name": "minecraft:cobbled_deepslate"
         }
       ]
     },
@@ -209,6 +209,34 @@
                   }
                 },
                 "biome": "minecraft:windswept_hills"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 1,
+          "name": "minecraft:diamond",
+          "functions": [
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:uniform_bonus_count",
+              "parameters": {
+                "bonusMultiplier": 1.25
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "position": {
+                  "y": {
+                    "min": -63,
+                    "max": 16
+                  }
+                }
               }
             }
           ]
@@ -467,7 +495,7 @@
         },
         {
           "type": "minecraft:empty",
-          "weight": 1000
+          "weight": 400
         }
       ]
     }

--- a/gm4_metallurgy/data/minecraft/loot_tables/blocks/deepslate.json
+++ b/gm4_metallurgy/data/minecraft/loot_tables/blocks/deepslate.json
@@ -1,0 +1,72 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "minecraft:deepslate"
+            },
+            {
+              "type": "minecraft:loot_table",
+              "name": "gm4_forterra_shamir:deepslate",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "nbt": "{gm4_metallurgy:{has_shamir:1b,active_shamir:'forterra'}}"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:cobbled_deepslate"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "__smithed__": {
+    "rules": [
+      {
+        "type": "smithed:insert",
+        "index": 1,
+        "target": "pools[0].entries[0].children",
+        "source": {
+          "type": "smithed:reference",
+          "path": "pools[0].entries[0].children[1]"
+        }
+      }
+    ],
+    "priority": {
+      "default": 0
+    }
+  }
+}


### PR DESCRIPTION
- Increased height range for post 1.18 height increase
- Fortune now modifies returns
- Works for Deepslate, and increased rates
- Decreased rates for Stone