### PR TITLE
Fix Enchantment Extractors' Mending advancement bug

### DIFF
--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/extract_item.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/extract_item.mcfunction
@@ -5,6 +5,10 @@
 
 data modify entity @s HandItems[0] set from storage gm4_enchantment_extractors:temp current_item
 
+# check if mending already in extractor
+data modify storage gm4_enchantment_extractors:temp block_items set from block ~ ~ ~ Items
+execute store result score $existing_mending gm4_ench_data if data storage gm4_enchantment_extractors:temp block_items[{tag:{StoredEnchantments:[{id:"minecraft:mending"}]}}]
+
 # if cursed extract only the curse
 execute if data storage gm4_enchantment_extractors:temp current_item.tag.Enchantments[{id:"minecraft:vanishing_curse"}] run function gm4_enchantment_extractors:extract_vanishing
 execute if data storage gm4_enchantment_extractors:temp current_item.tag.Enchantments[{id:"minecraft:binding_curse"}] run function gm4_enchantment_extractors:extract_binding
@@ -20,17 +24,18 @@ particle enchant ~ ~1.3 ~ 0 0 0 .5 10
 # failed extraction
 execute unless score $added_books gm4_ench_data matches 1.. run function gm4_enchantment_extractors:extract_failed
 
-# grant mending advancement
-data modify storage gm4_enchantment_extractors:temp block_items set from block ~ ~ ~ Items
-execute if data storage gm4_enchantment_extractors:temp block_items[{tag:{Enchantments:[{id:"minecraft:mending"}]}}] unless data storage gm4_enchantment_extractors:temp block_items[{tag:{Enchantments:[{id:"minecraft:mending"},{id:"minecraft:vanishing_curse"}]}}] run advancement grant @a[distance=..5] only gm4:enchantment_extractors_mending
-
 # update block inventory
 scoreboard players operation $slot_count gm4_ench_data += $added_books gm4_ench_data
 data remove storage gm4_enchantment_extractors:temp current_item.tag.Enchantments
 data modify block ~ ~ ~ Items append from storage gm4_enchantment_extractors:temp current_item
 
+# grant mending advancement
+data modify storage gm4_enchantment_extractors:temp block_items set from block ~ ~ ~ Items
+execute unless score $existing_mending gm4_ench_data matches 1.. if data storage gm4_enchantment_extractors:temp block_items[{tag:{StoredEnchantments:[{id:"minecraft:mending"}]}}] unless data storage gm4_enchantment_extractors:temp block_items[{tag:{StoredEnchantments:[{id:"minecraft:mending"},{id:"minecraft:vanishing_curse"}]}}] run advancement grant @a[distance=..5] only gm4:enchantment_extractors_mending
+
 # clean up
 data remove entity @s HandItems[0]
 data remove storage gm4_enchantment_extractors:temp block_items
+scoreboard players reset $existing_mending gm4_ench_data
 scoreboard players reset $curse_extracted gm4_ench_data
 scoreboard players reset $added_books gm4_ench_data


### PR DESCRIPTION
Fixes a bug where attempting any enchantment extraction would grant the advancement.  Now properly grants advancement if Mending is extracted "properly" (without Curse of Vanishing).

*Does not grant advancement if Mending is already in the Extractor