### PR TITLE
Fix Goblin Stealing

### DIFF
--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/add_count.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/add_count.mcfunction
@@ -1,8 +1,0 @@
-# @s = goblin that's stealing an item
-# run from goblin_steal/diamond and goblin_steal/iron_ingot and goblin_steal/gold_ingot
-
-# randomizer 2% of the time, the item will not add to the goblin's inventory
-execute store result score random gm4_menace_data run data get entity @e[limit=1,sort=random] UUID[0]
-execute if score random gm4_menace_data matches 2.. run scoreboard players add count gm4_menace_data 1
-
-execute store result entity @s ArmorItems[1].Count byte 1 run scoreboard players get count gm4_menace_data

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/check_player.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/check_player.mcfunction
@@ -1,20 +1,18 @@
+# checks if nearby players have any valuables
 # @s = goblin if there are nearby players
+# located at @s
 # run from main
 
 tag @r[gamemode=!creative,gamemode=!spectator,distance=..3] add gm4_goblin_target
-execute store result score diamond gm4_menace_data run clear @p[tag=gm4_goblin_target] diamond 0
-execute store result score iron_ingot gm4_menace_data run clear @p[tag=gm4_goblin_target] iron_ingot 0
-execute store result score gold_ingot gm4_menace_data run clear @p[tag=gm4_goblin_target] gold_ingot 0
+execute store result score diamond gm4_menace_data run clear @a[tag=gm4_goblin_target,limit=1,distance=..3] diamond 0
+execute store result score iron_ingot gm4_menace_data run clear @a[tag=gm4_goblin_target,limit=1,distance=..3] iron_ingot 0
+execute store result score gold_ingot gm4_menace_data run clear @a[tag=gm4_goblin_target,limit=1,distance=..3] gold_ingot 0
 
 # randomizer, (50% diamond, 25% iron, 20% gold attempts will fail)
-execute store result score random gm4_menace_data run data get entity @e[limit=1,sort=random] UUID[0]
-execute if score random gm4_menace_data matches 30.. if score diamond gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/diamond
-execute store result score random gm4_menace_data run data get entity @e[limit=1,sort=random] UUID[0]
-execute if score random gm4_menace_data matches 15.. if score iron_ingot gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/iron_ingot
-execute store result score random gm4_menace_data run data get entity @e[limit=1,sort=random] UUID[0]
-execute if score random gm4_menace_data matches 10.. if score gold_ingot gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/gold_ingot
+execute if score diamond gm4_menace_data matches 1.. unless entity @s[tag=gm4_goblin_diamond_full] if predicate gm4_menacing_goblins:diamond_steal_chance run function gm4_menacing_goblins:goblin_steal/diamond
+execute if score iron_ingot gm4_menace_data matches 1.. unless entity @s[tag=gm4_goblin_iron_full] if predicate gm4_menacing_goblins:iron_steal_chance run function gm4_menacing_goblins:goblin_steal/iron_ingot
+execute if score gold_ingot gm4_menace_data matches 1.. unless entity @s[tag=gm4_goblin_gold_full] if predicate gm4_menacing_goblins:gold_steal_chance run function gm4_menacing_goblins:goblin_steal/gold_ingot
 
-scoreboard players reset random gm4_menace_data
 scoreboard players reset diamond gm4_menace_data
 scoreboard players reset iron_ingot gm4_menace_data
 scoreboard players reset gold_ingot gm4_menace_data

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/diamond.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/diamond.mcfunction
@@ -1,13 +1,17 @@
+# steals a diamond from the player
 # @s = goblin if there are nearby players with diamonds
+# located at @s
 # run from goblin_steal/check_player
 
+# get current diamond count
+execute store result score count gm4_menace_data run data get entity @s ArmorItems[0].Count
+
 # take 1 diamond from player
-clear @p[tag=gm4_goblin_target] diamond 1
+clear @a[tag=gm4_goblin_target,limit=1,distance=..3] diamond 1
 
 # store diamonds at feet slot
-execute store result score count gm4_menace_data run data get entity @s ArmorItems[0].Count
 execute if score count gm4_menace_data matches 0 run data modify entity @s ArmorItems[0] set value {id:"minecraft:diamond",Count:1b}
-execute if score count gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/add_count
+execute if score count gm4_menace_data matches 1..63 if predicate gm4_menacing_goblins:store_chance store result entity @s ArmorItems[0].Count byte 1 run scoreboard players add count gm4_menace_data 1
 
 # show that it got stolen
 data modify entity @s HandItems[1] set value {id:"minecraft:diamond",Count:1b}
