### PR TITLE
Fix Bookshelf Inspector spawning markers

### DIFF
--- a/gm4_bookshelf_inspector/data/gm4_bookshelf_inspector/functions/evaluate/get_pos.mcfunction
+++ b/gm4_bookshelf_inspector/data/gm4_bookshelf_inspector/functions/evaluate/get_pos.mcfunction
@@ -1,6 +1,6 @@
 # spawn marker to get player position and rotation
 # @s = marker
-# at unspecified
+# at @s
 # run from evaluate/position
 
 tp @s @p[tag=gm4_bookshelf_inspector_target]

--- a/gm4_bookshelf_inspector/data/gm4_bookshelf_inspector/functions/evaluate/position.mcfunction
+++ b/gm4_bookshelf_inspector/data/gm4_bookshelf_inspector/functions/evaluate/position.mcfunction
@@ -5,7 +5,7 @@
 
 # store player position and rotation using a marker to avoid reading player NBT
 tag @s add gm4_bookshelf_inspector_target
-execute summon marker run function gm4_bookshelf_inspector:evaluate/get_pos
+execute at @s summon marker run function gm4_bookshelf_inspector:evaluate/get_pos
 tag @s remove gm4_bookshelf_inspector_target
 
 # calculate how far player has moved since last check


### PR DESCRIPTION
Markers were not properly deleted if the player was in a dimension other than the overworld, resulting in leftover marker entities.

This PR fixes it by spawning the markers at the executing player