### PR TITLE
Infinitas Shamir: Waterlogging blocks no longer breaks the shamir

### DIFF
--- a/base/data/gm4/tags/blocks/waterloggable.json
+++ b/base/data/gm4/tags/blocks/waterloggable.json
@@ -1,5 +1,6 @@
 {
   "values": [
+    "#minecraft:rails",
     "#minecraft:campfires",
     "#minecraft:candles",
     "#minecraft:fences",
@@ -50,6 +51,7 @@
     "minecraft:light_gray_stained_glass_pane",
     "minecraft:lime_stained_glass_pane",
     "minecraft:magenta_stained_glass_pane",
+    "minecraft:mangrove_propagule",
     "minecraft:mangrove_roots",
     "minecraft:medium_amethyst_bud",
     "minecraft:orange_stained_glass_pane",

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_mainhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_mainhand.json
@@ -314,8 +314,53 @@
             "predicate": {
               "block": {
                 "blocks": [
+                  "minecraft:flower_pot",
                   "minecraft:water"
                 ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "place_waterloggable": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
+                }
+              }
+            }
+          },
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "equipment": {
+                "mainhand": {
+                  "items": [
+                    "minecraft:water_bucket"
+                  ],
+                  "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
+                }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "tag": "gm4:waterloggable"
               }
             }
           }
@@ -365,6 +410,7 @@
       "place_tadpole",
       "place_tropical_fish",
       "place_water",
+      "place_waterloggable",
       "use_on_cauldron"
     ]
   ],

--- a/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_offhand.json
+++ b/gm4_metallurgy/data/gm4_infinitas_shamir/advancements/water/place_offhand.json
@@ -314,8 +314,53 @@
             "predicate": {
               "block": {
                 "blocks": [
+                  "minecraft:flower_pot",
                   "minecraft:water"
                 ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "place_waterloggable": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "creative"
+                }
+              }
+            }
+          },
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "equipment": {
+                "offhand": {
+                  "items": [
+                    "minecraft:water_bucket"
+                  ],
+                  "nbt": "{gm4_metallurgy:{active_shamir:\"infinitas\"}}"
+                }
+              }
+            }
+          }
+        ],
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "tag": "gm4:waterloggable"
               }
             }
           }
@@ -365,6 +410,7 @@
       "place_tadpole",
       "place_tropical_fish",
       "place_water",
+      "place_waterloggable",
       "use_on_cauldron"
     ]
   ],

--- a/gm4_metallurgy/data/gm4_metallurgy/predicates/infinitas_active.json
+++ b/gm4_metallurgy/data/gm4_metallurgy/predicates/infinitas_active.json
@@ -5,14 +5,20 @@
       "condition": "minecraft:entity_properties",
       "entity": "this",
       "predicate": {
-        "nbt": "{Tags:[\"gm4_infinitas_mainhand_empty\"]}"
+        "nbt": "{Tags:[\"gm4_infinitas_mainhand_empty\"]}",
+        "flags": {
+          "is_sneaking": true
+        }
       }
     },
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
       "predicate": {
-        "nbt": "{Tags:[\"gm4_infinitas_offhand_empty\"]}"
+        "nbt": "{Tags:[\"gm4_infinitas_offhand_empty\"]}",
+        "flags": {
+          "is_sneaking": true
+        }
       }
     }
   ]


### PR DESCRIPTION
- Previously only targeted cauldrons, now uses gm4:waterloggable block tag
- #rails and Mangrove Propagule missing from base block tag
- Also specifically flower pots break the check for some reason