### PR TITLE
Liab: Fix all brewed splash->lingering becoming lightning

### DIFF
--- a/gm4_lightning_in_a_bottle/data/gm4_lightning_in_a_bottle/loot_table/technical/brewing_stand/lingering.json
+++ b/gm4_lightning_in_a_bottle/data/gm4_lightning_in_a_bottle/loot_table/technical/brewing_stand/lingering.json
@@ -14,9 +14,7 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
-                    "predicates": {
-                      "minecraft:custom_data": "{data:{gm4_brewing:{insert:{components:{'minecraft:custom_data':{gm4_lightning_in_a_bottle:1b}}}}}}"
-                    }
+                    "nbt": "{data:{gm4_brewing:{insert:{components:{'minecraft:custom_data':{gm4_lightning_in_a_bottle:1b}}}}}}"
                   }
                 }
               ]


### PR DESCRIPTION
Seems like there was a single upgrade difference between brewed splash and lightning potions which resulted in any splash potion becoming a lingering bottle of lightning