### PR TITLE
Intro Toast Visibility

### DIFF
--- a/base/data/gm4/advancements/intro_song/root_display.json
+++ b/base/data/gm4/advancements/intro_song/root_display.json
@@ -17,7 +17,7 @@
   "parent": "gm4:intro_song/invisible_root",
   "criteria": {
     "requirement": {
-      "trigger": "minecraft:impossible"
+      "trigger": "minecraft:location"
     }
   }
 }

--- a/base/data/gm4/advancements/intro_song/root_display.json
+++ b/base/data/gm4/advancements/intro_song/root_display.json
@@ -5,7 +5,7 @@
       "nbt": "{CustomModelData:3420001}"
     },
     "title": {
-      "translate": "advancement.gm4.root.title",
+      "translate": "advancement.gm4.welcome_toast.title",
       "fallback": "Gamemode 4"
     },
     "description": {

--- a/base/data/gm4/advancements/intro_song/welcome_toast.json
+++ b/base/data/gm4/advancements/intro_song/welcome_toast.json
@@ -6,7 +6,7 @@
     },
     "title": {
       "translate": "advancement.gm4.welcome_toast.title",
-      "fallback": "This world is using Gamemode 4 Datapacks!"
+      "fallback": "Thank you for using Gamemode 4 Data Packs!"
     },
     "description": {
       "text": "This should not be seen."

--- a/base/data/gm4/advancements/intro_song/welcome_toast.json
+++ b/base/data/gm4/advancements/intro_song/welcome_toast.json
@@ -6,7 +6,7 @@
     },
     "title": {
       "translate": "advancement.gm4.welcome_toast.title",
-      "fallback": "Thank you for using Gamemode 4 Data Packs!"
+      "fallback": "This world is enhanced by Gamemode 4!"
     },
     "description": {
       "text": "This should not be seen."

--- a/base/data/gm4/advancements/intro_song/welcome_toast.json
+++ b/base/data/gm4/advancements/intro_song/welcome_toast.json
@@ -17,7 +17,25 @@
   "parent": "gm4:intro_song/invisible_root",
   "criteria": {
     "requirement": {
-      "trigger": "minecraft:location"
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "gm4"
+              },
+              "score": "gm4_modules"
+            },
+            "range": {
+              "min": 1
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/base/data/gm4/advancements/intro_song/welcome_toast.json
+++ b/base/data/gm4/advancements/intro_song/welcome_toast.json
@@ -6,7 +6,7 @@
     },
     "title": {
       "translate": "advancement.gm4.welcome_toast.title",
-      "fallback": "Gamemode 4"
+      "fallback": "This world is using Gamemode 4 Datapacks!"
     },
     "description": {
       "text": "This should not be seen."

--- a/base/data/gm4/functions/intro_song/main.mcfunction
+++ b/base/data/gm4/functions/intro_song/main.mcfunction
@@ -3,5 +3,4 @@
 execute as @a[tag=gm4_intro_playing] at @s run function gm4:intro_song/play
 
 execute if score $song_playing gm4_intro_song matches 1.. run schedule function gm4:intro_song/main 1t
-execute if score $song_playing gm4_intro_song matches 1.. run advancement grant @a only gm4:intro_song/root_display
 scoreboard players reset $song_playing gm4_intro_song


### PR DESCRIPTION
This PR addresses issue #875.

Moves the intro toast to a loaction-triggered advancement, thereby making it **appear upon first login** for every player, letting them know that Gamemode 4 is installed. Also **updates the text** of this 'Welcome Toast' to use its own translation key and fallback text.

Feel free to discuss the specific fallback message below, especially (check if resolved):
- [x] Datapacks or Data Packs?
- [x] Should we use a location trigger, or use an `impossible` trigger and grant it via functions? The latter would allow for a score-based toggle and/or a score based check instead of relying simple advancement existence.

![image showing the toast popup](https://github.com/Gamemode4Dev/GM4_Datapacks/assets/41843855/5216e4f0-210f-4c0e-9762-d5f6c7f41549)