### PR TITLE
Fix ender bolt tridents in the ground not spreading

### DIFF
--- a/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/data/gm4_metallurgy/functions/main.mcfunction
@@ -21,6 +21,6 @@ scoreboard players reset $tool_current_damage gm4_ml_data
 execute as @a run function gm4_metallurgy:player
 
 execute as @e[scores={gm4_bolt_time=-40..}] at @s run function gm4_ender_bolt_shamir:infection/active
-execute as @e[type=trident,nbt={inGround:1b,Trident:{tag:{gm4_metallurgy:{active_shamir:"ender_bolt"}}}}] at @s run function gm4_ender_bolt_shamir:infection/active
+execute as @e[type=trident,nbt={inGround:1b,Trident:{tag:{gm4_metallurgy:{active_shamir:"ender_bolt"}}}}] at @s run function gm4_ender_bolt_shamir:infection/symptoms
 
 schedule function gm4_metallurgy:main 16t

--- a/gm4_metallurgy/overlay_26/data/gm4_metallurgy/functions/main.mcfunction
+++ b/gm4_metallurgy/overlay_26/data/gm4_metallurgy/functions/main.mcfunction
@@ -21,6 +21,6 @@ scoreboard players reset $tool_current_damage gm4_ml_data
 execute as @a run function gm4_metallurgy:player
 
 execute as @e[scores={gm4_bolt_time=-40..}] at @s run function gm4_ender_bolt_shamir:infection/active
-execute as @e[type=trident,nbt={inGround:1b,item:{tag:{gm4_metallurgy:{active_shamir:"ender_bolt"}}}}] at @s run function gm4_ender_bolt_shamir:infection/active
+execute as @e[type=trident,nbt={inGround:1b,item:{tag:{gm4_metallurgy:{active_shamir:"ender_bolt"}}}}] at @s run function gm4_ender_bolt_shamir:infection/symptoms
 
 schedule function gm4_metallurgy:main 16t


### PR DESCRIPTION
Fixes #925

I also wanted to try to get it to work for hitting entities with a thrown trident, which is possible with an advancement, but the difficulty was finding the trident since the `infection/start` function runs at the player.