### PR TITLE
Zauber Cauldrons: Fix Rabbit Teleportation Easter Egg

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/rabbit_teleportation.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/rabbit_teleportation.mcfunction
@@ -1,6 +1,21 @@
+# teleports a rabbit inside a cauldron to another empty cauldron
 # @s = zauber cauldron without water in it
 # at align xyz
-# run from cauldron/structure/analyze/cauldron
+# run from cauldron/structure/validate/liquid
 
-tp @e[type=rabbit,dx=0,dy=0,dz=0,limit=1] @e[type=marker,tag=gm4_zauber_cauldron,limit=1,distance=1..,sort=random,scores={gm4_zc_rabtarget=1}]
+# advancement for player
 advancement grant @a[distance=..2,gamemode=!spectator,predicate=gm4_zauber_cauldrons:player/equipment/armor/full] only gm4:zauber_cauldrons_rabbit
+
+# departure sounds & particles
+particle minecraft:entity_effect ~.5 ~.5 ~.5 0.2 0.3 0.2 0.5 32
+playsound minecraft:entity.item.pickup neutral @a[distance=..8] ~ ~ ~ 0.5 0.5
+
+# teleport rabbit
+tag @e[type=rabbit,dx=0,dy=0,dz=0,limit=1] add gm4_zc_magic_rabbit
+tp @e[type=rabbit,dx=0,tag=gm4_zc_magic_rabbit,limit=1] @e[type=marker,tag=gm4_zauber_cauldron,limit=1,distance=1..,sort=random,scores={gm4_zc_rabtarget=1}]
+
+# arrival  particles
+execute at @e[type=rabbit,tag=gm4_zc_magic_rabbit,limit=1] align xyz run particle minecraft:entity_effect ~.5 ~.5 ~.5 0.2 0.3 0.2 0.5 32
+
+# remove tag from rabbit
+tag @e[type=rabbit] remove gm4_zc_magic_rabbit

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/rabbit_teleportation.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/rabbit_teleportation.mcfunction
@@ -3,6 +3,10 @@
 # at align xyz
 # run from cauldron/structure/validate/liquid
 
+# look for a target cauldron
+tag @e[type=marker,tag=gm4_zauber_cauldron,limit=1,distance=1..,sort=random,scores={gm4_zc_rabtarget=1}] add gm4_zc_selected_target
+execute unless entity @e[type=marker,tag=gm4_zc_selected_target] run return fail
+
 # advancement for player
 advancement grant @a[distance=..2,gamemode=!spectator,predicate=gm4_zauber_cauldrons:player/equipment/armor/full] only gm4:zauber_cauldrons_rabbit
 
@@ -12,10 +16,11 @@ playsound minecraft:entity.item.pickup neutral @a[distance=..8] ~ ~ ~ 0.5 0.5
 
 # teleport rabbit
 tag @e[type=rabbit,dx=0,dy=0,dz=0,limit=1] add gm4_zc_magic_rabbit
-tp @e[type=rabbit,dx=0,tag=gm4_zc_magic_rabbit,limit=1] @e[type=marker,tag=gm4_zauber_cauldron,limit=1,distance=1..,sort=random,scores={gm4_zc_rabtarget=1}]
+tp @e[type=rabbit,dx=0,tag=gm4_zc_magic_rabbit,limit=1] @e[type=marker,tag=gm4_zc_selected_target,limit=1]
 
 # arrival  particles
 execute at @e[type=rabbit,tag=gm4_zc_magic_rabbit,limit=1] align xyz run particle minecraft:entity_effect ~.5 ~.5 ~.5 0.2 0.3 0.2 0.5 32
 
-# remove tag from rabbit
+# remove tags
 tag @e[type=rabbit] remove gm4_zc_magic_rabbit
+tag @e[type=marker,tag=gm4_zauber_cauldron] remove gm4_zc_selected_target

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/validate/liquid.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/validate/liquid.mcfunction
@@ -2,7 +2,7 @@
 # at @s align xzy
 # run from main
 
-# reset rabbit target score (set to 1 in cauldron/structure/analyze/cauldron if an empty cauldron is present)
+# reset rabbit target score
 scoreboard players set @s gm4_zc_rabtarget 0
 
 # analyze

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/validate/liquid.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/structure/validate/liquid.mcfunction
@@ -13,6 +13,7 @@ execute if score $has_liquid gm4_zc_data matches 1 run function gm4_zauber_cauld
 
 # if the cauldron is empty, enable the rabbit teleportation easter egg
 execute unless score $has_liquid gm4_zc_data matches 1 if block ~ ~ ~ minecraft:cauldron if entity @e[type=rabbit,dx=0,dy=0,dz=0,limit=1] if entity @a[gamemode=!spectator,predicate=gm4_zauber_cauldrons:player/equipment/armor/full,distance=..2] run function gm4_zauber_cauldrons:cauldron/rabbit_teleportation
+execute unless score $has_liquid gm4_zc_data matches 1 run scoreboard players set @s gm4_zc_rabtarget 1
 
 # if there is no longer a cauldron, destroy the zauber cauldron
 execute unless block ~ ~ ~ #minecraft:cauldrons run function gm4_zauber_cauldrons:cauldron/structure/destroy

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/tests/rabbit_teleportation.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/tests/rabbit_teleportation.mcfunction
@@ -1,0 +1,30 @@
+# @template gm4:test_platform
+# @dummy ~1 ~1 ~1
+
+setblock ~ ~ ~1 netherrack
+setblock ~ ~1 ~1 fire
+setblock ~ ~2 ~1 water_cauldron[level=3]
+setblock ~2 ~ ~1 netherrack
+setblock ~2 ~1 ~1 fire
+setblock ~2 ~2 ~1 water_cauldron[level=3]
+
+give @s enchanted_book{StoredEnchantments:[{id:"minecraft:protection",lvl:1s}]}
+execute at @s run tp @s ~ ~ ~ facing ~1 ~ ~
+await delay 1s
+execute at @s run tp @s ~ ~ ~ facing ~-1 ~ ~
+await delay 1s
+
+await entity @s[advancements={gm4:zauber_cauldrons_create=true}]
+
+setblock ~ ~2 ~1 cauldron
+setblock ~2 ~2 ~1 cauldron
+summon rabbit ~0.5 ~3 ~1.5
+
+loot replace entity @s armor.feet loot gm4_zauber_cauldrons:items/armor/boots/speed_boost
+loot replace entity @s armor.legs loot gm4_zauber_cauldrons:items/armor/leggings/speed_boost
+loot replace entity @s armor.chest loot gm4_zauber_cauldrons:items/armor/chestplate/speed_boost
+loot replace entity @s armor.head loot gm4_zauber_cauldrons:items/armor/helmet/speed_boost
+
+await entity @s[advancements={gm4:zauber_cauldrons_rabbit=true}]
+
+execute positioned ~2.5 ~2.5 ~1.5 run assert entity @e[type=rabbit,dx=0]


### PR DESCRIPTION
This easter egg was accidentally broken during some recent update. This PR fixes it and adds some particles & sounds to get it up to spec with our latest design practices.