### PR TITLE
Modernize Desire Lines

### DIFF
--- a/gm4_desire_lines/beet.yaml
+++ b/gm4_desire_lines/beet.yaml
@@ -44,6 +44,7 @@ meta:
       Creator:
         - Sparks
       Updated by:
+        - Bloo
         - SpecialBuilder32
         - Misode
         - Andante

--- a/gm4_desire_lines/data/gm4_celaro_shamir/function/active.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/function/active.mcfunction
@@ -1,2 +1,10 @@
-scoreboard players set @s gm4_desire_lines 0
+# Effects of the Celaro Shamir
+# @s = player with Celaro on their armor
+# at unspecified
+# run from tick
+
+# semi-ensure desire lines is disabled ($probability should only be modified NOT SET, as the modification order is load dependent)
+scoreboard players remove $probability gm4_desire_lines 2147483647
+
+# secondary celaro effect: invisibility inside foliage
 execute if predicate gm4_celaro_shamir:stealth_active run effect give @s invisibility 1 0 true

--- a/gm4_desire_lines/data/gm4_celaro_shamir/function/active.mcfunction
+++ b/gm4_desire_lines/data/gm4_celaro_shamir/function/active.mcfunction
@@ -4,7 +4,7 @@
 # run from tick
 
 # semi-ensure desire lines is disabled ($probability should only be modified NOT SET, as the modification order is load dependent)
-scoreboard players remove $probability gm4_desire_lines 2147483647
+scoreboard players remove $probability gm4_desire_lines 1000
 
 # secondary celaro effect: invisibility inside foliage
 execute if predicate gm4_celaro_shamir:stealth_active run effect give @s invisibility 1 0 true

--- a/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
@@ -5,7 +5,7 @@ scoreboard objectives add gm4_dl_affcoarse dummy
 scoreboard players set #base_probability gm4_desire_lines 1
 scoreboard players set #sneak_penality gm4_desire_lines -5
 scoreboard players set #sprint_penalty gm4_desire_lines 5
-scoreboard players set #impact_penalty gm4_desire_lines 30
+scoreboard players set #impact_penalty gm4_desire_lines 15
 
 execute unless score desire_lines gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Desire Lines"}
 execute unless score desire_lines gm4_earliest_version < desire_lines gm4_modules run scoreboard players operation desire_lines gm4_earliest_version = desire_lines gm4_modules

--- a/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
@@ -1,14 +1,16 @@
-scoreboard objectives add gm4_dl_random dummy
-scoreboard objectives add gm4_desire_lines minecraft.custom:minecraft.walk_one_cm
-scoreboard objectives add gm4_dl_sprint minecraft.custom:minecraft.sprint_one_cm
+scoreboard objectives add gm4_desire_lines dummy
 scoreboard objectives add gm4_dl_affcoarse dummy
+
+# constants
+scoreboard players set #base_probability gm4_desire_lines 1
+scoreboard players set #sneak_penality gm4_desire_lines -5
+scoreboard players set #sprint_penalty gm4_desire_lines 5
+scoreboard players set #impact_penalty gm4_desire_lines 30
 
 execute unless score desire_lines gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Desire Lines"}
 execute unless score desire_lines gm4_earliest_version < desire_lines gm4_modules run scoreboard players operation desire_lines gm4_earliest_version = desire_lines gm4_modules
 scoreboard players set desire_lines gm4_modules 1
 
 schedule function gm4_desire_lines:tick 1t
-
-
 
 #$moduleUpdateList

--- a/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
@@ -4,8 +4,8 @@
 # run from player
 
 # check blocks
-fill ~ ~-0.07 ~ ~ ~-0.07 ~ coarse_dirt replace dirt
-fill ~ ~-0.07 ~ ~ ~-0.07 ~ dirt replace grass_block
+fill ~ ~-0.06 ~ ~ ~-0.06 ~ coarse_dirt replace dirt
+fill ~ ~-0.06 ~ ~ ~-0.06 ~ dirt replace grass_block
 fill ~ ~ ~ ~ ~ ~ air replace snow[layers=1]
 fill ~ ~ ~ ~ ~ ~ snow[layers=1] replace snow[layers=2]
 

--- a/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
@@ -1,13 +1,18 @@
-#@s=@a[gamemode=!creative,gamemode=!spectator]
-#run by player.mcfunction
+# converts the block the player is stepping on
+# @s = survival player who initiated a desire lines block conversion
+# at @s
+# run from player
 
-#check blocks
-fill ~ ~-1 ~ ~ ~-1 ~ coarse_dirt replace dirt
-fill ~ ~-1 ~ ~ ~-1 ~ dirt replace grass_block
+# check blocks
+fill ~ ~-0.07 ~ ~ ~-0.07 ~ coarse_dirt replace dirt
+fill ~ ~-0.07 ~ ~ ~-0.07 ~ dirt replace grass_block
 fill ~ ~ ~ ~ ~ ~ air replace snow[layers=1]
 fill ~ ~ ~ ~ ~ ~ snow[layers=1] replace snow[layers=2]
