### PR TITLE
Soul Glass Fix

### DIFF
--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_1.mcfunction
@@ -1,8 +1,8 @@
 #@s = soul glass AEC with level 1 beacon below it
 #run from effects/check
 
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=40,dy=296,dz=40] minecraft:slowness 11 0
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=40,dy=296,dz=40] minecraft:mining_fatigue 11 0
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=40,dy=296,dz=40] minecraft:weakness 11 0
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=40,dy=296,dz=40] minecraft:slow_falling 11 0
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=40,dy=296,dz=40] minecraft:glowing 11 0
+execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=40,dy=296,dz=40,gamemode=!spectator] minecraft:slowness 11 0
+execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=40,dy=296,dz=40,gamemode=!spectator] minecraft:mining_fatigue 11 0
+execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=40,dy=296,dz=40,gamemode=!spectator] minecraft:weakness 11 0
+execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=40,dy=296,dz=40,gamemode=!spectator] minecraft:slow_falling 11 0
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=40,dy=296,dz=40,gamemode=!spectator] minecraft:glowing 11 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_2.mcfunction
@@ -1,8 +1,8 @@
 #@s = soul glass AEC with level 1 beacon below it
 #run from effects/check
 
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=60,dy=316,dz=60] minecraft:slowness 13 0
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=60,dy=316,dz=60] minecraft:mining_fatigue 13 0
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=60,dy=316,dz=60] minecraft:weakness 13 0
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=60,dy=316,dz=60] minecraft:slow_falling 13 0
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=60,dy=316,dz=60] minecraft:glowing 13 0
+execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=60,dy=316,dz=60,gamemode=!spectator] minecraft:slowness 13 0
+execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=60,dy=316,dz=60,gamemode=!spectator] minecraft:mining_fatigue 13 0
+execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=60,dy=316,dz=60,gamemode=!spectator] minecraft:weakness 13 0
+execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=60,dy=316,dz=60,gamemode=!spectator] minecraft:slow_falling 13 0
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=60,dy=316,dz=60,gamemode=!spectator] minecraft:glowing 13 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_3.mcfunction
@@ -1,8 +1,8 @@
 #@s = soul glass AEC with level 1 beacon below it
 #run from effects/check
 
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=80,dy=336,dz=80] minecraft:slowness 15 0
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=80,dy=336,dz=80] minecraft:mining_fatigue 15 0
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=80,dy=336,dz=80] minecraft:weakness 15 0
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=80,dy=336,dz=80] minecraft:slow_falling 15 0
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=80,dy=336,dz=80] minecraft:glowing 15 0
+execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=80,dy=336,dz=80,gamemode=!spectator] minecraft:slowness 15 0
+execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=80,dy=336,dz=80,gamemode=!spectator] minecraft:mining_fatigue 15 0
+execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=80,dy=336,dz=80,gamemode=!spectator] minecraft:weakness 15 0
+execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=80,dy=336,dz=80,gamemode=!spectator] minecraft:slow_falling 15 0
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=80,dy=336,dz=80,gamemode=!spectator] minecraft:glowing 15 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4.mcfunction
@@ -1,16 +1,16 @@
 #@s = soul glass AEC with level 1 beacon below it
 #run from effects/check
 
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz=100] minecraft:slowness 17 0
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 0
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 0
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
+execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slowness 17 0
+execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:mining_fatigue 17 0
+execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:weakness 17 0
+execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slow_falling 17 0
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:glowing 17 0
 
-execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=100,dy=356,dz=100] minecraft:slowness 17 0
-execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 0
-execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 0
-execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 0
-execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 0
+execute if score @s gm4_sg_secondary matches 1 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slowness 17 0
+execute if score @s gm4_sg_secondary matches 3 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:mining_fatigue 17 0
+execute if score @s gm4_sg_secondary matches 5 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:weakness 17 0
+execute if score @s gm4_sg_secondary matches 8 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slow_falling 17 0
+execute if score @s gm4_sg_secondary matches 11 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:glowing 17 0
 
-execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=100,dy=356,dz=100] minecraft:poison 17 0
+execute if score @s gm4_sg_secondary matches 10 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:poison 17 0

--- a/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
+++ b/gm4_soul_glass/data/gm4_soul_glass/functions/effect/level_4_strong.mcfunction
@@ -1,8 +1,8 @@
 #@s = soul glass AEC with level 1 beacon below it
 #run from effects/check
 
-execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz=100] minecraft:slowness 17 1
-execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100] minecraft:mining_fatigue 17 1
-execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100] minecraft:weakness 17 1
-execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100] minecraft:slow_falling 17 1
-execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100] minecraft:glowing 17 1
+execute if score @s gm4_sg_primary matches 1 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slowness 17 1
+execute if score @s gm4_sg_primary matches 3 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:mining_fatigue 17 1
+execute if score @s gm4_sg_primary matches 5 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:weakness 17 1
+execute if score @s gm4_sg_primary matches 8 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:slow_falling 17 1
+execute if score @s gm4_sg_primary matches 11 run effect give @a[dx=100,dy=356,dz=100,gamemode=!spectator] minecraft:glowing 17 1

--- a/gm4_soul_glass/data/gm4_soul_glass/tags/blocks/beacon_passable.json
+++ b/gm4_soul_glass/data/gm4_soul_glass/tags/blocks/beacon_passable.json
@@ -78,6 +78,7 @@
         "minecraft:lime_stained_glass",
         "minecraft:magenta_stained_glass_pane",
         "minecraft:magenta_stained_glass",
+        "minecraft:moss_carpet",
         "minecraft:moving_piston",
         "minecraft:orange_stained_glass_pane",
         "minecraft:orange_stained_glass",


### PR DESCRIPTION
Soul glass beacons were giving effects to spectators when they shouldn't.