### PR TITLE
Fix disassembling tools in 1.21.1

### DIFF
--- a/gm4_disassemblers/data/minecraft/tags/item/gold_tool_materials.json
+++ b/gm4_disassemblers/data/minecraft/tags/item/gold_tool_materials.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:gold_ingot"
+  ]
+}

--- a/gm4_disassemblers/data/minecraft/tags/item/iron_tool_materials.json
+++ b/gm4_disassemblers/data/minecraft/tags/item/iron_tool_materials.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:iron_ingot"
+  ]
+}


### PR DESCRIPTION
When updating the packs to 1.21.2, I noticed that the recipes used some new item tags. I changed the disassemblers beet code to use them, but didn't notice that this would break the 1.21.1 version of the pack.

The proper way to implement this would be reading the 1.21.1 vanilla recipe files to generate the loot tables, but that's a whole bunch of overlays. Since the recipes themselves didn't change, adding a copy of the vanilla files is a lot easier.

I tested this locally to make sure the fix works.