### PR TITLE
Animi Item Loss Fix

### DIFF
--- a/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/wait_for_respawn.mcfunction
+++ b/gm4_animi_shamir/data/gm4_animi_shamir/functions/player/wait_for_respawn.mcfunction
@@ -3,8 +3,8 @@
 # at world spawn
 # self schduled or run from gm4_animi_shamir:item_caching/add_entry or gm4_animi_shamir:player/rejoin
 
-# look for players that just respawned (@e only selects living entities)
-execute as @e[type=player,scores={gm4_animi_deaths=1..}] at @s run function gm4_animi_shamir:player/upon_respawn
+# look for players that just respawned (@e only selects living entities) and has loaded the chunks around themselves
+execute as @e[type=player,scores={gm4_animi_deaths=1..}] at @s if loaded ~ ~ ~ run function gm4_animi_shamir:player/upon_respawn
 
 # reschedule if there is a player (dead or alive) with a gm4_animi_deaths score (@a also selects dead players)
 execute if entity @p[scores={gm4_animi_deaths=1..}] run schedule function gm4_animi_shamir:player/wait_for_respawn 1t


### PR DESCRIPTION
Adds a simple one-line check to the Animi Shamir, that extends the delay after a player has respawned to wait for the chunks around the player to load. This fixes a long-standing issue (#879) where Animi items would turn to stone after respawning with the player.