### PR TITLE
Zauber Cauldrons: Fix Edge-Case Causing Leftover Custom Liquid Display Entities

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/invalid_recipe.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/invalid_recipe.mcfunction
@@ -8,4 +8,6 @@ execute align xyz run kill @e[type=item,dx=0,dy=0,dz=0]
 #visuals
 scoreboard players reset $expected_item_amount gm4_zc_fullness
 summon tnt
-kill @s
+
+# kill marker and related entities
+function gm4_zauber_cauldrons:cauldron/structure/destroy

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/check_liquid.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/lingering/check_liquid.mcfunction
@@ -6,5 +6,5 @@
 # the select_effect function is generated via beet from templates
 execute if score $has_powder_snow gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/lingering/select_effect
 
-# no powder snow
-execute unless score $has_powder_snow gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/invalid_recipe
+# water used instead of powder snow
+execute if score $has_water gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/invalid_recipe

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/check_liquid.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/potions/splash/check_liquid.mcfunction
@@ -6,5 +6,5 @@
 # the select_effect function is generated via beet from templates
 execute if score $has_powder_snow gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/splash/select_effect
 
-# no powder snow
-execute unless score $has_powder_snow gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/invalid_recipe
+# water used instead of powder snow
+execute if score $has_water gm4_zc_data matches 1.. run function gm4_zauber_cauldrons:recipes/potions/invalid_recipe


### PR DESCRIPTION
Tier IV Splash- and Lingering Potion recipes cause an explosion when used with water instead of Powdered Snow.

Due to a check for 'not Powdered Snow' instead of an explicit check for 'Water', these recipes could be performed inside custom liquids. This was not intended and caused leftover display entities.

Additionally, this explosion did not call the proper destroy function but simply killed the Zauber Cauldron marker, leaving display entities behind.

This PR fixes the two issues described above.

Thanks to @SpecialBuilder32 for discovering this issue.