### PR TITLE
Infinitas Shamir: Update to 1.20 and leftover fixes

### DIFF
--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/empty/pickup_mainhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/empty/pickup_mainhand.json
@@ -21,13 +21,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     },
     "lava_bucket": {
@@ -50,7 +55,7 @@
       }
     },
     "milk_bucket": {
-      "trigger": "minecraft:filled_bucket",
+      "trigger": "minecraft:player_interacted_with_entity",
       "conditions": {
         "player": [
           {
@@ -63,7 +68,7 @@
         ],
         "item": {
           "items": [
-            "minecraft:milk_bucket"
+            "minecraft:bucket"
           ]
         }
       }

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/empty/pickup_offhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/empty/pickup_offhand.json
@@ -21,13 +21,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     },
     "lava_bucket": {
@@ -50,7 +55,7 @@
       }
     },
     "milk_bucket": {
-      "trigger": "minecraft:filled_bucket",
+      "trigger": "minecraft:player_interacted_with_entity",
       "conditions": {
         "player": [
           {
@@ -63,7 +68,7 @@
         ],
         "item": {
           "items": [
-            "minecraft:milk_bucket"
+            "minecraft:bucket"
           ]
         }
       }

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/lava/place_mainhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/lava/place_mainhand.json
@@ -7,35 +7,27 @@
           {
             "condition": "minecraft:inverted",
             "term": {
-              "condition": "minecraft:alternative",
-              "terms": [
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:value_check",
-                    "value": {
-                      "type": "minecraft:score",
-                      "target": {
-                        "type": "minecraft:fixed",
-                        "name": "$lava_infinitas"
-                      },
-                      "score": "gm4_ml_data"
-                    },
-                    "range": 1
-                  }
-                },
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "player",
-                      "gamemode": "creative"
-                    }
-                  }
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
                 }
-              ]
+              }
             }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$lava_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
           },
           {
             "condition": "minecraft:entity_properties",
@@ -51,6 +43,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:lava"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -61,51 +65,55 @@
           {
             "condition": "minecraft:inverted",
             "term": {
-              "condition": "minecraft:alternative",
-              "terms": [
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:value_check",
-                    "value": {
-                      "type": "minecraft:score",
-                      "target": {
-                        "type": "minecraft:fixed",
-                        "name": "$lava_infinitas"
-                      },
-                      "score": "gm4_ml_data"
-                    },
-                    "range": 1
-                  }
-                },
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:entity_properties",
-                    "entity": "this",
-                    "predicate": {
-                      "nbt": "{Tags:[\"gm4_infinitas_mainhand_lava\"]}",
-                      "equipment": {
-                        "mainhand": {
-                          "items": [
-                            "minecraft:bucket"
-                          ]
-                        }
-                      }
-                    }
-                  }
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
                 }
-              ]
+              }
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$lava_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Tags:[\"gm4_infinitas_mainhand_lava\"]}",
+              "equipment": {
+                "mainhand": {
+                  "items": [
+                    "minecraft:bucket"
+                  ]
+                }
+              }
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:lava_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:lava_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/lava/place_offhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/lava/place_offhand.json
@@ -7,35 +7,27 @@
           {
             "condition": "minecraft:inverted",
             "term": {
-              "condition": "minecraft:alternative",
-              "terms": [
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:value_check",
-                    "value": {
-                      "type": "minecraft:score",
-                      "target": {
-                        "type": "minecraft:fixed",
-                        "name": "$lava_infinitas"
-                      },
-                      "score": "gm4_ml_data"
-                    },
-                    "range": 1
-                  }
-                },
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "player",
-                      "gamemode": "creative"
-                    }
-                  }
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
                 }
-              ]
+              }
             }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$lava_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
           },
           {
             "condition": "minecraft:entity_properties",
@@ -51,6 +43,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:lava"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -61,51 +65,55 @@
           {
             "condition": "minecraft:inverted",
             "term": {
-              "condition": "minecraft:alternative",
-              "terms": [
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:value_check",
-                    "value": {
-                      "type": "minecraft:score",
-                      "target": {
-                        "type": "minecraft:fixed",
-                        "name": "$lava_infinitas"
-                      },
-                      "score": "gm4_ml_data"
-                    },
-                    "range": 1
-                  }
-                },
-                {
-                  "condition": "minecraft:inverted",
-                  "term": {
-                    "condition": "minecraft:entity_properties",
-                    "entity": "this",
-                    "predicate": {
-                      "nbt": "{Tags:[\"gm4_infinitas_offhand_lava\"]}",
-                      "equipment": {
-                        "offhand": {
-                          "items": [
-                            "minecraft:bucket"
-                          ]
-                        }
-                      }
-                    }
-                  }
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
                 }
-              ]
+              }
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$lava_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Tags:[\"gm4_infinitas_offhand_lava\"]}",
+              "equipment": {
+                "offhand": {
+                  "items": [
+                    "minecraft:bucket"
+                  ]
+                }
+              }
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:lava_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:lava_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/powder_snow/place_mainhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/powder_snow/place_mainhand.json
@@ -18,6 +18,18 @@
             }
           },
           {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$powder_snow_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
+          {
             "condition": "minecraft:entity_properties",
             "entity": "this",
             "predicate": {
@@ -31,6 +43,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:powder_snow"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -38,6 +62,31 @@
       "trigger": "minecraft:item_used_on_block",
       "conditions": {
         "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
+                }
+              }
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$powder_snow_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
           {
             "condition": "minecraft:entity_properties",
             "entity": "this",
@@ -53,13 +102,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:powder_snow_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:powder_snow_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/powder_snow/place_offhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/powder_snow/place_offhand.json
@@ -18,6 +18,18 @@
             }
           },
           {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$powder_snow_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
+          {
             "condition": "minecraft:entity_properties",
             "entity": "this",
             "predicate": {
@@ -31,6 +43,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:powder_snow"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -38,6 +62,31 @@
       "trigger": "minecraft:item_used_on_block",
       "conditions": {
         "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
+                }
+              }
+            }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "$powder_snow_infinitas"
+              },
+              "score": "gm4_ml_data"
+            },
+            "range": 1
+          },
           {
             "condition": "minecraft:entity_properties",
             "entity": "this",
@@ -53,13 +102,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:powder_snow_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:powder_snow_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_mainhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_mainhand.json
@@ -31,6 +31,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -62,6 +74,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -99,6 +123,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -130,6 +166,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -167,6 +215,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -198,6 +258,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -235,6 +307,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -257,13 +341,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:water_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_offhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_offhand.json
@@ -31,6 +31,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -62,6 +74,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -99,6 +123,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -130,6 +166,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -167,6 +215,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -198,6 +258,18 @@
                   ],
                   "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
                 }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
               }
             }
           }
