### PR TITLE
Add Mud Crafting to Cement Mixers

### DIFF
--- a/gm4_cement_mixers/data/gm4_cement_mixers/functions/item_fill/mud.mcfunction
+++ b/gm4_cement_mixers/data/gm4_cement_mixers/functions/item_fill/mud.mcfunction
@@ -1,0 +1,7 @@
+# run from gm4_cement_mixers:item_fill
+# @s = tank being processed
+
+scoreboard players set $item_value gm4_lt_value -1
+data merge storage gm4_liquid_tanks:temp/tank {output:{id:"mud"}}
+function gm4_liquid_tanks:smart_item_fill
+tag @s add gm4_lt_fill

--- a/gm4_cement_mixers/data/gm4_cement_mixers/functions/water_concrete.mcfunction
+++ b/gm4_cement_mixers/data/gm4_cement_mixers/functions/water_concrete.mcfunction
@@ -17,3 +17,6 @@ execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:pu
 execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:red_concrete_powder"}} run function gm4_cement_mixers:item_fill/red_concrete
 execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:white_concrete_powder"}} run function gm4_cement_mixers:item_fill/white_concrete
 execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:yellow_concrete_powder"}} run function gm4_cement_mixers:item_fill/yellow_concrete
+execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:dirt"}} run function gm4_cement_mixers:item_fill/mud
+execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:coarse_dirt"}} run function gm4_cement_mixers:item_fill/mud
+execute if data storage gm4_liquid_tanks:temp/tank {input_slot:{id:"minecraft:rooted_dirt"}} run function gm4_cement_mixers:item_fill/mud


### PR DESCRIPTION
This allows Concrete Mixers to turn `dirt`, `coarse_dirt`, and `rooted_dirt` into `mud` at the cost of a third of a bucket of water.

**NOTE:** I have not tested this in game, neither was this feature discussed within the community yet. 