### PR TITLE
Your Sparks is in another castle!

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -97,7 +97,7 @@
     },
     {
         "name": "Sparks",
-        "links": ["https://twitter.com/SparksTheGamer"]
+        "links": ["https://twitter.com/SelcouthSparks"]
     },
     {
         "name": "SpecialBuilder32",


### PR DESCRIPTION
My Twitter handle changed a while ago and I just noticed the old URL is still used by the site.

I did a search of the whole repo and I think the only place the link is referenced is contributors.json so hopefully it isn't listed somewhere else as well!