### PR TITLE
Spawner Minecarts: Use Zauber Cauldron's Flower Algorithm

### DIFF
--- a/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/fuel/initiate_flower_types.mcfunction
+++ b/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/fuel/initiate_flower_types.mcfunction
@@ -4,70 +4,39 @@
 
 #randomly marks flower types as poisonous on module installation
 
-#initialise fixed values
-scoreboard players set modulo_2 gm4_sm_flowers 2
-scoreboard players set modulo_4 gm4_sm_flowers 4
-scoreboard players set divider gm4_sm_flowers 10
+# initialize randomizer
+random reset gm4_zauber_cauldrons:flowers/poisonous_flowers 0 true true
 
-#copy seed to scoreboard
-execute store result score seed gm4_sm_flowers run seed
+# assign poisonous/lucky score
+# NOTE the order these flowers are assigned scores in MUST be the same as the one in Zauber Cauldrons, otherwise the lucky/unlucky flowers won't match up
+# in the future we should probably find a way to not make this depend on the order these flowers have their values rolled in
+# as spawner minecarts should receive a complete overhaul soon anyways, this fix was put in place to ensure lucky flower parity between Zauber & Spawner Minecarts for now
+# -Bloo, Feb 2024
+execute store result score dandelion gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score poppy gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score blue_orchid gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score allium gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score azure_bluet gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score red_tulip gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score orange_tulip gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score white_tulip gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score pink_tulip gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score oxeye_daisy gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score cornflower gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
+execute store result score lily_of_the_valley gm4_sm_flowers run random value 0..1 gm4_zauber_cauldrons:flowers/poisonous_flowers
 
-#set all flowers to a digit of the seed. Obtain up to 20 random bits, the set first
-#of 10 bits is obtained by mod 2, the second set by mod 4 later.
-scoreboard players operation red_tulip gm4_sm_flowers = seed gm4_sm_flowers
-scoreboard players operation red_tulip gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation cornflower gm4_sm_flowers = red_tulip gm4_sm_flowers
-scoreboard players operation orange_tulip gm4_sm_flowers = red_tulip gm4_sm_flowers
-scoreboard players operation orange_tulip gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation lily_of_the_valley gm4_sm_flowers = orange_tulip gm4_sm_flowers
-scoreboard players operation white_tulip gm4_sm_flowers = orange_tulip gm4_sm_flowers
-scoreboard players operation white_tulip gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation pink_tulip gm4_sm_flowers = white_tulip gm4_sm_flowers
-scoreboard players operation pink_tulip gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation oxeye_daisy gm4_sm_flowers = pink_tulip gm4_sm_flowers
-scoreboard players operation oxeye_daisy gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation dandelion gm4_sm_flowers = oxeye_daisy gm4_sm_flowers
-scoreboard players operation dandelion gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation blue_orchid gm4_sm_flowers = dandelion gm4_sm_flowers
-scoreboard players operation blue_orchid gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation allium gm4_sm_flowers = blue_orchid gm4_sm_flowers
-scoreboard players operation allium gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation azure_bluet gm4_sm_flowers = allium gm4_sm_flowers
-scoreboard players operation azure_bluet gm4_sm_flowers /= divider gm4_sm_flowers
-scoreboard players operation poppy gm4_sm_flowers = azure_bluet gm4_sm_flowers
-scoreboard players operation poppy gm4_sm_flowers /= divider gm4_sm_flowers
-
-#scale down to 1 bit (mod2 for set 1, mod4 for set 2): 1=poisonous 0=normal
-#set 1
-scoreboard players operation red_tulip gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation orange_tulip gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation white_tulip gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation pink_tulip gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation oxeye_daisy gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation dandelion gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation blue_orchid gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation allium gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation azure_bluet gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-scoreboard players operation poppy gm4_sm_flowers %= modulo_2 gm4_sm_flowers
-#set2
-scoreboard players operation cornflower gm4_sm_flowers %= modulo_4 gm4_sm_flowers
-execute if score cornflower gm4_sm_flowers matches 1..2 run scoreboard players set cornflower gm4_sm_flowers 1
-execute if score cornflower gm4_sm_flowers matches 3 run scoreboard players set cornflower gm4_sm_flowers 0
-scoreboard players operation lily_of_the_valley gm4_sm_flowers %= modulo_4 gm4_sm_flowers
-execute if score lily_of_the_valley gm4_sm_flowers matches 1..2 run scoreboard players set lily_of_the_valley gm4_sm_flowers 1
-execute if score lily_of_the_valley gm4_sm_flowers matches 3 run scoreboard players set lily_of_the_valley gm4_sm_flowers 0
-
-#store amount of non poisonous flowers as 10-<sum of flower scores>
+# calculate amount of required flowers
 scoreboard players set required_flowers gm4_sm_flowers 12
