### PR TITLE
Soul Glass under Nether Roof Fix

### DIFF
--- a/gm4_soul_glass/data/gm4_soul_glass/tags/block/beacon_passable.json
+++ b/gm4_soul_glass/data/gm4_soul_glass/tags/block/beacon_passable.json
@@ -21,6 +21,7 @@
         "minecraft:bamboo",
         "minecraft:barrier",
         "minecraft:beacon",
+        "minecraft:bedrock",
         "minecraft:bell",
         "minecraft:black_stained_glass_pane",
         "minecraft:black_stained_glass",


### PR DESCRIPTION
This PR adds "minecraft:bedrock" to the "#gm4_soulglass:beacon_passable" block tag.

This fixes an issue where a soul glass beacon under the nether roof fails, but does work above.