### PR TITLE
Zauber Liquids & Mob Curing: Enable Compatibility with Zauber Cauldrons v1.10

### DIFF
--- a/gm4_mob_curing/beet.yaml
+++ b/gm4_mob_curing/beet.yaml
@@ -13,7 +13,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_trades: 1.3.0
+        lib_trades: 1.4.0
       schedule_loops: [main]
     website:
       description: Revert mooshrooms, pigmen and witches back to their previous forms.

--- a/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/drinkable.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/drinkable.json
@@ -5,31 +5,31 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/instant_damage"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/instant_damage"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/instant_health"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/instant_health"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/jump_boost"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/jump_boost"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/poison"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/poison"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/regeneration"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/regeneration"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/speed"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/speed"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/drinkable/strength"
+          "name": "gm4_zauber_cauldrons:items/potions/drinkable/strength"
         }
       ]
     },

--- a/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/lingering.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/lingering.json
@@ -5,31 +5,31 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/instant_damage"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/instant_damage"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/instant_health"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/instant_health"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/jump_boost"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/jump_boost"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/poison"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/poison"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/regeneration"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/regeneration"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/speed"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/speed"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/lingering/strength"
+          "name": "gm4_zauber_cauldrons:items/potions/lingering/strength"
         }
       ]
     },

--- a/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/splash.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_tables/technical/potion_cleric/zauber/splash.json
@@ -5,31 +5,31 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/instant_damage"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/instant_damage"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/instant_health"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/instant_health"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/jump_boost"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/jump_boost"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/poison"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/poison"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/regeneration"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/regeneration"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/speed"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/speed"
         },
         {
           "type": "minecraft:loot_table",
-          "name": "gm4_zauber_cauldrons:recipes/potions/splash/strength"
+          "name": "gm4_zauber_cauldrons:items/potions/splash/strength"
         }
       ]
     },

--- a/gm4_zauber_liquids/beet.yaml
+++ b/gm4_zauber_liquids/beet.yaml
@@ -13,7 +13,7 @@ meta:
     versioning:
       required:
         gm4_liquid_tanks: 2.1.0
-        gm4_zauber_cauldrons: 1.6.0
+        gm4_zauber_cauldrons: 1.10.0
     website:
       description: From cauldron-made potions to potion-filled tanks! Store your tier IV potions and wormholes in Liquid Tanks!
       recommended: []

--- a/gm4_zauber_liquids/beet.yaml
+++ b/gm4_zauber_liquids/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_zauber_liquids
 name: Zauber Liquids
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_harming_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_harming_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_damage
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/instant_damage
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_healing_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_healing_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/instant_health
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/instant_health
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_leaping_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_leaping_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/jump_boost
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/jump_boost
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_poison_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_poison_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/poison
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/poison
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_regeneration_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_regeneration_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/regeneration
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/regeneration
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_strength_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_strength_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/strength
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/strength
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_swiftness_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_swiftness_potion.mcfunction
@@ -3,7 +3,7 @@
 
 # $item_value set in item_fill function for efficiency
 
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/potions/drinkable/speed
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/potions/drinkable/speed
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_wormhole_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_wormhole_potion.mcfunction
@@ -9,7 +9,7 @@ execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_za
 execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run scoreboard players get @s gm4_zl_warp_cd
 
 # $item_value set in item_fill function for efficiency
-loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:recipes/chorus/wormhole
+loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/wormhole
 data modify storage gm4_liquid_tanks:temp/tank output set from entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] HandItems[0]
 item replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand with air
 function gm4_liquid_tanks:smart_item_fill


### PR DESCRIPTION
Zauber Cauldrons v1.10 changed the name of some loot tables which these modules relied upon. This PR fixes the loot table references.

As Zauber Cauldrons v1.10 is only available for Minecraft 1.20.3+, this means Zauber Liquids will also only be available for those Minecraft versions.