### PR TITLE
Optimize book binders NBT modifications

### DIFF
--- a/gm4_book_binders/data/gm4_book_binders/function/binder/placement/disable.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/function/binder/placement/disable.mcfunction
@@ -1,9 +1,6 @@
-# @s any book binder armor stand in lectern with book on actual lectern
+# @s any active book binder armor stand in lectern with book on actual lectern
 # at @s
 # run from gm4_book_binders:process_binder
 
 data merge entity @s {DisabledSlots:2039583,Marker:1b}
 tag @s remove gm4_book_binder_active
-
-# kill armor stands that are no longer in a lectern
-execute unless block ~ ~ ~ lectern run function gm4_book_binders:binder/placement/kill

--- a/gm4_book_binders/data/gm4_book_binders/function/binder/placement/enable.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/function/binder/placement/enable.mcfunction
@@ -1,4 +1,4 @@
-# @s any book binder armor stand in lectern with book on actual lectern
+# @s any disabled book binder armor stand in lectern without book on actual lectern
 # at @s
 # run from gm4_book_binders:process_binder
 

--- a/gm4_book_binders/data/gm4_book_binders/function/process_binders.mcfunction
+++ b/gm4_book_binders/data/gm4_book_binders/function/process_binders.mcfunction
@@ -3,8 +3,11 @@
 # run from gm4_book_binders:main
 
 # disable bookbinders with books on actual lectern
-execute unless entity @s[tag=gm4_book_binder_active] run function gm4_book_binders:binder/placement/enable
-execute unless block ~ ~ ~ lectern[has_book=false] run function gm4_book_binders:binder/placement/disable
+execute unless entity @s[tag=gm4_book_binder_active] if block ~ ~ ~ lectern[has_book=false] run function gm4_book_binders:binder/placement/enable
+execute if entity @s[tag=gm4_book_binder_active] unless block ~ ~ ~ lectern[has_book=false] run function gm4_book_binders:binder/placement/disable
+
+# kill armor stands that are no longer in a lectern
+execute unless block ~ ~ ~ lectern run function gm4_book_binders:binder/placement/kill
 
 # slow clock per book binder for recipe processing
 scoreboard players add @s[tag=gm4_book_binder_active] gm4_binder_data 1


### PR DESCRIPTION
I noticed that the `main` function of book binders was not super performant, and this boiled down to some NBT modification commands. The module would repeatedly modify the `DisabledSlots` NBT, even if the disabled/enabled state of a book binder hadn't changed. This simply adds some checks for the `gm4_book_binder_active` tag.

Not yet tested in-game

Performance report below is on an idle server with 2 book binder entities, but still book binders taking > 3% of the `scheduledFunctions` seems too much too me.
![image](https://github.com/user-attachments/assets/042c3a6b-5fa0-41c7-8592-0ff08351c7d0)