+
+scoreboard players operation required_flowers gm4_sm_flowers -= dandelion gm4_sm_flowers
+scoreboard players operation required_flowers gm4_sm_flowers -= poppy gm4_sm_flowers
+scoreboard players operation required_flowers gm4_sm_flowers -= blue_orchid gm4_sm_flowers
+scoreboard players operation required_flowers gm4_sm_flowers -= allium gm4_sm_flowers
+scoreboard players operation required_flowers gm4_sm_flowers -= azure_bluet gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= red_tulip gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= orange_tulip gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= white_tulip gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= pink_tulip gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= oxeye_daisy gm4_sm_flowers
-scoreboard players operation required_flowers gm4_sm_flowers -= dandelion gm4_sm_flowers
-scoreboard players operation required_flowers gm4_sm_flowers -= blue_orchid gm4_sm_flowers
-scoreboard players operation required_flowers gm4_sm_flowers -= allium gm4_sm_flowers
-scoreboard players operation required_flowers gm4_sm_flowers -= azure_bluet gm4_sm_flowers
-scoreboard players operation required_flowers gm4_sm_flowers -= poppy gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= cornflower gm4_sm_flowers
 scoreboard players operation required_flowers gm4_sm_flowers -= lily_of_the_valley gm4_sm_flowers

--- a/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/init.mcfunction
+++ b/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/init.mcfunction
@@ -2,7 +2,7 @@ scoreboard objectives add gm4_spawner_fuel dummy
 scoreboard objectives add gm4_spawner_time dummy
 scoreboard objectives add gm4_spawner_data dummy
 scoreboard objectives add gm4_sm_flowers dummy
-execute unless score required_flowers gm4_zc_flowers matches -2147483648..2147483647 run function gm4_spawner_minecarts:fuel/initiate_flower_types
+execute unless score required_flowers gm4_sm_flowers matches -2147483648..2147483647 run function gm4_spawner_minecarts:fuel/initiate_flower_types
 
 execute unless score spawner_minecarts gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Spawner Minecarts"}
 execute unless score spawner_minecarts gm4_earliest_version < spawner_minecarts gm4_modules run scoreboard players operation spawner_minecarts gm4_earliest_version = spawner_minecarts gm4_modules

--- a/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/init.mcfunction
+++ b/gm4_spawner_minecarts/data/gm4_spawner_minecarts/functions/init.mcfunction
@@ -2,7 +2,7 @@ scoreboard objectives add gm4_spawner_fuel dummy
 scoreboard objectives add gm4_spawner_time dummy
 scoreboard objectives add gm4_spawner_data dummy
 scoreboard objectives add gm4_sm_flowers dummy
-function gm4_spawner_minecarts:fuel/initiate_flower_types
+execute unless score required_flowers gm4_zc_flowers matches -2147483648..2147483647 run function gm4_spawner_minecarts:fuel/initiate_flower_types
 
 execute unless score spawner_minecarts gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Spawner Minecarts"}
 execute unless score spawner_minecarts gm4_earliest_version < spawner_minecarts gm4_modules run scoreboard players operation spawner_minecarts gm4_earliest_version = spawner_minecarts gm4_modules


### PR DESCRIPTION
With the latest Zauber Update the lucky flower selection algorithm had changed to use the new `random` command, however, spawner Minecart's algorithm still uses the old sytem leaving us with two different sets of lucky flowers.

This copies Zauber Cauldron's algorithm into Spawner Minecarts. This is not a pretty fix, but it will work until Spawner Minecarts receives [its planned overhaul](https://docs.google.com/document/d/1N88S8LXu-Zlo3H6jA6j2TSNVKnEEFAK_wIobP47Ivow/edit?usp=sharing).