### PR TITLE
Fix TP Jammer item name

### DIFF
--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/loot_tables/items/teleportation_jammer.json
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/loot_tables/items/teleportation_jammer.json
@@ -18,7 +18,7 @@
                 {
                   "translate": "%1$s%3427655$s",
                   "with": [
-                    "Teleportation Anchor",
+                    "Teleportation Jammer",
                     {
                       "translate": "block.gm4.teleportation_jammer"
                     }


### PR DESCRIPTION
Currently the Loot Table for TP Jammers gives them the name TP Anchor.

This PR fixes that