### PR TITLE
Combat Expanded - small fixes

### DIFF
--- a/gm4_combat_expanded/data/gm4_combat_expanded/functions/slow_clock.mcfunction
+++ b/gm4_combat_expanded/data/gm4_combat_expanded/functions/slow_clock.mcfunction
@@ -21,7 +21,8 @@ execute as @e[type=creeper,tag=gm4_ce_toxic_creeper] run function gm4_combat_exp
 # cloaked crepers
 effect give @e[type=creeper,tag=gm4_ce_cloaked_creeper] invisibility 33 0
 
-# cleanup totem displays (this is just in case a totem dies in an unexpected way)
+# cleanup totems
+execute as @e[type=armor_stand,tag=gm4_ce_totem] at @s unless entity @a[distance=..32,gamemode=!spectator] run function gm4_combat_expanded:armor/modifier/type/totem/remove
 execute as @e[type=block_display,tag=gm4_ce_totem_display] at @s unless entity @e[type=armor_stand,tag=gm4_ce_totem,distance=..5] run kill @s
 
 # cleanup beacon light markers

--- a/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/armor.json
+++ b/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/armor.json
@@ -25,7 +25,7 @@
       "conditions": [
         {
           "condition": "minecraft:random_chance",
-          "chance": 0.5
+          "chance": 0.75
         }
       ]
     }

--- a/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/atkspeed.json
+++ b/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/atkspeed.json
@@ -2,19 +2,15 @@
   "type": "minecraft:generic",
   "pools": [
     {
-      "rolls": 10,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "minecraft:stone"
-        }
-      ]
-    },
-    {
       "rolls": {
-        "type": "minecraft:binomial",
-        "n": 15,
-        "p": 0.3
+        "min": {
+          "min": 10,
+          "max": 15
+        },
+        "max": {
+          "min": 10,
+          "max": 25
+        }
       },
       "entries": [
         {

--- a/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/damage.json
+++ b/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/damage.json
@@ -14,7 +14,7 @@
       "rolls": {
         "type": "minecraft:binomial",
         "n": 3,
-        "p": 0.4
+        "p": 0.475
       },
       "entries": [
         {

--- a/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/speed.json
+++ b/gm4_combat_expanded/data/gm4_combat_expanded/loot_tables/randomizer/speed.json
@@ -2,19 +2,15 @@
   "type": "minecraft:generic",
   "pools": [
     {
-      "rolls": 5,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "minecraft:stone"
-        }
-      ]
-    },
-    {
       "rolls": {
-        "type": "minecraft:binomial",
-        "n": 15,
-        "p": 0.3
+        "min": {
+          "min": 5,
+          "max": 10
+        },
+        "max": {
+          "min": 5,
+          "max": 20
+        }
       },
       "entries": [
         {


### PR DESCRIPTION
- Fixes Totemic totems hanging around if there are no players with Totemic armor online, they are now removed from a 30s slow clock
- Reworks modifier stat chances to make higher stats less rare (read: possible to obtain)