### PR TITLE
Port custom crafting recipes to official JSON recipes

### DIFF
--- a/gm4_block_compressors/data/gm4_block_compressors/recipe/compressor.json
+++ b/gm4_block_compressors/data/gm4_block_compressors/recipe/compressor.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "IPI",
+    "pOp",
+    "CCC"
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "P": {
+      "item": "minecraft:purpur_block"
+    },
+    "p": {
+      "item": "minecraft:piston"
+    },
+    "O": {
+      "item": "minecraft:obsidian"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "block/block_compressor_full",
+      "minecraft:profile": "$block_compressor",
+      "minecraft:custom_data": "{gm4_machines:{id:'block_compressor'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.block_compressor\",\"fallback\":\"Compressor\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_boots_of_ostara/data/gm4_boots_of_ostara/recipe/boots_of_ostara.json
+++ b/gm4_boots_of_ostara/data/gm4_boots_of_ostara/recipe/boots_of_ostara.json
@@ -1,0 +1,41 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "pattern": [
+    " S ",
+    "MLG",
+    " W "
+  ],
+  "key": {
+    "S": {
+      "item": "minecraft:wheat_seeds"
+    },
+    "M": {
+      "item": "minecraft:moss_block"
+    },
+    "L": {
+      "item": "minecraft:leather_boots"
+    },
+    "G": {
+      "item": "minecraft:grass_block"
+    },
+    "W": {
+      "item": "minecraft:water_bucket"
+    }
+  },
+  "result": {
+    "id": "minecraft:leather_boots",
+    "components": {
+      "minecraft:dyed_color": {
+        "rgb": 3705899,
+        "show_in_tooltip": false
+      },
+      "minecraft:custom_model_data": "item/boots_of_ostara",
+      "minecraft:custom_data": "{gm4_boots_of_ostara:1b}",
+      "minecraft:custom_name": "{\"translate\": \"item.gm4.boots_of_ostara\",\"fallback\": \"Boots of Ostara\",\"italic\": false}",
+      "minecraft:lore": [
+        "{\"translate\":\"item.gm4.boots_of_ostara.lore\",\"fallback\":\"Brings abundance beneath you!\",\"color\":\"dark_gray\",\"italic\":false}"
+      ]
+    }
+  }
+}

