### PR TITLE
Patch 1.20.4 Zauber Liquids

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.event_name != 'pull_request' && 'release' || format('pr-{0}', github.event.number) }}
     steps:

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_drain/zauber_wormhole_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_drain/zauber_wormhole_potion.mcfunction
@@ -5,7 +5,9 @@
 execute store result score $math gm4_zl_warp_cx run data get storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.x
 execute store result score $math gm4_zl_warp_cy run data get storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.y
 execute store result score $math gm4_zl_warp_cz run data get storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.z
-execute store result score $math gm4_zl_warp_cd run data get storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.dimension
+# execute store result score $math gm4_zl_warp_cd run data get storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.dimension
+    # zauber cauldrons 1.10 changes the item format. Existing tanks will break with that update
+
 # Double score for first one so the initail input is just the actual position
 execute if score @s gm4_lt_value matches 0 run scoreboard players operation $math gm4_zl_warp_cx += $math gm4_zl_warp_cx
 execute if score @s gm4_lt_value matches 0 run scoreboard players operation $math gm4_zl_warp_cy += $math gm4_zl_warp_cy
@@ -25,6 +27,7 @@ scoreboard players operation @s gm4_zl_warp_cz += $math gm4_zl_warp_cz
 scoreboard players operation @s gm4_zl_warp_cz /= #2 gm4_lt_value
 
 # set dimension if first wormhole
-execute if score @s gm4_lt_value matches 0 run scoreboard players operation @s gm4_zl_warp_cd = $math gm4_zl_warp_cd
+# execute if score @s gm4_lt_value matches 0 run scoreboard players operation @s gm4_zl_warp_cd = $math gm4_zl_warp_cd
+execute if score @s gm4_lt_value matches 0 run data modify entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest,distance=..1] ArmorItems[3].tag.gm4_zauber_liquids.stored_wormhole.dimension set from storage gm4_liquid_tanks:temp/tank input_slot.tag.gm4_zauber_cauldrons.cauldron_pos.dimension
 
 function gm4_zauber_liquids:item_drain/zauber_potion

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_wormhole_potion.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/item_fill/zauber_wormhole_potion.mcfunction
@@ -6,7 +6,8 @@
 execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.x int 1 run scoreboard players get @s gm4_zl_warp_cx
 execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.y int 1 run scoreboard players get @s gm4_zl_warp_cy
 execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.z int 1 run scoreboard players get @s gm4_zl_warp_cz
-execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run scoreboard players get @s gm4_zl_warp_cd
+# execute store result storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.dimension int 1 run scoreboard players get @s gm4_zl_warp_cd
+data modify storage gm4_zauber_cauldrons:blueprint/item/wormhole gm4_zauber_cauldrons.cauldron_pos.dimension set from entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest,distance=..1] ArmorItems[3].tag.gm4_zauber_liquids.stored_wormhole.dimension
 
 # $item_value set in item_fill function for efficiency
 loot replace entity @e[type=armor_stand,tag=gm4_liquid_tank_stand,limit=1,sort=nearest,distance=..1] weapon.mainhand loot gm4_zauber_cauldrons:items/wormhole

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/relocate/restore_wormhole_scores.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/relocate/restore_wormhole_scores.mcfunction
@@ -6,4 +6,4 @@
 execute store result score @s[tag=gm4_lt_zauber_wormhole_potion] gm4_zl_warp_cx run data get storage gm4_relocators:temp gm4_relocation.entity_data.zl_warp_cx
 execute store result score @s[tag=gm4_lt_zauber_wormhole_potion] gm4_zl_warp_cy run data get storage gm4_relocators:temp gm4_relocation.entity_data.zl_warp_cy
 execute store result score @s[tag=gm4_lt_zauber_wormhole_potion] gm4_zl_warp_cz run data get storage gm4_relocators:temp gm4_relocation.entity_data.zl_warp_cz
