### PR TITLE
Fix Arborenda Unbreaking Behaviour

### DIFF
--- a/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/roll_binomial_distribution.json
+++ b/gm4_metallurgy/data/gm4_arborenda_shamir/loot_tables/roll_binomial_distribution.json
@@ -17,7 +17,8 @@
                         "type": "minecraft:fixed",
                         "name": "$damage_chance"
                     },
-                    "score": "gm4_arb_data"
+                    "score": "gm4_arb_data",
+                    "scale": 0.01
                 }
             },
             "entries": [


### PR DESCRIPTION
Fixes #836, which caused Arborenda to effectively ignore Unbreaking.

Note that Arborenda still only uses a single durability point per tree on Spigot due to a Spigot bug.