### PR TITLE
Fix multiple fusing rituals breaking each other

### DIFF
--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/soul_forge/wither_roses/steps.mcfunction
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/functions/soul_forge/wither_roses/steps.mcfunction
@@ -7,9 +7,9 @@ scoreboard players reset @s[scores={gm4_oa_forge=10..}] gm4_oa_forge
 
 # every 160 ticks (8 seconds): spawn an indicator, wait 80 ticks (4 seconds) then consume the wither rose at that indicator if possible
 execute if score @s gm4_oa_forge matches 2 run function gm4_orb_of_ankou:soul_forge/wither_roses/summon_indicator
-scoreboard players add @e[type=marker,tag=gm4_oa_wither_rose_catcher] gm4_oa_marker 16
-execute if score @s gm4_oa_forge matches 8 at @e[type=marker,tag=gm4_oa_wither_rose_catcher,scores={gm4_oa_marker=112..},limit=1,sort=nearest] if block ~ ~ ~ wither_rose run function gm4_orb_of_ankou:soul_forge/wither_roses/consume
-kill @e[type=marker,tag=gm4_oa_wither_rose_catcher,scores={gm4_oa_marker=112..}]
+scoreboard players add @e[type=marker,tag=gm4_oa_wither_rose_catcher,distance=..8,limit=1,sort=nearest] gm4_oa_marker 16
+execute if score @s gm4_oa_forge matches 8 at @e[type=marker,tag=gm4_oa_wither_rose_catcher,scores={gm4_oa_marker=112..},distance=..8,limit=1,sort=nearest] if block ~ ~ ~ wither_rose run function gm4_orb_of_ankou:soul_forge/wither_roses/consume
+kill @e[type=marker,tag=gm4_oa_wither_rose_catcher,scores={gm4_oa_marker=112..},distance=..8]
 
 # indicator particles
 execute at @e[type=marker,tag=gm4_oa_wither_rose_catcher] run particle witch ~ ~ ~ 0 .2 0 0 7 normal


### PR DESCRIPTION
- If two fusing rituals are taking place they can break each other due to lack of distance and limit checking
- Fixes #838