@@ -235,6 +307,18 @@
               }
             }
           }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water"
+                ]
+              }
+            }
+          }
         ]
       }
     },
@@ -257,13 +341,18 @@
             }
           }
         ],
-        "location": {
-          "block": {
-            "blocks": [
-              "minecraft:water_cauldron"
-            ]
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:water_cauldron"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     }
   },

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/functions/mark_item_validity.mcfunction
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/functions/mark_item_validity.mcfunction
@@ -6,7 +6,7 @@ execute unless score valid_item gm4_ml_data matches 1 store success score valid_
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:cod_bucket"}}]
 execute unless score valid_item gm4_ml_data matches 1 if score $lava_infinitas gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:lava_bucket"}}]
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:milk_bucket"}}]
-execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:powder_snow_bucket"}}]
+execute unless score valid_item gm4_ml_data matches 1 if score $powder_snow_infinitas gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:powder_snow_bucket"}}]
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:pufferfish_bucket"}}]
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:salmon_bucket"}}]
 execute unless score valid_item gm4_ml_data matches 1 store success score valid_item gm4_ml_data if entity @s[nbt={Item:{id:"minecraft:tadpole_bucket"}}]

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/mainhand/after/empty.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/mainhand/after/empty.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/mainhand/after/use_bucket.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/mainhand/after/use_bucket.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/empty.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/empty.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/use_bucket.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/use_bucket.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/water.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/predicates/offhand/after/water.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/gm4_metallurgy/data/gm4_metallurgy/functions/init.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/init.mcfunction
@@ -87,7 +87,11 @@ scoreboard objectives add gm4_infinitas_water_held dummy
 scoreboard objectives add gm4_infinitas_leave minecraft.custom:leave_game
 scoreboard objectives add gm4_infinitas_success_check dummy
 scoreboard players add $lava_infinitas gm4_ml_data 0
-data modify storage gm4_infinitas_shamir:bucket shamir set value {display:{Lore:['{"italic":false,"color":"#467A1B","translate":"%1$s%3427655$s","with":["Curie\'s Bismium Band",{"translate":"item.gm4.metallurgy.band","with":[{"translate":"item.gm4.metallurgy.curies_bismium"}]}]}','{"italic":false,"color":"aqua","translate":"%1$s%3427655$s","with":["Shamir",{"translate":"item.gm4.metallurgy.shamir"}]}','{"italic":false,"color":"gray","translate":"%1$s%3427655$s","with":["Infinitas",{"translate":"item.gm4.shamir.infinitas"}]}']},CustomModelData:3420100,gm4_metallurgy:{metal:{type:"curies_bismium"},custom_model_data:3420100,has_shamir:1b,active_shamir:"infinitas",skull_owner:"[Drop to Fix Item] gm4_infinitas_shamir:band"}}
+scoreboard players add $powder_snow_infinitas gm4_ml_data 0
+
+# register infinitas storage
+data remove storage gm4_infinitas_shamir:bucket shamir
+execute unless data storage gm4_infinitas_shamir:bucket shamir run data modify storage gm4_infinitas_shamir:bucket shamir set value {display:{Lore:['{"italic":false,"color":"#467A1B","translate":"item.gm4.metallurgy.band","fallback":"%s Band","with":[{"translate":"item.gm4.metallurgy.curies_bismium","fallback":"Curie\'s Bismium"}]}','{"italic":false,"color":"aqua","translate":"item.gm4.metallurgy.shamir","fallback":"Shamir"}','{"italic":false,"color":"gray","translate":"item.gm4.shamir.infinitas","fallback":"Infinitas"}']},CustomModelData:3420100,gm4_metallurgy:{metal:{type:"curies_bismium"},custom_model_data:3420100,has_shamir:1b,active_shamir:"infinitas",skull_owner:"[Drop to Fix Item] gm4_infinitas_shamir:band"}}
 
 #musical
 scoreboard objectives add gm4_note_collect totalKillCount

--- a/gm4_metallurgy/data/gm4_metallurgy/predicates/infinitas_active.json
+++ b/gm4_metallurgy/data/gm4_metallurgy/predicates/infinitas_active.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",


### PR DESCRIPTION
- Actually works in 1.20, after including the required location tags
- Addresses SneakingSpider's last mentioned issue regarding milk/cows
  - Turns out milk uses player_interacted_with_entity, not filled_bucket
- Addresses rx's concern about the powder snow toggle
  - It is now off by default
- Updates the bucket shamir nbt in init
  - As a result, this autoupdates pre-existing Infinitas buckets after use