+
+# remove foliage
 execute if block ~ ~ ~ #gm4:foliage unless block ~ ~ ~ moss_carpet run setblock ~ ~ ~ air destroy
-#advancement check
-execute if block ~ ~-1 ~ coarse_dirt run scoreboard players add @s gm4_dl_affcoarse 1
+
+# advancement check
+execute if block ~ ~-0.07 ~ coarse_dirt run scoreboard players add @s gm4_dl_affcoarse 1
 advancement grant @s[scores={gm4_dl_affcoarse=8000}] only gm4:desire_lines_8000
 advancement grant @s[scores={gm4_dl_affcoarse=10000}] only gm4:desire_lines_10000

--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -15,10 +15,8 @@ execute if predicate {"condition":"minecraft:entity_properties","entity":"this",
 execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"movement":{"vertical_speed":{"min":2}}}} run scoreboard players operation $probability gm4_desire_lines += #impact_penalty gm4_desire_lines
 function #gm4_desire_lines:expansion
 
-# slow falling prevents desire lines
 # | NOTE: if you are writing an expansion, do NOT 'set' $probability, as the order in which expansions are called is arbitrary.
 # | Instead, modify $probability by addition or subtraction. Do NOT subtract max_int, as that may cause over or underflows.
-execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players set $probability gm4_desire_lines 0
 
 # trigger block conversion
 execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} at @s run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -1,11 +1,17 @@
-#@s=@a[gamemode=!spectator,gamemode=!creative]
-#run by main
+# checks the player's current state to decide whether or not to trigger a block conversion
+# @s = any survival player
+# at unspecified
+# run from tick
 
-scoreboard players operation @s gm4_desire_lines += @s gm4_dl_sprint
-scoreboard players set @s gm4_dl_sprint 0
-execute if score @s gm4_desire_lines matches 30.. run scoreboard players set @s gm4_desire_lines 19
-execute if score @s gm4_desire_lines matches 1.. run scoreboard players remove @s gm4_desire_lines 20
+# terminate if player is not able to create a desire line
+execute unless predicate gm4_desire_lines:is_affected run return fail
 
+# determine trigger probability
+scoreboard players operation $probability gm4_desire_lines = #base_probability gm4_desire_lines
+execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"flags":{"is_sneaking":true}}} run scoreboard players operation $probability gm4_desire_lines += #sneak_penality gm4_desire_lines
+execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"flags":{"is_sprinting":true}}} run scoreboard players operation $probability gm4_desire_lines += #sprint_penalty gm4_desire_lines
+execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"movement":{"vertical_speed":{"min":2}}}} run scoreboard players operation $probability gm4_desire_lines += #impact_penalty gm4_desire_lines
 function #gm4_desire_lines:expansion
-execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players set @s gm4_desire_lines 0
-execute if score desire_lines gm4_dl_random matches ..2 if score @s gm4_desire_lines matches 1.. positioned ~ ~ ~ run function gm4_desire_lines:path
+
+# trigger block conversion
+execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} at @s run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -5,8 +5,6 @@
 
 # terminate if player is not able to create a desire line
 execute unless predicate gm4_desire_lines:is_affected run return fail
-# slow falling prevents desire lines
-execute if predicate gm4_desire_lines:has_slow_falling run return fail
 
 # determine trigger probability
 scoreboard players operation $probability gm4_desire_lines = #base_probability gm4_desire_lines

--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -5,6 +5,8 @@
 
 # terminate if player is not able to create a desire line
 execute unless predicate gm4_desire_lines:is_affected run return fail
+# slow falling prevents desire lines
+execute if predicate gm4_desire_lines:has_slow_falling run return fail
 
 # determine trigger probability
 scoreboard players operation $probability gm4_desire_lines = #base_probability gm4_desire_lines

--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -13,5 +13,10 @@ execute if predicate {"condition":"minecraft:entity_properties","entity":"this",
 execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"movement":{"vertical_speed":{"min":2}}}} run scoreboard players operation $probability gm4_desire_lines += #impact_penalty gm4_desire_lines
 function #gm4_desire_lines:expansion
 
+# slow falling prevents desire lines
+# | NOTE: if you are writing an expansion, do NOT 'set' $probability, as the order in which expansions are called is arbitrary.
+# | Instead, modify $probability by addition or subtraction. Do NOT subtract max_int, as that may cause over or underflows.
+execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players set $probability gm4_desire_lines 0
+
 # trigger block conversion
 execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} at @s run function gm4_desire_lines:path

--- a/gm4_desire_lines/data/gm4_desire_lines/function/tick.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/tick.mcfunction
@@ -1,6 +1,3 @@
-scoreboard players add desire_lines gm4_dl_random 27
-execute if score desire_lines gm4_dl_random matches 100.. run scoreboard players remove desire_lines gm4_dl_random 100
-
-execute as @a[gamemode=!adventure,gamemode=!spectator,gamemode=!creative] at @s run function gm4_desire_lines:player
+execute as @a[gamemode=survival] run function gm4_desire_lines:player
 
 schedule function gm4_desire_lines:tick 1t

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/has_slow_falling.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/has_slow_falling.json
@@ -1,9 +1,0 @@
-{
-  "condition": "minecraft:entity_properties",
-  "entity": "this",
-  "predicate": {
-    "effects": {
-      "slow_falling": {}
-    }
-  }
-}

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
@@ -11,6 +11,9 @@
         "flags": {
             "is_on_ground": true
         },
