### PR TITLE
Fix weld implementation of yellow_shulker_box

### DIFF
--- a/lib_forceload/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
+++ b/lib_forceload/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
@@ -88,10 +88,10 @@
     "rules": [
       {
         "type": "smithed:append",
-        "target": "pools[0].conditions",
+        "target": "pools[0].entries[0].conditions",
         "source": {
           "type": "smithed:reference",
-          "path": "pools[0].conditions[0]"
+          "path": "pools[0].entries[0].conditions[0]"
         }
       },
       {


### PR DESCRIPTION
The loot table works in vanilla, but when used with weld it targets the wrong path.