### PR TITLE
display guidebook module on website

### DIFF
--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -18,7 +18,6 @@ pipeline:
 
 meta:
   gm4:
-    minecraft: []
     versioning:
       required:
         lib_forceload: 1.4.0


### PR DESCRIPTION
The guidebook has been hidden on the website for version 1.21. This PR fixes that