### PR TITLE
Soul Glass: Hotfix Module Not Applying Effects

### DIFF
--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/check.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/check.mcfunction
@@ -1,7 +1,7 @@
 #@s = soul glass AEC
 #run from beacon_clock
 
-execute unless block ~ ~-1 ~ beacon{primary_effect:-1} run function gm4_soul_glass:effect/update_effects
+execute if data block ~ ~-1 ~ primary_effect run function gm4_soul_glass:effect/update_effects
 
 execute store result score @s gm4_sg_levels run data get block ~ ~-1 ~ Levels
 

--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_primary_id.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_primary_id.mcfunction
@@ -1,0 +1,14 @@
+# Converts a string effect id to a matching numeric id, as scoreboard lookups are cheaper and this conversion only has to be done once when soul glass is first placed on a beacon
+# @s = gm4_soul_glass marker
+# at @s
+# run from effect/update_effects
+
+# convert id
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:speed"} run scoreboard players set @s gm4_sg_primary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_primary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_primary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_primary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_primary 1
+
+# clean up storage
+data remove storage gm4_soul_glass:temp effect

--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_primary_id.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_primary_id.mcfunction
@@ -5,10 +5,10 @@
 
 # convert id
 execute if data storage gm4_soul_glass:temp {effect:"minecraft:speed"} run scoreboard players set @s gm4_sg_primary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_primary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_primary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_primary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_primary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_primary 3
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_primary 5
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_primary 8
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_primary 11
 
 # clean up storage
 data remove storage gm4_soul_glass:temp effect

--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_secondary_id.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_secondary_id.mcfunction
@@ -5,11 +5,11 @@
 
 # convert id
 execute if data storage gm4_soul_glass:temp {effect:"minecraft:speed"} run scoreboard players set @s gm4_sg_secondary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_secondary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_secondary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_secondary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_secondary 1
-execute if data storage gm4_soul_glass:temp {effect:"minecraft:regeneration"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_secondary 3
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_secondary 5
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_secondary 8
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_secondary 11
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:regeneration"} run scoreboard players set @s gm4_sg_secondary 10
 
 # clean up storage
 data remove storage gm4_soul_glass:temp effect

--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_secondary_id.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/obtain_numeric_secondary_id.mcfunction
@@ -1,0 +1,15 @@
+# Converts a string effect id to a matching numeric id, as scoreboard lookups are cheaper and this conversion only has to be done once when soul glass is first placed on a beacon
+# @s = gm4_soul_glass marker
+# at @s
+# run from effect/update_effects
+
+# convert id
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:speed"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:haste"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:strength"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:jump_boost"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:resistance"} run scoreboard players set @s gm4_sg_secondary 1
+execute if data storage gm4_soul_glass:temp {effect:"minecraft:regeneration"} run scoreboard players set @s gm4_sg_secondary 1
+
+# clean up storage
+data remove storage gm4_soul_glass:temp effect

--- a/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
+++ b/gm4_soul_glass/overlay_18/data/gm4_soul_glass/functions/effect/update_effects.mcfunction
@@ -1,11 +1,14 @@
 #@s = soul glass AEC
 #run from effects/check
 
-execute store result score @s gm4_sg_primary run data get block ~ ~-1 ~ primary_effect
-execute unless block ~ ~-1 ~ beacon{secondary_effect:-1} store result score @s gm4_sg_secondary run data get block ~ ~-1 ~ secondary_effect
+data modify storage gm4_soul_glass:temp effect set from block ~ ~-1 ~ primary_effect
+function gm4_soul_glass:effect/obtain_numeric_primary_id
 
-data modify block ~ ~-1 ~ primary_effect set value -1
-data modify block ~ ~-1 ~ secondary_effect set value -1
+data modify storage gm4_soul_glass:temp effect set from block ~ ~-1 ~ secondary_effect
+execute if data storage gm4_soul_glass:temp effect run function gm4_soul_glass:effect/obtain_numeric_secondary_id
+
+data remove block ~ ~-1 ~ primary_effect
+data remove block ~ ~-1 ~ secondary_effect
 
 playsound minecraft:entity.wither.spawn block @a[distance=..10] ~ ~ ~ .5 1.3
 particle minecraft:witch ~ ~-1 ~ 0.5 0.5 0.5 0 40 force


### PR DESCRIPTION
The change of `Primary` -> `primary_effect` and `Secondary` -> `secondary_effect` did also bring a change from numeric to string ids in beacon NBT. The previous code was only updated to reflect the name change of the NB tag but was not able to cope with the new string ids. This is a compromise in which numeric ids are still used internally by soul glass as scores are faster to check than nbt, as a result the string effect id is converted to a numeric one when the beacon is first converted to a soul glass beacon.

It would be possible to simplify this code a lot by simplying pulling the string id and handing it into a macro, but whether that is more performant would need to be tested.

This is a hotfix, not a future-proof solution.