### PR TITLE
Upload artifact of failing test worlds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,5 +149,5 @@ jobs:
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
-          name: 'Test world for ${GITHUB_SHA::7}'
+          name: 'Test world for ${{ github.sha }}'
           path: ${{ github.workspace }}/world/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,5 +141,13 @@ jobs:
           cp out/gm4_*.zip world/datapacks
 
       - name: Run test server
+        id: run-tests
         run: |
           java -Xmx2G -Dpacktest.auto -Dpacktest.auto.annotations -jar server.jar nogui
+
+      - name: Upload test world
+        if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'Test world for ${GITHUB_SHA::7}'
+          path: ${{ github.workspace }}/world/

--- a/gm4_better_fire/data/gm4_better_fire/tests/set_fire.mcfunction
+++ b/gm4_better_fire/data/gm4_better_fire/tests/set_fire.mcfunction
@@ -2,4 +2,4 @@
 
 summon arrow ~1.5 ~4 ~1.5 {Fire:100s,Motion:[0.0,-0.1,0.0]}
 
-await block ~1 ~1 ~1 fire
+await block ~1 ~1 ~1 diamond_block

--- a/gm4_better_fire/data/gm4_better_fire/tests/set_fire.mcfunction
+++ b/gm4_better_fire/data/gm4_better_fire/tests/set_fire.mcfunction
@@ -2,4 +2,4 @@
 
 summon arrow ~1.5 ~4 ~1.5 {Fire:100s,Motion:[0.0,-0.1,0.0]}
 
-await block ~1 ~1 ~1 diamond_block
+await block ~1 ~1 ~1 fire


### PR DESCRIPTION
Current problems:
- Tests are run at a random position in the world, so when you load the world you can't find the tests (there is a single line in the log with the coordinates, for example 4443907, -59, -13802014)
- Dummies are not saved, and these are often the things you want to check
- Ideally the game should be frozen when you enter it, with `/tick freeze`