### PR TITLE
Better Fire: Fix Flint drop

### DIFF
--- a/gm4_better_fire/data/gm4_better_fire/functions/arrow.mcfunction
+++ b/gm4_better_fire/data/gm4_better_fire/functions/arrow.mcfunction
@@ -5,6 +5,6 @@
 # runs from on_fire
 
 setblock ~ ~ ~ fire keep
-execute if entity @s[nbt={pickup:1b}] run loot spawn ~ ~ ~ loot gm4_better_fire:flint
+execute if entity @s[nbt={pickup:1b}] run loot spawn ~ ~ ~ loot gm4_better_fire:entities/flame_arrow/flint
 
 kill @s


### PR DESCRIPTION
> please put this under the namespace `/loot_tables/entities/flame_arrow` or something similar. Don't forget to update the functions that call this loot table

\- Beeps, [2.5 years ago](https://github.com/Gamemode4Dev/GM4_Datapacks/pull/652#discussion_r686542803)

Oh.  Yeah...