-execute store result score @s[tag=gm4_lt_zauber_wormhole_potion] gm4_zl_warp_cd run data get storage gm4_relocators:temp gm4_relocation.entity_data.zl_warp_cd
+execute if entity @s[tag=gm4_lt_zauber_wormhole_potion] run data modify entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest,distance=..1] ArmorItems[3].tag.gm4_zauber_liquids.stored_wormhole.dimension set from storage gm4_relocators:temp gm4_relocation.entity_data.zl_warp_cz

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/relocate/store_wormhole_scores.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/relocate/store_wormhole_scores.mcfunction
@@ -6,4 +6,4 @@
 execute store result storage gm4_relocators:temp merge_data.entity_data.zl_warp_cx int 1 run scoreboard players get @s gm4_zl_warp_cx
 execute store result storage gm4_relocators:temp merge_data.entity_data.zl_warp_cy int 1 run scoreboard players get @s gm4_zl_warp_cy
 execute store result storage gm4_relocators:temp merge_data.entity_data.zl_warp_cz int 1 run scoreboard players get @s gm4_zl_warp_cz
-execute store result storage gm4_relocators:temp merge_data.entity_data.zl_warp_cd int 1 run scoreboard players get @s gm4_zl_warp_cd
+data modify storage gm4_relocators:temp merge_data.entity_data.zl_warp_cd set from entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest,distance=..1] ArmorItems[3].tag.gm4_zauber_liquids.stored_wormhole.dimension

--- a/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
+++ b/gm4_zauber_liquids/data/gm4_zauber_liquids/functions/util/wormhole.mcfunction
@@ -4,12 +4,21 @@
 # To work with non-player mobs, both versions require a change to @e from @a on line 14 of wormhole_targeting/set_dimension.mcfunction
 
 # Set coords
-scoreboard players operation $wormhole_x gm4_zc_data = @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cx
-scoreboard players operation $wormhole_y gm4_zc_data = @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cy
-scoreboard players operation $wormhole_z gm4_zc_data = @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cz
-scoreboard players operation $wormhole_d gm4_zc_data = @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_zl_warp_cd
-scoreboard players set $read_coordinates gm4_zc_data 1
-execute at @s run function gm4_zauber_cauldrons:player/wormhole_targeting/prepare_teleport
+data remove storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos
+execute store result storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos.x int 1 run scoreboard players get @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank,limit=1] gm4_zl_warp_cx
+execute store result storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos.y int 1 run scoreboard players get @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank,limit=1] gm4_zl_warp_cy
+execute store result storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos.z int 1 run scoreboard players get @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank,limit=1] gm4_zl_warp_cz
+execute at @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] run data modify storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos.dimension set from entity @e[type=armor_stand,tag=gm4_liquid_tank_display,limit=1,sort=nearest,distance=..1] ArmorItems[3].tag.gm4_zauber_liquids.stored_wormhole.dimension
+
+effect give @s resistance 1 12 true
+
+# particles and sound for depart
+particle minecraft:portal ~ ~.6 ~ .25 .25 .25 0 100
+playsound minecraft:entity.enderman.teleport player @a[distance=0.001..8] ~ ~ ~ 1 .3
+
+# teleport user to destination
+function gm4_zauber_cauldrons:player/wormhole_targeting/acquire_destination_context with storage gm4_zauber_cauldrons:temp/wormhole_targeting/destination cauldron_pos
+
 
 scoreboard players remove @e[type=marker,tag=gm4_liquid_tank,tag=gm4_processing_tank] gm4_lt_value 1
 playsound entity.player.swim block @a[distance=..8] ~ ~ ~ .5 1.5


### PR DESCRIPTION
Fixes the missed upgrades in zauber liquids for the v1.10 zauber cauldrons item format. 

I'm anticipating another set of breaking changes for 1.20.6 in both LT and ZC, so this is more of a fix for the archives. Merge conflicts with the 1.20.5 branch can be safely ignored/overwritten.