### PR TITLE
add polished blackstone bricks to full_collision

### DIFF
--- a/base/data/gm4/tags/blocks/full_collision.json
+++ b/base/data/gm4/tags/blocks/full_collision.json
@@ -209,6 +209,7 @@
         "minecraft:polished_andesite",
         "minecraft:polished_basalt",
         "minecraft:polished_blackstone",
+        "minecraft:polished_blackstone_bricks",
         "minecraft:polished_deepslate",
         "minecraft:polished_diorite",
         "minecraft:polished_granite",


### PR DESCRIPTION
`polished_blackstone_bricks` were missing from `gm4:full_collision`