### PR TITLE
Chairs: Make dismounting reliant on a tag instead of a team

### DIFF
--- a/gm4_chairs/data/gm4_chairs/advancements/hit.json
+++ b/gm4_chairs/data/gm4_chairs/advancements/hit.json
@@ -9,7 +9,7 @@
             "entity": "this",
             "predicate": {
               "type": "minecraft:pig",
-              "team": "gm4_chairs"
+              "nbt": "{Tags:[\"gm4_chairs\"]}"
             }
           }
         ]

--- a/gm4_chairs/data/gm4_chairs/functions/create_chair.mcfunction
+++ b/gm4_chairs/data/gm4_chairs/functions/create_chair.mcfunction
@@ -4,7 +4,7 @@
 # run from main
 
 # spawn chair
-summon minecraft:pig ~ ~-10000.39 ~ {Tags:["gm4_chairs","smithed.entity","smithed.strict","smithed.block"],Team:"gm4_chairs",NoAI:1b,Saddle:1b,NoGravity:1b,Silent:1b,DeathTime:19s,InLove:2147483647,Attributes:[{Name:"generic.max_health",Base:1.0},{Name:"generic.movement_speed",Base:0.0}],ActiveEffects:[{Id:14,Amplifier:0,Duration:2147483647,ShowParticles:0b},{Id:11,Amplifier:10b,Duration:2147483647,ShowParticles:0b}],DeathLootTable:"minecraft:empty"}
+summon minecraft:pig ~ ~-10000.39 ~ {CustomName:'"gm4_chair"',Tags:["gm4_chairs","smithed.entity","smithed.strict","smithed.block"],Team:"gm4_chairs",NoAI:1b,Saddle:1b,NoGravity:1b,Silent:1b,DeathTime:19s,InLove:2147483647,Attributes:[{Name:"generic.max_health",Base:1.0},{Name:"generic.movement_speed",Base:0.0}],ActiveEffects:[{Id:14,Amplifier:0,Duration:2147483647,ShowParticles:0b},{Id:11,Amplifier:10b,Duration:2147483647,ShowParticles:0b}],DeathLootTable:"minecraft:empty"}
 
 # set chair to orientation of stairs
 execute if block ~ ~ ~ #minecraft:stairs[facing=north] positioned ~ ~-10000 ~ as @e[type=minecraft:pig,tag=gm4_chairs,distance=..0.4,limit=1] at @s run tp @s ~ ~10000 ~.05 0 0

--- a/gm4_chairs/data/gm4_chairs/predicates/sitting_in_chair.json
+++ b/gm4_chairs/data/gm4_chairs/predicates/sitting_in_chair.json
@@ -4,7 +4,7 @@
   "predicate": {
     "vehicle": {
       "type": "minecraft:pig",
-      "team": "gm4_chairs"
+      "nbt": "{Tags:[\"gm4_chairs\"]}"
     }
   }
 }


### PR DESCRIPTION
This PR changes how chairs are referenced from predicates and andvancements within the code to rely on `Tags` instead of `Team`.
Functionally this makes no difference, however, this prevents player on an inproperly configured `spigot`/`paper` server from dying in the void.

This PR also adds a `CustomName` to the pig used by chairs. This is purely to follow the Gamemode 4 Standard and has no technical impact whatsoever.

A review by @Dennis-0 would be appreciated.