+        "effects": {
+            "minecraft:slow_falling": {}
+        },
         "movement": {
             "speed": {
                 "min": 0.01

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
@@ -1,23 +1,37 @@
 {
-    "condition": "minecraft:entity_properties",
-    "entity": "this",
-    "predicate": {
-        "type_specific": {
-            "type": "minecraft:player",
-            "gamemode": [
-                "survival"
-            ]
+    "condition": "minecraft:all_of",
+    "terms": [
+        {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+                "type_specific": {
+                    "type": "minecraft:player",
+                    "gamemode": [
+                        "survival"
+                    ]
+                },
+                "flags": {
+                    "is_on_ground": true
+                },
+                "movement": {
+                    "speed": {
+                        "min": 0.01
+                    }
+                }
+            }
         },
-        "flags": {
-            "is_on_ground": true
-        },
-        "effects": {
-            "minecraft:slow_falling": {}
-        },
-        "movement": {
-            "speed": {
-                "min": 0.01
+        {
+            "condition": "minecraft:inverted",
+            "term": {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                    "effects": {
+                        "minecraft:slow_falling": {}
+                    }
+                }
             }
         }
-    }
+    ]
 }

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/is_affected.json
@@ -1,0 +1,20 @@
+{
+    "condition": "minecraft:entity_properties",
+    "entity": "this",
+    "predicate": {
+        "type_specific": {
+            "type": "minecraft:player",
+            "gamemode": [
+                "survival"
+            ]
+        },
+        "flags": {
+            "is_on_ground": true
+        },
+        "movement": {
+            "speed": {
+                "min": 0.01
+            }
+        }
+    }
+}

--- a/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
@@ -11,7 +11,12 @@ scoreboard players operation @s gm4_vibro_shock = @s gm4_vibro_hurt
 scoreboard players operation @s gm4_vibro_shock += @s gm4_vibro_absorb
 schedule function gm4_vibro_shamir:shock/activate 1t
 
-# desire lines effect in a 5x5
-scoreboard players remove @s gm4_desire_lines 3
+# terminate if desire lines is not installed
+execute unless score gm4_desire_lines load.status matches 1.. run return 1
+
+# desire lines is installed, apply guarenteed effect (unless the player has some strong desire lines inhibiting item) in a 5x5
+# | the inverse sneak penalty is not enough to cicumvent desire lines in this case
+scoreboard players set $probability gm4_desire_lines 100
+scoreboard players operation $probability gm4_desire_lines -= #sneak_penality gm4_desire_lines
 function #gm4_desire_lines:expansion
-execute if score gm4_desire_lines load.status matches 1.. unless score @s gm4_desire_lines matches 0 run function gm4_vibro_shamir:desire_lines
+execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} run function gm4_vibro_shamir:desire_lines

--- a/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
@@ -19,5 +19,4 @@ execute unless score gm4_desire_lines load.status matches 1.. run return 1
 scoreboard players set $probability gm4_desire_lines 100
 scoreboard players operation $probability gm4_desire_lines -= #sneak_penality gm4_desire_lines
 function #gm4_desire_lines:expansion
-execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players remove $probability gm4_desire_lines 1000
 execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} run function gm4_vibro_shamir:desire_lines

--- a/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
+++ b/gm4_metallurgy/data/gm4_vibro_shamir/function/shockwave.mcfunction
@@ -19,4 +19,5 @@ execute unless score gm4_desire_lines load.status matches 1.. run return 1
 scoreboard players set $probability gm4_desire_lines 100
 scoreboard players operation $probability gm4_desire_lines -= #sneak_penality gm4_desire_lines
 function #gm4_desire_lines:expansion
+execute if predicate gm4_desire_lines:has_slow_falling run scoreboard players remove $probability gm4_desire_lines 1000
 execute if predicate {"condition":"minecraft:random_chance","chance":{"type":"minecraft:score","target":{"type":"minecraft:fixed","name":"$probability"},"score":"gm4_desire_lines","scale":0.01}} run function gm4_vibro_shamir:desire_lines


### PR DESCRIPTION
Desire Lines hadn't been touched since the days when scoreboard pseudo-randomizers were an artform. This PR updates Desire Lines to be predicate-based instead, making its randomization easier to understand.

_Desire Lines will not behave exactly the same as they did before the update._ However, it should be close enough to be considered a quality-only update.

## Changes
- Removed scoreboard pseudo-randomizer in favor of a `random_chance` predicate
- Set base Desire Lines probability to 1%
- Desire Lines may only be formed if the player is considered to be on the ground
- Sprinting now increases the Desire Lines probability (+5%)
- Vertical momentum now harshly increases the Desire Lines probability (+30%)
- Sneaking now slighlty inhibits Desire Lines (-5%)

## Fixes
- Desire Lines no longer changes blocks below slabs, trapdoors, or carpets