### PR TITLE
Fix compression level lore

### DIFF
--- a/gm4_block_compressors/data/gm4_block_compressors/loot_tables/technical/compressed_lore.json
+++ b/gm4_block_compressors/data/gm4_block_compressors/loot_tables/technical/compressed_lore.json
@@ -13,12 +13,11 @@
               "entity": "this",
               "name": {
                 "translate": "text.gm4.block_compressors.compressed",
-                "fallback": "Compressed *",
+                "fallback": "Compressed * %s",
                 "with": [
                   {
                     "nbt": "Item.tag.gm4_block_compressors.compression_level",
-                    "storage": "gm4_block_compressors:temp/item_stack",
-                    "interpret": true
+                    "storage": "gm4_block_compressors:temp/item_stack"
                   }
                 ],
                 "color": "gray",


### PR DESCRIPTION
Two issues:
* The `interpret` flag did not need to be set, because it's just including a single integer from storage
* The `%s` was missing so `with` was not being used

This caused some warnings to log and the compression level was not included in the lore line.
![image](https://github.com/Gamemode4Dev/GM4_Datapacks/assets/17352009/4436600c-9a2f-447e-b59b-f3d1ca8773f3)
![image](https://github.com/Gamemode4Dev/GM4_Datapacks/assets/17352009/ff6d6f64-342b-42c4-9f76-53df4ab22ee2)
