### PR TITLE
[CC Lib] Fix local builds of modules using vanilla item tags

### DIFF
--- a/lib_machines/generate_item_tags.py
+++ b/lib_machines/generate_item_tags.py
@@ -4,7 +4,6 @@ from beet.contrib.vanilla import Vanilla
 MCVERSION = "1.19.2"
 CC_VERSION = "3.0"
 
-
 def beet_default(ctx: Context):
   """Creates a predicate for every vanilla item tag and a function checking all of these predicates."""
   vanilla = ctx.inject(Vanilla)

--- a/lib_machines/generate_item_tags.py
+++ b/lib_machines/generate_item_tags.py
@@ -9,9 +9,9 @@ def beet_default(ctx: Context):
   """Creates a predicate for every vanilla item tag and a function checking all of these predicates."""
   vanilla = ctx.inject(Vanilla)
   item_tags = vanilla.data.item_tags
+  item_tags = [id.removeprefix("minecraft:") for id in item_tags]
 
   for id in item_tags:
-    id = id.removeprefix("minecraft:")
     ctx.data[f"gm4_custom_crafters-{CC_VERSION}:vanilla_item_tags/{id}"] = Predicate({
       "condition": "minecraft:entity_properties",
       "entity": "this",
@@ -30,5 +30,5 @@ def beet_default(ctx: Context):
     "# located at the center of the block",
     f"# run from gm4_custom_crafters-{CC_VERSION}:process_input/check_item via #gm4_custom_crafter:custom_item_checks",
     "",
-    *[f"execute if predicate gm4_custom_crafters-{CC_VERSION}:vanilla_item_tags/{id.removeprefix('minecraft:')} run data modify storage gm4_custom_crafters:temp/crafter item.item_tags.minecraft.{id.removeprefix('minecraft:')} set value 1b" for id in item_tags],
+    *[f"execute if predicate gm4_custom_crafters-{CC_VERSION}:vanilla_item_tags/{id} run data modify storage gm4_custom_crafters:temp/crafter item.item_tags.minecraft.{id} set value 1b" for id in item_tags],
   ])

--- a/lib_machines/generate_item_tags.py
+++ b/lib_machines/generate_item_tags.py
@@ -4,6 +4,7 @@ from beet.contrib.vanilla import Vanilla
 MCVERSION = "1.19.2"
 CC_VERSION = "3.0"
 
+
 def beet_default(ctx: Context):
   """Creates a predicate for every vanilla item tag and a function checking all of these predicates."""
   vanilla = ctx.inject(Vanilla)
@@ -29,5 +30,5 @@ def beet_default(ctx: Context):
     "# located at the center of the block",
     f"# run from gm4_custom_crafters-{CC_VERSION}:process_input/check_item via #gm4_custom_crafter:custom_item_checks",
     "",
-    *[f"execute if predicate gm4_custom_crafters-{CC_VERSION}:vanilla_item_tags/{id} run data modify storage gm4_custom_crafters:temp/crafter item.item_tags.minecraft.{id} set value 1b" for id in item_tags],
+    *[f"execute if predicate gm4_custom_crafters-{CC_VERSION}:vanilla_item_tags/{id.removeprefix('minecraft:')} run data modify storage gm4_custom_crafters:temp/crafter item.item_tags.minecraft.{id.removeprefix('minecraft:')} set value 1b" for id in item_tags],
   ])


### PR DESCRIPTION
Currently, the script for generating the predicates and function for using vanilla item tags in recipes only removes the prefix when using it in the predicate, not the function. This is not an issue when building releases on github, as the github source for `Vanilla` does not have these prefixes at all. However, while building locally, it can have this prefix, causing that function to contain invalid paths.

This change moves the prefix removal in order to fix this issue.