### PR TITLE
Add Nullscape support to End Fishing

### DIFF
--- a/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/debris.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/debris.json
@@ -82,6 +82,12 @@
                   "predicate": {
                     "biomes": "minecraft:end_highlands"
                   }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
+                  }
                 }
               ]
             }
@@ -134,6 +140,12 @@
                   "condition": "minecraft:location_check",
                   "predicate": {
                     "biomes": "minecraft:small_end_islands"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/void_barrens"
                   }
                 }
               ]

--- a/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/scattered_treasure.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/scattered_treasure.json
@@ -122,7 +122,7 @@
           "name": "minecraft:dragon_head"
         },
         {
-          "type": "minecraft:item",
+          "type": "minecraft:loot_table",
           "conditions": [
             {
               "condition": "minecraft:any_of",
@@ -148,44 +148,11 @@
               ]
             }
           ],
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0,
-                "max": 0.005
-              }
-            },
-            {
-              "function": "minecraft:set_components",
-              "components": {
-                "minecraft:custom_model_data": "item/captains_wings"
-              }
-            },
-            {
-              "function": "minecraft:set_lore",
-              "mode": "append",
-              "lore": [
-                {
-                  "translate": "text.gm4.end_ship_elytra.10.1",
-                  "fallback": "Nobody imagined the Captain's lost",
-                  "italic": false,
-                  "color": "dark_gray"
-                },
-                {
-                  "translate": "text.gm4.end_ship_elytra.10.2",
-                  "fallback": "wings would be seen again, ever.",
-                  "italic": false,
-                  "color": "dark_gray"
-                }
-              ]
-            }
-          ],
           "weight": 1,
-          "name": "minecraft:elytra"
+          "value": "gm4_end_fishing:items/captains_wings"
         },
         {
-          "type": "minecraft:item",
+          "type": "minecraft:loot_table",
           "conditions": [
             {
               "condition": "minecraft:location_check",
@@ -194,41 +161,8 @@
               }
             }
           ],
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0,
-                "max": 0.005
-              }
-            },
-            {
-              "function": "minecraft:set_components",
-              "components": {
-                "minecraft:custom_model_data": "item/captains_wings"
-              }
-            },
-            {
-              "function": "minecraft:set_lore",
-              "mode": "append",
-              "lore": [
-                {
-                  "translate": "text.gm4.end_ship_elytra.10.1",
-                  "fallback": "Nobody imagined the Captain's lost",
-                  "italic": false,
-                  "color": "dark_gray"
-                },
-                {
-                  "translate": "text.gm4.end_ship_elytra.10.2",
-                  "fallback": "wings would be seen again, ever.",
-                  "italic": false,
-                  "color": "dark_gray"
-                }
-              ]
-            }
-          ],
           "weight": 2,
-          "name": "minecraft:elytra"
+          "value": "gm4_end_fishing:items/captains_wings"
         },
         {
           "type": "minecraft:item",

--- a/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/scattered_treasure.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/scattered_treasure.json
@@ -68,6 +68,24 @@
                   "predicate": {
                     "biomes": "minecraft:end_barrens"
                   }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/void_barrens"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/crystal_peaks"
+                  }
                 }
               ]
             }
@@ -89,6 +107,12 @@
                   "condition": "minecraft:location_check",
                   "predicate": {
                     "biomes": "minecraft:end_highlands"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
                   }
                 }
               ]
@@ -113,6 +137,12 @@
                   "condition": "minecraft:location_check",
                   "predicate": {
                     "biomes": "minecraft:end_highlands"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
                   }
                 }
               ]
@@ -158,6 +188,52 @@
           "type": "minecraft:item",
           "conditions": [
             {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "#gm4_end_fishing:nullscape/crystal_peaks"
+              }
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0,
+                "max": 0.005
+              }
+            },
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:custom_model_data": "item/captains_wings"
+              }
+            },
+            {
+              "function": "minecraft:set_lore",
+              "mode": "append",
+              "lore": [
+                {
+                  "translate": "text.gm4.end_ship_elytra.10.1",
+                  "fallback": "Nobody imagined the Captain's lost",
+                  "italic": false,
+                  "color": "dark_gray"
+                },
+                {
+                  "translate": "text.gm4.end_ship_elytra.10.2",
+                  "fallback": "wings would be seen again, ever.",
+                  "italic": false,
+                  "color": "dark_gray"
+                }
+              ]
+            }
+          ],
+          "weight": 2,
+          "name": "minecraft:elytra"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
               "condition": "minecraft:any_of",
               "terms": [
                 {
@@ -170,6 +246,12 @@
                   "condition": "minecraft:location_check",
                   "predicate": {
                     "biomes": "minecraft:end_highlands"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
                   }
                 }
               ]

