### PR TITLE
Enchantment Extractors: Fix failed extract events

### DIFF
--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/extract_failed.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/extract_failed.mcfunction
@@ -4,13 +4,16 @@
 # run from extract_item
 
 # smoke: 80% -> (1 * 0.8)
-execute store success score $failed_smoke gm4_ench_data if predicate gm4_enchantment_extractors:failed_smoke_chance run particle poof ~ ~1.5 ~ 0.2 0.2 0.2 0.05 5
+scoreboard players set $failed_smoke gm4_ench_data 0
+execute if predicate gm4_enchantment_extractors:failed_smoke_chance store success score $failed_smoke gm4_ench_data run particle poof ~ ~1.5 ~ 0.2 0.2 0.2 0.05 5
 execute if score $failed_smoke gm4_ench_data matches 1 run playsound item.shield.break block @a[distance=..8] ~ ~ ~ 0.6 0.3
 
 # congealed enchantment: 10% -> (1 - 0.8) * 0.5
-execute store success score $failed_congealed_ench gm4_ench_data if score $failed_smoke gm4_ench_data matches 0 if predicate gm4_enchantment_extractors:failed_congealed_chance run summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Congealed Enchantment§",{"translate":"entity.gm4.congealed_enchantment"}]}',CustomNameVisible:0,Team:"gm4_hide_name",LifeTicks:100,Attributes:[{Name:"generic.attack_damage",Base:2}],Health:4.0f,Motion:[0.0,0.35,0.0]}
-execute if score $failed_smoke gm4_ench_data matches 1 run playsound entity.evoker.prepare_attack block @a[distance=..8] ~ ~ ~ .8 1.8
+scoreboard players set $failed_congealed_ench gm4_ench_data 0
+execute if score $failed_smoke gm4_ench_data matches 0 if predicate gm4_enchantment_extractors:failed_congealed_chance store success score $failed_congealed_ench gm4_ench_data run summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Congealed Enchantment§",{"translate":"entity.gm4.congealed_enchantment"}]}',CustomNameVisible:0,Team:"gm4_hide_name",LifeTicks:100,Attributes:[{Name:"generic.attack_damage",Base:2}],Health:4.0f,Motion:[0.0,0.35,0.0]}
+execute if score $failed_congealed_ench gm4_ench_data matches 1 run playsound entity.evoker.prepare_attack block @a[distance=..8] ~ ~ ~ .8 1.8
 
 # living enchantment: 10% -> (1 - 0.8 - ((1 - 0.8) * 0.5)) 
-execute store success score $failed_living_ench gm4_ench_data if score $failed_congealed_ench gm4_ench_data matches 0 run summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Living Enchantment§",{"translate":"entity.gm4.living_enchantment"}]}',CustomNameVisible:0,Team:"gm4_hide_name",HandItems:[{id:"minecraft:golden_sword",Count:1},{}],HandDropChances:[0.0f,0.0f],Motion:[0.0,0.25,0.0]}
-execute if score $failed_congealed_ench gm4_ench_data matches 1 run playsound entity.evoker.prepare_attack block @a[distance=..8] ~ ~ ~ 1.3 .6
+scoreboard players set $failed_living_ench gm4_ench_data 0
+execute if score $failed_smoke gm4_ench_data matches 0 if score $failed_congealed_ench gm4_ench_data matches 0 store success score $failed_living_ench gm4_ench_data run summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Living Enchantment§",{"translate":"entity.gm4.living_enchantment"}]}',CustomNameVisible:0,Team:"gm4_hide_name",HandItems:[{id:"minecraft:golden_sword",Count:1},{}],HandDropChances:[0.0f,0.0f],Motion:[0.0,0.25,0.0]}
+execute if score $failed_living_ench gm4_ench_data matches 1 run playsound entity.evoker.prepare_attack block @a[distance=..8] ~ ~ ~ 1.3 .6


### PR DESCRIPTION
Fixes #863

Vexes can currently spawn, but they were not consistent with the sounds that accompanied them. This PR fixes the inconsistencies and makes sure only one type of failed extract event happens