--- a/gm4_disassemblers/data/gm4_disassemblers/recipe/disassembler.json
+++ b/gm4_disassemblers/data/gm4_disassemblers/recipe/disassembler.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "ITI",
+    "OSO",
+    "CCC"
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "T": {
+      "item": "minecraft:tnt"
+    },
+    "O": {
+      "item": "minecraft:obsidian"
+    },
+    "S": {
+      "item": "minecraft:stonecutter"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/disassembler",
+      "minecraft:profile": "$disassembler",
+      "minecraft:custom_data": "{gm4_machines:{id:'disassembler'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.disassembler\",\"fallback\":\"Disassembler\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/recipe/enchantment_extractor.json
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/recipe/enchantment_extractor.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    " E ",
+    "GgG",
+    "CCC"
+  ],
+  "key": {
+    "E": {
+      "item": "minecraft:enchanting_table"
+    },
+    "G": {
+      "item": "minecraft:gold_ingot"
+    },
+    "g": {
+      "item": "minecraft:grindstone"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/enchantment_extractor",
+      "minecraft:profile": "$enchantment_extractor",
+      "minecraft:custom_data": "{gm4_machines:{id:'enchantment_extractor'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.enchantment_extractor\",\"fallback\":\"Enchantment Extractor\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/recipe/ender_hopper.json
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/recipe/ender_hopper.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "E",
+    "R",
+    "H"
+  ],
+  "key": {
+    "E": {
+      "item": "minecraft:ender_eye"
+    },
+    "R": {
+      "item": "minecraft:respawn_anchor"
+    },
+    "H": {
+      "item": "minecraft:hopper"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/ender_hopper",
+      "minecraft:profile": "$ender_hopper",
+      "minecraft:custom_data": "{gm4_machines:{id:'ender_hopper'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.ender_hopper\",\"fallback\":\"Ender Hopper\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/recipe/ender_hopper_minecart.json
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/recipe/ender_hopper_minecart.json
@@ -1,0 +1,28 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "E",
+    "R",
+    "H"
+  ],
+  "key": {
+    "E": {
+      "item": "minecraft:ender_eye"
+    },
+    "R": {
+      "item": "minecraft:respawn_anchor"
+    },
+    "H": {
+      "item": "minecraft:hopper_minecart"
+    }
+  },
+  "result": {
+    "id": "minecraft:hopper_minecart",
+    "components": {
+      "minecraft:custom_model_data": "item/ender_hopper_minecart",
+      "minecraft:custom_data": "{gm4_machines:{id:'ender_hopper_minecart'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.ender_hopper_minecart\",\"fallback\":\"Minecart with Ender Hopper\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/bricks.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "CCC",
+    "CCC",
+    "CCC"
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:bricks",
+    "count": 4
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/charcoal_block.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/charcoal_block.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "LLL",
+    "LWL",
+    "LLL"
+  ],
+  "key": {
+    "L": {
+      "tag": "minecraft:logs_that_burn"
+    },
+    "W": {
+      "item": "minecraft:wheat"
+    }
+  },
+  "result": {
+    "id": "minecraft:coal_block",
+    "count": 2,
+    "components": {
+      "minecraft:custom_model_data": "item/charcoal_block",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.charcoal_block\",\"fallback\":\"Block of Charcoal\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/deepslate_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/deepslate_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "DDD",
+    "DCD",
+    "DDD"
+  ],
+  "key": {
+    "D": {
+      "item": "minecraft:cobbled_deepslate"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:deepslate_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/end_stone_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/end_stone_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "EEE",
+    "ECE",
+    "EEE"
+  ],
+  "key": {
+    "E": {
+      "item": "minecraft:end_stone"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:end_stone_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/forming_press.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/forming_press.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    " P ",
+    "CcC",
+    "CFC"
+  ],
+  "key": {
+    "P": {
+      "item": "minecraft:piston"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "c": {
+      "item": "minecraft:comparator"
+    },
+    "F": {
+      "item": "minecraft:furnace"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/forming_press",
+      "minecraft:profile": "$forming_press",
+      "minecraft:custom_data": "{gm4_machines:{id:'forming_press'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.forming_press\",\"fallback\":\"Forming Press\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/lava_bucket.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/lava_bucket.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "pattern": [
+    "NNN",
+    "NBN",
+    "NNN"
+  ],
+  "key": {
+    "N": {
+      "item": "minecraft:netherrack"
+    },
+    "B": {
+      "item": "minecraft:bucket"
+    }
+  },
+  "result": {
+    "id": "minecraft:lava_bucket"
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/mud_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/mud_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "MMM",
+    "MCM",
+    "MMM"
+  ],
+  "key": {
+    "M": {
+      "item": "minecraft:mud"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:mud_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/nether_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/nether_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "NNN",
+    "NCN",
+    "NNN"
+  ],
+  "key": {
+    "N": {
+      "item": "minecraft:netherrack"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:nether_bricks",
+    "count": 4
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/packed_mud.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/packed_mud.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "WMW",
+    "MWM",
+    "WMW"
+  ],
+  "key": {
+    "W": {
+      "item": "minecraft:wheat"
+    },
+    "M": {
+      "item": "minecraft:mud"
+    }
+  },
+  "result": {
+    "id": "minecraft:packed_mud",
+    "count": 8
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/polished_blackstone_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/polished_blackstone_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "BBB",
+    "BCB",
+    "BBB"
+  ],
+  "key": {
+    "B": {
+      "item": "minecraft:blackstone"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:polished_blackstone_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/prismarine_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/prismarine_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "PPP",
+    "PCP",
+    "PPP"
+  ],
+  "key": {
+    "P": {
+      "item": "minecraft:prismarine_shard"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:prismarine_bricks",
+    "count": 4
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/purpur_block.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/purpur_block.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "FFF",
+    "FCF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:chorus_fruit"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:purpur_block",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/quartz_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/quartz_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "QQQ",
+    "QCQ",
+    "QQQ"
+  ],
+  "key": {
+    "Q": {
+      "item": "minecraft:quartz_block"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:quartz_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/red_nether_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/red_nether_bricks.json
@@ -1,0 +1,24 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "WNW",
+    "NCN",
+    "WNW"
+  ],
+  "key": {
+    "W": {
+      "item": "minecraft:nether_wart"
+    },
+    "N": {
+      "item": "minecraft:netherrack"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:red_nether_bricks",
+    "count": 4
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/stone_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/stone_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "CCC",
+    "CcC",
+    "CCC"
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "c": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:stone_bricks",
+    "count": 16
+  }
+}

--- a/gm4_forming_press/data/gm4_forming_press/recipe/tuff_bricks.json
+++ b/gm4_forming_press/data/gm4_forming_press/recipe/tuff_bricks.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "pattern": [
+    "TTT",
+    "TCT",
+    "TTT"
+  ],
+  "key": {
+    "T": {
+      "item": "minecraft:tuff"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    }
+  },
+  "result": {
+    "id": "minecraft:tuff_bricks",
+    "count": 16
+  }
+}

--- a/gm4_heart_canisters/data/gm4_heart_canisters/recipe/heart_canister_tier_1.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/recipe/heart_canister_tier_1.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "OIO",
+    "GNG",
+    "OGO"
+  ],
+  "key": {
+    "O": {
+      "item": "minecraft:obsidian"
+    },
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "G": {
+      "item": "minecraft:golden_apple"
+    },
+    "N": {
+      "item": "minecraft:nether_star"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/heart_canister_tier_1",
+      "minecraft:profile": "$heart_canister_tier_1",
+      "minecraft:custom_data": "{gm4_heart_canister:1b,gm4_heart_canister_tier:1b}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.heart_canister\",\"fallback\":\"Heart Canister\",\"italic\":false}",
+      "minecraft:lore": [
+        "{\"translate\":\"item.gm4.heart_canister.lore.tier\",\"fallback\":\"Tier %s\",\"with\":[\"1\"],\"color\":\"gray\",\"italic\":false}"
+      ]
+    }
+  }
+}

--- a/gm4_liquid_minecarts/data/gm4_liquid_minecarts/recipe/liquid_minecart.json
+++ b/gm4_liquid_minecarts/data/gm4_liquid_minecarts/recipe/liquid_minecart.json
@@ -1,0 +1,31 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "IGI",
+    "ICI",
+    " H "
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "G": {
+      "item": "minecraft:glass"
+    },
+    "C": {
+      "item": "minecraft:comparator"
+    },
+    "H": {
+      "item": "minecraft:hopper_minecart"
+    }
+  },
+  "result": {
+    "id": "minecraft:hopper_minecart",
+    "components": {
+      "minecraft:custom_model_data": "item/liquid_minecart",
+      "minecraft:custom_data": "{gm4_machines:{id:'liquid_minecart'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.liquid_minecart\",\"fallback\":\"Minecart with Liquid Tank\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/recipe/liquid_tank.json
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/recipe/liquid_tank.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "IGI",
+    "ICI",
+    " H "
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "G": {
+      "item": "minecraft:glass"
+    },
+    "C": {
+      "item": "minecraft:comparator"
+    },
+    "H": {
+      "item": "minecraft:hopper"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/liquid_tank",
+      "minecraft:profile": "$liquid_tank",
+      "minecraft:custom_data": "{gm4_machines:{id:'liquid_tank'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.liquid_tank\",\"fallback\":\"Liquid Tank\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_mountaineering/data/gm4_mountaineering/recipe/crampons.json
+++ b/gm4_mountaineering/data/gm4_mountaineering/recipe/crampons.json
@@ -1,0 +1,40 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "pattern": [
+    " B ",
+    "NNN"
+  ],
+  "key": {
+    "B": {
+      "item": "minecraft:chainmail_boots"
+    },
+    "N": {
+      "item": "minecraft:iron_nugget"
+    }
+  },
+  "result": {
+    "id": "minecraft:chainmail_boots",
+    "components": {
+      "minecraft:custom_model_data": "item/crampons",
+      "minecraft:custom_data": "{gm4_mountaineering:{item:'crampons'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.crampons\",\"fallback\":\"Crampons\",\"italic\":false}",
+      "minecraft:attribute_modifiers": [
+        {
+          "type": "minecraft:generic.movement_speed",
+          "id": "gm4_mountaineering:crampon_slowness",
+          "amount": -0.2,
+          "operation": "add_multiplied_base",
+          "slot": "feet"
+        },
+        {
+          "type": "minecraft:generic.armor",
+          "id": "gm4_mountaineering:crampon_armor",
+          "amount": 1,
+          "operation": "add_value",
+          "slot": "feet"
+        }
+      ]
+    }
+  }
+}

--- a/gm4_mountaineering/data/gm4_mountaineering/recipe/ski_pole.json
+++ b/gm4_mountaineering/data/gm4_mountaineering/recipe/ski_pole.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "pattern": [
+    "T",
+    "S",
+    "S"
+  ],
+  "key": {
+    "T": {
+      "item": "minecraft:tripwire_hook"
+    },
+    "S": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "id": "minecraft:stick",
+    "components": {
+      "minecraft:custom_model_data": "item/poles",
+      "minecraft:max_stack_size": 1,
+      "minecraft:custom_data": "{gm4_mountaineering:{item:'poles'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.poles\",\"fallback\":\"Ski Pole\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_mountaineering/data/gm4_mountaineering/recipe/skis.json
+++ b/gm4_mountaineering/data/gm4_mountaineering/recipe/skis.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "pattern": [
+    "I I",
+    "IBI",
+    "I I"
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "B": {
+      "item": "minecraft:iron_boots"
+    }
+  },
+  "result": {
+    "id": "minecraft:iron_boots",
+    "components": {
+      "minecraft:custom_model_data": "item/skis",
+      "minecraft:custom_data": "{gm4_mountaineering:{item:'skis'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.skis\",\"fallback\":\"Skis\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_orb_of_ankou/data/gm4_orb_of_ankou/recipe/orb_of_ankou.json
+++ b/gm4_orb_of_ankou/data/gm4_orb_of_ankou/recipe/orb_of_ankou.json
@@ -1,0 +1,39 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "NCN",
+    "CSC",
+    "NCN"
+  ],
+  "key": {
+    "N": {
+      "item": "minecraft:netherite_scrap"
+    },
+    "C": {
+      "item": "minecraft:clay_ball"
+    },
+    "S": {
+      "item": "minecraft:nether_star"
+    }
+  },
+  "result": {
+    "id": "minecraft:firework_star",
+    "components": {
+      "minecraft:enchantment_glint_override": true,
+      "minecraft:custom_model_data": "item/orb_of_ankou",
+      "minecraft:hide_additional_tooltip": {},
+      "minecraft:firework_explosion": {
+        "shape": "small_ball",
+        "colors": [
+          13092807
+        ]
+      },
+      "minecraft:custom_data": "{gm4_orb_of_ankou:{item:'orb'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.orb_of_ankou\",\"fallback\":\"Orb of Ankou\",\"color\":\"aqua\",\"italic\":false}",
+      "minecraft:lore": [
+        "{\"translate\":\"text.gm4.orb_of_ankou.empty\",\"fallback\":\"Empty\",\"color\":\"gray\"}"
+      ]
+    }
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_11.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_11.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:coal"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_11"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_13.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_13.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:yellow_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_13"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_blocks.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_blocks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:orange_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_blocks"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_cat.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_cat.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:green_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_cat"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_chirp.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_chirp.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:red_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_chirp"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_far.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_far.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:lime_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_far"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_mall.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_mall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:purple_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_mall"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_mellohi.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_mellohi.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:magenta_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_mellohi"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_stal.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_stal.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:black_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_stal"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_strad.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_strad.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:white_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_strad"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_wait.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_wait.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:light_blue_dye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_wait"
+  }
+}

--- a/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_ward.json
+++ b/gm4_record_crafting/data/gm4_record_crafting/recipe/music_disc_ward.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:flint"
+    },
+    "D": {
+      "item": "minecraft:ender_eye"
+    }
+  },
+  "result": {
+    "id": "minecraft:music_disc_ward"
+  }
+}

--- a/gm4_smelteries/data/gm4_smelteries/recipe/smeltery.json
+++ b/gm4_smelteries/data/gm4_smelteries/recipe/smeltery.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "CCC",
+    "CFC",
+    "IcI"
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "F": {
+      "item": "minecraft:furnace"
+    },
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "c": {
+      "item": "minecraft:comparator"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/smeltery",
+      "minecraft:profile": "$smeltery",
+      "minecraft:custom_data": "{gm4_machines:{id:'smeltery'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.smeltery\",\"fallback\":\"Smeltery\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/recipe/teleportation_anchor.json
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/recipe/teleportation_anchor.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "EPE",
+    "OLO",
+    "CCC"
+  ],
+  "key": {
+    "E": {
+      "item": "minecraft:end_stone_bricks"
+    },
+    "P": {
+      "item": "minecraft:ender_pearl"
+    },
+    "O": {
+      "item": "minecraft:crying_obsidian"
+    },
+    "L": {
+      "item": "minecraft:lodestone"
+    },
+    "C": {
+      "item": "minecraft:chiseled_stone_bricks"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/teleportation_anchor",
+      "minecraft:profile": "$teleportation_anchor",
+      "minecraft:custom_data": "{gm4_machines:{id:'teleportation_anchor'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.teleportation_anchor\",\"fallback\":\"Teleportation Anchor\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/recipe/teleportation_jammer.json
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/recipe/teleportation_jammer.json
@@ -1,0 +1,40 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    " P ",
+    "OEO",
+    "CeC"
+  ],
+  "key": {
+    "P": [
+      {
+        "item": "minecraft:purpur_block"
+      },
+      {
+        "item": "minecraft:purpur_pillar"
+      }
+    ],
+    "O": {
+      "item": "minecraft:crying_obsidian"
+    },
+    "E": {
+      "item": "minecraft:ender_eye"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "e": {
+      "item": "minecraft:end_crystal"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "item/teleportation_jammer",
+      "minecraft:profile": "$teleportation_jammer",
+      "minecraft:custom_data": "{gm4_machines:{id:'teleportation_jammer'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.teleportation_jammer\",\"fallback\":\"Teleportation Jammer\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/recipe/piston_minecart.json
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/recipe/piston_minecart.json
@@ -1,0 +1,31 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "group": "gm4_tunnel_bores:piston_minecart",
+  "pattern": [
+    " F ",
+    "TMP"
+  ],
+  "key": {
+    "F": {
+      "item": "minecraft:furnace"
+    },
+    "T": {
+      "item": "minecraft:tripwire_hook"
+    },
+    "M": {
+      "item": "minecraft:minecart"
+    },
+    "P": {
+      "item": "minecraft:piston"
+    }
+  },
+  "result": {
+    "id": "minecraft:furnace_minecart",
+    "components": {
+      "minecraft:custom_model_data": "item/piston_minecart",
+      "minecraft:custom_data": "{gm4_machines:{id:'tunnel_bore'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.minecart.bore\",\"fallback\":\"Minecart with Piston\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/gm4_tunnel_bores/data/gm4_tunnel_bores/recipe/piston_minecart_from_furnace_minecart.json
+++ b/gm4_tunnel_bores/data/gm4_tunnel_bores/recipe/piston_minecart_from_furnace_minecart.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "group": "gm4_tunnel_bores:piston_minecart",
+  "pattern": [
+    "TMP"
+  ],
+  "key": {
+    "T": {
+      "item": "minecraft:tripwire_hook"
+    },
+    "M": {
+      "item": "minecraft:furnace_minecart"
+    },
+    "P": {
+      "item": "minecraft:piston"
+    }
+  },
+  "result": {
+    "id": "minecraft:furnace_minecart",
+    "components": {
+      "minecraft:custom_model_data": "item/piston_minecart",
+      "minecraft:custom_data": "{gm4_machines:{id:'tunnel_bore'}}",
+      "minecraft:custom_name": "{\"translate\":\"item.gm4.minecart.bore\",\"fallback\":\"Minecart with Piston\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}

--- a/lib_custom_crafters/data/gm4_custom_crafters/recipe/custom_crafter.json
+++ b/lib_custom_crafters/data/gm4_custom_crafters/recipe/custom_crafter.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "pattern": [
+    "ILI",
+    "CTC",
+    "CDC"
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_ingot"
+    },
+    "L": {
+      "item": "minecraft:light_blue_dye"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "T": {
+      "item": "minecraft:crafting_table"
+    },
+    "D": {
+      "item": "minecraft:dropper"
+    }
+  },
+  "result": {
+    "id": "minecraft:player_head",
+    "components": {
+      "minecraft:custom_model_data": "gm4_custom_crafters:item/custom_crafter",
+      "minecraft:profile": "$gm4_custom_crafters:custom_crafter",
+      "minecraft:custom_data": "{gm4_machines:{id:'custom_crafter'}}",
+      "minecraft:custom_name": "{\"translate\":\"block.gm4.custom_crafter\",\"fallback\":\"Custom Crafter\",\"color\":\"white\",\"italic\":false}"
+    }
+  }
+}


### PR DESCRIPTION
- Closes #980 

## Notes
- Leaving out: auto crafter, heart canister tier 2, relocators, scuba gear
- Slightly modifies: ender hopper minecart, liquid minecart
- Discarding item data: boots of ostara, mountaineering

## Todo
- [x] Create initial recipe JSON files
- [ ] Add recipe unlock advancements
- [ ] Update record crafting advancement
- [ ] Update wiki, guidebook, readme
- [ ] Maybe: overwrite some vanilla recipes to add `group` field for forming press recipes
- [ ] Maybe: rebrand record crafting, standard crafting, and forming press

## Future work
- Switch from `custom_name` to `item_name` and `rarity`
- Discuss whether we want to add a `[GM4] <module name>` tag line
- Remove auto crafting module