--- a/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/valuables.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/loot_table/gameplay/fish/valuables.json
@@ -26,6 +26,12 @@
                   "predicate": {
                     "biomes": "minecraft:end_highlands"
                   }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
+                  }
                 }
               ]
             }
@@ -40,8 +46,45 @@
         },
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "inverted",
+              "term": {
+                "condition": "location_check",
+                "predicate": {
+                  "biomes": "#gm4_end_fishing:nullscape/crystal_peaks"
+                }
+              }
+            }
+          ],
           "weight": 1,
           "name": "minecraft:obsidian"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "location_check",
+              "predicate": {
+                "biomes": "#gm4_end_fishing:nullscape/crystal_peaks"
+              }
+            }
+          ],
+          "weight": 8,
+          "name": "minecraft:crying_obsidian"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "location_check",
+              "predicate": {
+                "biomes": "#gm4_end_fishing:nullscape/crystal_peaks"
+              }
+            }
+          ],
+          "weight": 16,
+          "name": "minecraft:amethyst_block"
         },
         {
           "type": "minecraft:item",
@@ -109,6 +152,12 @@
                   "predicate": {
                     "biomes": "minecraft:end_midlands"
                   }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/shadowlands"
+                  }
                 }
               ]
             }
@@ -130,6 +179,12 @@
                   "condition": "minecraft:location_check",
                   "predicate": {
                     "biomes": "minecraft:end_barrens"
+                  }
+                },
+                {
+                  "condition": "minecraft:location_check",
+                  "predicate": {
+                    "biomes": "#gm4_end_fishing:nullscape/void_barrens"
                   }
                 }
               ]

--- a/gm4_end_fishing/data/gm4_end_fishing/loot_table/items/captains_wings.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/loot_table/items/captains_wings.json
@@ -1,0 +1,46 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:elytra",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:custom_model_data": "item/captains_wings"
+              }
+            },
+            {
+              "function": "minecraft:set_lore",
+              "mode": "append",
+              "lore": [
+                {
+                  "translate": "text.gm4.end_ship_elytra.10.1",
+                  "fallback": "Nobody imagined the Captain's lost",
+                  "italic": false,
+                  "color": "dark_gray"
+                },
+                {
+                  "translate": "text.gm4.end_ship_elytra.10.2",
+                  "fallback": "wings would be seen again, ever.",
+                  "italic": false,
+                  "color": "dark_gray"
+                }
+              ]
+            },
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "min": 0,
+                "max": 0.005
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/crystal_peaks.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/crystal_peaks.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        {
+            "id": "nullscape:crystal_peaks",
+            "required": false
+        }
+    ]
+}

--- a/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/shadowlands.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/shadowlands.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        {
+            "id": "nullscape:shadowlands",
+            "required": false
+        }
+    ]
+}

--- a/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/void_barrens.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/tags/worldgen/biome/nullscape/void_barrens.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        {
+            "id": "nullscape:void_barrens",
+            "required": false
+        }
+    ]
+}


### PR DESCRIPTION
Currently, End Fishing only supports the Vanilla biomes. This PR adds support for [Nullscape biomes](https://stardustlabs.miraheze.org/wiki/Nullscape#Biomes) - meaning loot can be gained by fishing in Nullscape's biomes. This is also important, since Nullscape prevents a couple of vanilla end biomes from generating.

### History
This was previously discussed over a year ago, but it was not easily possible due to how End Fishing is set up. Now that it is possible to reference biome tags in loot tables, this idea is possible (and can be expanded to other custom end biomes if needed in the future).

### Implementation
Three new biome tags were made, following the `gm4_end_fishing:nullscape/[biome]` schema. These tags reference the respective Nullscape biome, setting `required` to `false`. Then the loot tables reference the tags as they would any other vanilla end biome.

### Nullscape Biome Loot
- **Shadowlands** - Copies the End Midlands loot distribution, since End Midlands does not generate in Nullscape
- **Void Barrens** - Copies the End Barrens loot distribution, since End Barrens does not generate in Nullscape
- **Crystal Peaks** - Has the default loot distribution, except:
  - **Valuables** - Obsidian is replaced with Crying Obsidian, and added an extra Amethyst Block entry
  - **Scattered Treasure** - Made Captain's Wings *slightly* more common (since it's a mountain biome)

### Note
While working on the loot tables, I noticed that Captain's Wings (elytra) was an inline definition in the `scattered_treasure` loot table. Instead of making a new PR for it, I just moved it to `gm4_end_fishing:items/captains_wings` (just like `ravaged_wings` already is) in bb4c0aa. This can be reverted if for some reason it is not wanted.