@@ -15,6 +19,9 @@ playsound minecraft:entity.zombie.ambient hostile @a[distance=..5] ~ ~ ~ 0.2 2
 playsound minecraft:entity.witch.celebrate hostile @a[distance=..5] ~ ~ ~ 1 2
 playsound minecraft:block.chain.break hostile @a[distance=..5] ~ ~ ~ 2 2
 particle block minecraft:diamond_block ~ ~ ~ 0 0 0 1 15 force
+
+# mark full inventory with tag (to prevent continuous data checks)
+execute if score count gm4_menace_data matches 64.. run tag @s add gm4_goblin_diamond_full
 
 # clear scores
 scoreboard players reset count gm4_menace_data

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/gold_ingot.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/gold_ingot.mcfunction
@@ -1,13 +1,17 @@
+# steals a gold ingot from the player
 # @s = goblin if there are nearby players with gold ingots
+# located at @s
 # run from goblin_steal/check_player
 
+# get current gold ingot count
+execute store result score count gm4_menace_data run data get entity @s ArmorItems[2].Count
+
 # take 1 gold ingot from player
-clear @p[tag=gm4_goblin_target] gold_ingot 1
+clear @a[tag=gm4_goblin_target,limit=1,distance=..3] gold_ingot 1
 
 # store gold ingots at chest slot
-execute store result score count gm4_menace_data run data get entity @s ArmorItems[2].Count
 execute if score count gm4_menace_data matches 0 run data modify entity @s ArmorItems[2] set value {id:"minecraft:gold_ingot",Count:1b}
-execute if score count gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/add_count
+execute if score count gm4_menace_data matches 1..63 if predicate gm4_menacing_goblins:store_chance store result entity @s ArmorItems[2].Count byte 1 run scoreboard players add count gm4_menace_data 1
 
 # show that it got stolen
 data modify entity @s HandItems[1] set value {id:"minecraft:gold_ingot",Count:1b}
@@ -15,6 +19,9 @@ playsound minecraft:entity.zombie.ambient hostile @a[distance=..5] ~ ~ ~ 0.2 2
 playsound minecraft:entity.witch.celebrate hostile @a[distance=..5] ~ ~ ~ 1 2
 playsound minecraft:block.chain.break hostile @a[distance=..5] ~ ~ ~ 2 2
 particle block minecraft:gold_block ~ ~ ~ 0 0 0 1 15 force
+
+# mark full inventory with tag (to prevent continuous data checks)
+execute if score count gm4_menace_data matches 64.. run tag @s add gm4_goblin_gold_full
 
 # clear scores
 scoreboard players reset count gm4_menace_data

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/iron_ingot.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_steal/iron_ingot.mcfunction
@@ -1,13 +1,17 @@
+# steals an iron ingot from the player
 # @s = goblin if there are nearby players with iron ingots
+# located at @s
 # run from goblin_steal/check_player
 
-# take 1 iron ingot from player
-clear @p[tag=gm4_goblin_target] iron_ingot 1
-
-# store iron ingots at legs slot
+# get current iron ingot count
 execute store result score count gm4_menace_data run data get entity @s ArmorItems[1].Count
+
+# take 1 iron ingot from player
+clear @a[tag=gm4_goblin_target,limit=1,distance=..3] iron_ingot 1
+
+# store iron ingots at chest slot
 execute if score count gm4_menace_data matches 0 run data modify entity @s ArmorItems[1] set value {id:"minecraft:iron_ingot",Count:1b}
-execute if score count gm4_menace_data matches 1.. run function gm4_menacing_goblins:goblin_steal/add_count
+execute if score count gm4_menace_data matches 1..63 if predicate gm4_menacing_goblins:store_chance store result entity @s ArmorItems[1].Count byte 1 run scoreboard players add count gm4_menace_data 1
 
 # show that it got stolen
 data modify entity @s HandItems[1] set value {id:"minecraft:iron_ingot",Count:1b}
@@ -15,6 +19,9 @@ playsound minecraft:entity.zombie.ambient hostile @a[distance=..5] ~ ~ ~ 0.2 2
 playsound minecraft:entity.witch.celebrate hostile @a[distance=..5] ~ ~ ~ 1 2
 playsound minecraft:block.chain.break hostile @a[distance=..5] ~ ~ ~ 2 2
 particle block minecraft:iron_block ~ ~ ~ 0 0 0 1 15 force
