### PR TITLE
Crossbow Cartridges 1.21: Torch place fix

### DIFF
--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/torch/place.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/torch/place.mcfunction
@@ -3,8 +3,8 @@
 # at @s
 # run from projectile/torch/check
 
-execute positioned ~.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.1 ~ ~ minecraft:wall_torch[facing=west]
-execute positioned ~ ~ ~.05 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.1 minecraft:wall_torch[facing=north]
-execute positioned ~-.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.1 ~ ~ minecraft:wall_torch[facing=east]
-execute positioned ~ ~ ~-.05 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.1 minecraft:wall_torch[facing=south]
-execute positioned ~ ~-.05 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.1 ~ minecraft:torch
+execute positioned ~.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.15 ~ ~ minecraft:wall_torch[facing=west]
+execute positioned ~ ~ ~.1 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.15 minecraft:wall_torch[facing=north]
+execute positioned ~-.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.15 ~ ~ minecraft:wall_torch[facing=east]
+execute positioned ~ ~ ~-.1 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.15 minecraft:wall_torch[facing=south]
+execute positioned ~ ~-.1 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.15 ~ minecraft:torch


### PR DESCRIPTION
Testing on a 1.21.4 realm (issue courtesy of Mama), shooting a torch with a crossbow cartridge fails to place where it typically would.  This issue is fixed by slightly extending the check and placement of the torch.