### PR TITLE
Fix Guidebook RP for 1.21.2+

### DIFF
--- a/gm4_guidebook/assets/gm4/font/vanilla_items.json
+++ b/gm4_guidebook/assets/gm4/font/vanilla_items.json
@@ -479,15 +479,6 @@
         },
         {
             "type": "bitmap",
-            "file": "minecraft:item/bundle_filled.png",
-            "ascent": -32768,
-            "height": -16,
-            "chars": [
-                "\u0938"
-            ]
-        },
-        {
-            "type": "bitmap",
             "file": "minecraft:item/cake.png",
             "ascent": -32768,
             "height": -16,
@@ -4488,15 +4479,6 @@
             "height": 16,
             "chars": [
                 "\u0dc6"
-            ]
-        },
-        {
-            "type": "bitmap",
-            "file": "minecraft:item/bundle_filled.png",
-            "ascent": 8,
-            "height": 16,
-            "chars": [
-                "\u0dc7"
             ]
         },
         {

--- a/gm4_guidebook/assets/gm4_guidebook/lang/en_us.json
+++ b/gm4_guidebook/assets/gm4_guidebook/lang/en_us.json
@@ -850,7 +850,6 @@
     "gui.gm4.guidebook.crafting.display.minecraft.bubble_coral_fan": "\u0dc4\u0935\uf015",
     "gui.gm4.guidebook.crafting.display.minecraft.bucket": "\u0dc5\u0936\uf015",
     "gui.gm4.guidebook.crafting.display.minecraft.bundle": "\u0dc6\u0937\uf015",
-    "gui.gm4.guidebook.crafting.display.minecraft.bundle_filled": "\u0dc7\u0938\uf015",
     "gui.gm4.guidebook.crafting.display.minecraft.cake": "\u0dc8\u0939\uf015",
     "gui.gm4.guidebook.crafting.display.minecraft.campfire": "\u0dc9\u093a\uf015",
     "gui.gm4.guidebook.crafting.display.minecraft.candle": "\u0dca\u093b\uf015",


### PR DESCRIPTION
- remove bundle_filled references since the texture file no longer exists

This is a temporary hotfix. Ideally, the models are generated with a build script in the future.