### PR TITLE
Metallurgy: Other explosions create ore lumps

### DIFF
--- a/gm4_metallurgy/data/minecraft/loot_table/blocks/stone.json
+++ b/gm4_metallurgy/data/minecraft/loot_table/blocks/stone.json
@@ -37,7 +37,12 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
-                    "type": "minecraft:tnt"
+                    "type": [
+                      "minecraft:tnt",
+                      "minecraft:creeper",
+                      "minecraft:wither",
+                      "minecraft:wither_skull"
+                    ]
                   }
                 },
                 {


### PR DESCRIPTION
Adds creepers, withers, and wither skeletons alongside TNT creating ore lumps when destroying stone