### PR TITLE
Auto Crafter QoL Changes

### DIFF
--- a/gm4_auto_crafting/data/gm4_auto_crafting/functions/main.mcfunction
+++ b/gm4_auto_crafting/data/gm4_auto_crafting/functions/main.mcfunction
@@ -1,4 +1,4 @@
-schedule function gm4_auto_crafting:main 16t
+schedule function gm4_auto_crafting:main 4t
 
 # process machine
 execute as @e[type=marker,tag=gm4_auto_crafter,tag=!gm4_ac_full] at @s if block ~ ~ ~ dropper[triggered=false]{Items:[{}]} positioned ^ ^ ^-1 if block ^1 ^ ^ #gm4_auto_crafting:glass if block ^-1 ^ ^ #gm4_auto_crafting:glass if block ^ ^ ^-1 piston if block ^ ^1 ^ barrel{Items:[{}]} if predicate gm4_auto_crafting:has_multiblock at @s run function gm4_auto_crafting:auto_crafter/process_input

--- a/gm4_auto_crafting/data/gm4_auto_crafting/predicates/has_multiblock.json
+++ b/gm4_auto_crafting/data/gm4_auto_crafting/predicates/has_multiblock.json
@@ -24,123 +24,251 @@
     }
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 1,
-    "offsetY": 1,
-    "offsetZ": 0,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "west",
-          "half": "bottom"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 1,
+        "offsetY": 1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 1,
+        "offsetY": 1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "west",
+              "half": "bottom"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 1,
-    "offsetY": -1,
-    "offsetZ": 0,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "west",
-          "half": "top"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 1,
+        "offsetY": -1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 1,
+        "offsetY": -1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "west",
+              "half": "top"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": -1,
-    "offsetY": 1,
-    "offsetZ": 0,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "east",
-          "half": "bottom"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": -1,
+        "offsetY": 1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": -1,
+        "offsetY": 1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "east",
+              "half": "bottom"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": -1,
-    "offsetY": -1,
-    "offsetZ": 0,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "east",
-          "half": "top"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": -1,
+        "offsetY": -1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": -1,
+        "offsetY": -1,
+        "offsetZ": 0,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "east",
+              "half": "top"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 0,
-    "offsetY": 1,
-    "offsetZ": 1,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "north",
-          "half": "bottom"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": 1,
+        "offsetZ": 1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": 1,
+        "offsetZ": 1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "north",
+              "half": "bottom"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 0,
-    "offsetY": -1,
-    "offsetZ": 1,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "north",
-          "half": "top"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": -1,
+        "offsetZ": 1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": -1,
+        "offsetZ": 1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "north",
+              "half": "top"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 0,
-    "offsetY": 1,
-    "offsetZ": -1,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "south",
-          "half": "bottom"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": 1,
+        "offsetZ": -1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": 1,
+        "offsetZ": -1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "south",
+              "half": "bottom"
+            }
+          }
         }
       }
-    }
+    ]
   },
   {
-    "condition": "minecraft:location_check",
-    "offsetX": 0,
-    "offsetY": -1,
-    "offsetZ": -1,
-    "predicate": {
-      "block": {
-        "tag": "minecraft:wooden_stairs",
-        "state": {
-          "facing": "south",
-          "half": "top"
+    "condition": "minecraft:alternative",
+    "terms": [
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": -1,
+        "offsetZ": -1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:planks"
+          }
+        }
+      },
+      {
+        "condition": "minecraft:location_check",
+        "offsetX": 0,
+        "offsetY": -1,
+        "offsetZ": -1,
+        "predicate": {
+          "block": {
+            "tag": "minecraft:wooden_stairs",
+            "state": {
+              "facing": "south",
+              "half": "top"
+            }
+          }
         }
       }
-    }
+    ]
   }
 ]


### PR DESCRIPTION
- Planks can now be used instead of stairs for the auto crafter multiblock structure
- Auto Crafters run on a clock equal to dropper speed