+
+# mark full inventory with tag (to prevent continuous data checks)
+execute if score count gm4_menace_data matches 64.. run tag @s add gm4_goblin_iron_full
 
 # clear scores
 scoreboard players reset count gm4_menace_data

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_transform.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/goblin_transform.mcfunction
@@ -1,7 +1,7 @@
 # @s = skeleton, zombie, or creeper to be converted into a goblin
 # called by event
 
-summon zombie ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Goblin§",{"translate":"entity.gm4.goblin"}]}',CustomNameVisible:0,Team:"gm4_hide_name",DeathLootTable:"gm4_menacing_goblins:goblin",LeftHanded:1b,CanPickUpLoot:0b,Health:24f,IsBaby:1b,CanBreakDoors:0b,Tags:["gm4_goblin","smithed.entity"],HandItems:[{id:"minecraft:golden_sword",Count:1b},{}],HandDropChances:[0.3F,-327.67F],ArmorItems:[{},{},{},{id:"minecraft:carved_pumpkin",Count:1b,tag:{Enchantments:[{id:"minecraft:thorns",lvl:3s}]}}],ArmorDropChances:[1.0F,1.0F,1.0F,-327.67F],ActiveEffects:[{Id:11,Amplifier:4b,Duration:20,ShowParticles:1b}],Attributes:[{Name:"minecraft:generic.max_health",Base:24.0d},{Name:"minecraft:generic.follow_range",Base:48.0d}]}
+summon zombie ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Goblin§",{"translate":"entity.gm4.goblin"}]}',CustomNameVisible:0,Team:"gm4_hide_name",DeathLootTable:"gm4_menacing_goblins:entities/goblin",LeftHanded:1b,CanPickUpLoot:0b,Health:24f,IsBaby:1b,CanBreakDoors:0b,Tags:["gm4_goblin","smithed.entity"],HandItems:[{id:"minecraft:golden_sword",Count:1b},{}],HandDropChances:[0.3F,-327.67F],ArmorItems:[{},{},{},{id:"minecraft:carved_pumpkin",Count:1b,tag:{Enchantments:[{id:"minecraft:thorns",lvl:3s}]}}],ArmorDropChances:[2.0F,2.0F,2.0F,-327.67F],ActiveEffects:[{Id:11,Amplifier:4b,Duration:20,ShowParticles:1b}],Attributes:[{Name:"minecraft:generic.max_health",Base:24.0d},{Name:"minecraft:generic.follow_range",Base:48.0d}]}
 scoreboard players set @e[type=zombie,tag=gm4_goblin,distance=0] gm4_entity_version 1
 
 tp @e[type=zombie,limit=1,distance=0] @s

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/main.mcfunction
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/functions/main.mcfunction
@@ -1,4 +1,4 @@
 execute as @e[type=zombie,tag=gm4_goblin,tag=!smithed.entity] run function gm4_menaging_goblins:upgrade_path/smithed_compat
-execute as @e[type=zombie,tag=gm4_goblin] at @s if entity @a[limit=1,distance=..3] run function gm4_menacing_goblins:goblin_steal/check_player
+execute as @e[type=zombie,tag=gm4_goblin] unless entity @s[tag=gm4_goblin_diamond_full,tag=gm4_goblin_iron_full,tag=gm4_goblin_gold_full] at @s if entity @a[limit=1,distance=..3] run function gm4_menacing_goblins:goblin_steal/check_player
 
 schedule function gm4_menacing_goblins:main 16t

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/diamond_steal_chance.json
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/diamond_steal_chance.json
@@ -1,0 +1,4 @@
+{
+    "condition": "minecraft:random_chance",
+    "chance": 0.50
+}

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/gold_steal_chance.json
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/gold_steal_chance.json
@@ -1,0 +1,4 @@
+{
+    "condition": "minecraft:random_chance",
+    "chance": 0.80
+}

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/iron_steal_chance.json
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/iron_steal_chance.json
@@ -1,0 +1,4 @@
+{
+    "condition": "minecraft:random_chance",
+    "chance": 0.75
+}

--- a/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/store_chance.json
+++ b/gm4_midnight_menaces/data/gm4_menacing_goblins/predicates/store_chance.json
@@ -1,0 +1,4 @@
+{
+    "condition": "minecraft:random_chance",
+    "chance": 0.85
+}


### PR DESCRIPTION
Midnight menaces goblin steal now properly works and will drop the correct amount of stolen items upon death.

Changes:
- goblin store chance is reduced from 98% to 85%, meaning killing the goblin will only result in 85% of items recovered
- goblins will only store up to 64 of each resource (diamond, gold, iron)
- goblin loot table is fixed and will now drop rotten flesh and nuggets
- stolen items will drop when the goblin is killed by anything, not just upon player kill