### PR TITLE
1.21.4 Resource Pack Support

### DIFF
--- a/beet-dev.yaml
+++ b/beet-dev.yaml
@@ -36,7 +36,7 @@ pipeline:
     directory: resource_pack
     pipeline:
       - resource_pack.dev_description
-  - gm4.plugins.resource_pack.pad_model_overrides
+  - gm4.plugins.resource_pack.pad_item_def_range_dispatch
   - gm4.plugins.resource_pack.link_resource_pack
   - gm4.plugins.output.resource_pack
   - gm4.plugins.resource_pack.dump_registry

--- a/beet-release.yaml
+++ b/beet-release.yaml
@@ -82,7 +82,7 @@ pipeline:
       - gm4.plugins.output.release_resource_pack
       - gm4.plugins.write_mcmeta
       - gm4.plugins.manifest.update_patch
-      - gm4.plugins.resource_pack.pad_model_overrides
+      - gm4.plugins.resource_pack.pad_item_def_range_dispatch
     meta:
       pack_scan: resource_pack
 

--- a/docs/resource-pack-management.md
+++ b/docs/resource-pack-management.md
@@ -16,6 +16,7 @@ This document explains Gamemode 4's Resource Pack management tools, which use cu
     * [Extending `TemplateOptions`](#extending-templateoptions)
     * [Extending `TransformOptions`](#extending-transformoptions)
     * [Extending `ContainerGuiOptions`](#extending-containerguioptions)
+    * [Extending `ItemModelOptions`](#extending-itemmodeloptions)
 
 ## Getting Started
 Just like how data pack resources are stored in a `data` directory, resource pack assets are stored in an `assets` directory for each module, and follow the same structure as an ordinary minecraft resource pack. 
@@ -166,27 +167,16 @@ model:
   apple: item/my_model_apple
   potato: item/my_model_potato
 ```
-More complex model predicates for items with multiple vanilla models (e.g. elytra & broken elytra, clock ect) can be specified here as a list of predicates, following the same syntax as model files e.g.
+More complex model styles, like for items with multiple vanilla models (e.g. elytra & broken elytra, clock ect) are handled through a special-case syntax. Currently only broken elytra are supported, so packs utlizing conditions in item model definitions will need to provide handlers.
 ```yaml
+item: elytra
 model:
-  - predicate: {broken: 0}
-    model: item/elytra/captains_wings
-  - predicate: {broken: 1}
-    model: item/elytra/broken_captains_wings
+  type: condition_broken
+  unbroken: item/elytra/captains_wings
+  broken: item/elytra/broken_captains_wings
 ```
-This list of predicates may also be mapped to a specific item as above.
 
-```yaml
-item: [apple, elytra]
-model:
-  apple: my_model_apple
-  elytra:
-    - predicate: {broken: 0}
-      model: item/elytra/captains_wings
-    - predicate: {broken: 1}
-      model: item/elytra/broken_captains_wings
-```
-Items who have multiple vanilla models, like clocks, who do not have the manual predicates specified in model will have the same provided model file applied to all variants.
+Items who have multiple vanilla models, like clocks, who do not utilize special-case providers in the model config will have the same provided model file applied to all variants.
 
 - `template` (optional), a model-file generating template to apply. Accepts a string name of a template, or a compound containing template configuration values. Defaults to `custom`, which generates no Model files. See [here](#model-templates) for details on available templates.
 - `transforms` (optional), a list of model transforms to apply. Accepts a compound of configuration data. See [here](#model-transforms) for details on available transforms.
@@ -267,3 +257,9 @@ Additionally, there are two extendable subclasses already available for containe
 
 #### Methods
 - `process(self, config: GuiFont, counter_cache: Cache) -> tuple[str, list[dict[str, Any]]]`: Requisitions unique characters and returns the translation value (usually made of these characters), and a list of font providers, which usually reference `config.texture`.
+
+### Extending ItemModelOptions
+Individual modules may add additional handlers for special-case item model definitions by extending `ItemModelOptions` in a beet plugin. This subclass defines the additional config fields and a method that generates the model compound used in the item model definition. 
+
+#### Methods
+- 'generate_json(self) -> dict[str,Any]`: Returns the model object used in the item model defintion. e.g. ```{"type": "minecraft:condition"...}```

--- a/gm4/plugins/autoload.py
+++ b/gm4/plugins/autoload.py
@@ -9,5 +9,6 @@ def beet_default(ctx: Context):
     ctx.require(
         "beet.contrib.default",
         "beet.contrib.model_merging",
+        "gm4.plugins.resource_pack.merge_policy",
         "gm4_metallurgy.shamir_model_template.merge_policy"
     )

--- a/gm4/plugins/backwards.py
+++ b/gm4/plugins/backwards.py
@@ -28,14 +28,9 @@ def resource_pack(ctx: Context):
 
   # use a draft generator to ensure merge rules are followed
   with ctx.generate.draft() as draft:
-    overlay = draft.assets.overlays[f"backport_57"]
-    overlay.supported_formats = { "min_inclusive": 0, "max_inclusive": 57 }
+    overlay = draft.assets.overlays[f"backport_42"]
+    overlay.supported_formats = { "min_inclusive": 0, "max_inclusive": 42 }
     rp.generate_model_overrides_1_21_3(overlay)
-
-  # TODO NOTE
-  # call the old RP code from here, for clarity and sense - requires handling for 
-  # sub packs AKA libraries. Wrap 1.21.3- rp code in a generate.draft to ensure proper
-  # merge rules apply. Note outdated methods of rp-plugin.
 
 
 FURNACE_RENAMES = {

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -30,7 +30,7 @@ from beet import (
 )
 from beet.contrib.link import LinkManager
 from beet.contrib.optifine import OptifineProperties
-from beet.contrib.vanilla import Vanilla
+from beet.contrib.vanilla import Vanilla, ClientJar
 from beet.core.utils import format_validation_error
 from mecha import (
     AstChildren,
@@ -354,6 +354,11 @@ def beet_default(ctx: Context):
 
     logging.getLogger("beet.contrib.babelbox").addFilter(block_incomplete_translation)
     logging.getLogger("mecha").addFilter(limit_mecha_diagnostics)
+
+    # attach context to template classes
+    VanillaTemplate.vanilla = Vanilla(ctx)
+    VanillaTemplate.vanilla.minecraft_version = '1.21.4'
+    VanillaTemplate.vanilla_jar = VanillaTemplate.vanilla.mount("assets/minecraft/items")
 
     yield
     tl.warn_unused_translations()
@@ -993,6 +998,8 @@ class HandheldTemplate(TemplateOptions):
 
 class VanillaTemplate(TemplateOptions):
     name = "vanilla"
+    vanilla: ClassVar[Vanilla] # mounted to by beet plugin since it requires context access
+    vanilla_jar: ClassVar[ClientJar]
 
     def process(self, config: ModelData, models_container: NamespaceProxy[Model]):
         model_names = config.model.entries()
@@ -1003,8 +1010,9 @@ class VanillaTemplate(TemplateOptions):
 
         ret_list: list[Model] = []
         for item, model_name in zip(config.item.entries(), model_names):
+            vanilla_model_path: str = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {}).get("model", "") # type: ignore ; json access is string
             m = models_container[model_name] = Model({      # type: ignore ; list is checked above to be all strings
-                "parent": f"minecraft:item/{item}"
+                "parent": vanilla_model_path
             })
             ret_list.append(m)
         config.model = MapOption(__root__=dict(zip(config.item.entries(), model_names)))

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -1010,7 +1010,11 @@ class VanillaTemplate(TemplateOptions):
 
         ret_list: list[Model] = []
         for item, model_name in zip(config.item.entries(), model_names):
-            vanilla_model_path: str = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {}).get("model", "") # type: ignore ; json access is string
+            model_compound = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {})
+            if model_compound["type"] == "minecraft:special": # uses some special handling
+                vanilla_model_path: str = model_compound["base"] # covers player_head use case. Others may not be handled properly yet.
+            else:
+                vanilla_model_path: str = model_compound.get("model", "") # type: ignore ; json access is string
             m = models_container[model_name] = Model({      # type: ignore ; list is checked above to be all strings
                 "parent": vanilla_model_path
             })

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -384,13 +384,29 @@ def dump_registry(ctx: Context):
     JsonFile(registry).dump(origin="", path="gm4/modeldata_registry.json")
     ctx.cache["modeldata_registry"].delete()
 
-def pad_model_overrides(ctx: Context):
+def pad_item_def_range_dispatch(ctx: Context):
+    """Adds entries to vanilla item definitions range_dispach, filling in gaps between CMD values"""
+    pad_model_overrides_1_21_3(ctx, ctx.assets.overlays["backport_57"]) # call legacy pad function
+
+    for item_def in ctx.assets["minecraft"].item_models.values():
+        vanilla_item_def = item_def.data["model"]["fallback"]
+        entries: list[Any] = item_def.data["model"]["entries"]
+        prior_cmd = 1e8
+        for i, entry in reversed(list(enumerate(entries))):
+            if prior_cmd-(prior_cmd:=entry["threshold"]) > 1: # theres a gap to fill
+                entries.insert(i+1, {
+                    "threshold": prior_cmd+1,
+                    "model": vanilla_item_def
+                })
+
+# NOTE legacy code called by plugins.backwards. Remove in 1.22 update
+def pad_model_overrides_1_21_3(ctx: Context, assets: ResourcePack):
     """Adds overrides for the vanilla model, filling in gaps between CMD values"""
     vanilla = ctx.inject(Vanilla)
     vanilla.minecraft_version = '1.21.3'
     vanilla_models_jar = vanilla.mount("assets/minecraft/models/item")
 
-    for name, model in ctx.assets["minecraft"].models.items():
+    for name, model in assets["minecraft"].models.items():
         vanilla_overrides = [{"predicate":{},"model": f"minecraft:{name}"}] + vanilla_models_jar.assets["minecraft"].models[name].data.get("overrides", [])
         overrides: list[Any] = model.data["overrides"]
         prior_cmd = 1e8
@@ -513,7 +529,8 @@ class GM4ResourcePack(MutatingReducer, InvokeOnJsonNbt):
 
 
 
-    def generate_model_overrides(self):
+    # NOTE legacy code called by plugins.backwards. Remove in 1.22 update
+    def generate_model_overrides_1_21_3(self, pack: ResourcePack):
         """Generates item model overrides in the 'minecraft' namespace, adding predicates for custom_model_data"""
         vanilla = self.ctx.inject(Vanilla)
         vanilla.minecraft_version = '1.21.3'

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -359,6 +359,9 @@ def beet_default(ctx: Context):
     VanillaTemplate.vanilla = Vanilla(ctx)
     VanillaTemplate.vanilla.minecraft_version = '1.21.4'
     VanillaTemplate.vanilla_jar = VanillaTemplate.vanilla.mount("assets/minecraft/items")
+    AdvancementIconTemplate.vanilla = Vanilla(ctx)
+    AdvancementIconTemplate.vanilla.minecraft_version = '1.21.4'
+    AdvancementIconTemplate.vanilla_jar = AdvancementIconTemplate.vanilla.mount("assets/minecraft/items")
 
     yield
     tl.warn_unused_translations()
@@ -1044,12 +1047,16 @@ class BlockTemplate(TemplateOptions):
 class AdvancementIconTemplate(TemplateOptions):
     name = "advancement"
     forward: Optional[str]
+    vanilla: ClassVar[Vanilla] # mounted to by beet plugin since it requires context access
+    vanilla_jar: ClassVar[ClientJar]
 
     # NOTE since advancements are all in the gm4 namespace, so are these models. This template ignores the 'model' field of ModelData
     def process(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
         advancement_name = config.reference.split("/")[-1]
         if not self.forward:
-            self.forward = f"minecraft:item/{config.item.entries()[0]}"
+            item = config.item.entries()[0]
+            self.forward = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {}).get("model", "") # type: ignore ; json access is string
+
         m = models_container[f"gm4:gui/advancements/{advancement_name}"] = Model({
             "parent": self.forward
         })

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -410,7 +410,7 @@ def dump_registry(ctx: Context):
 
 def pad_item_def_range_dispatch(ctx: Context):
     """Adds entries to vanilla item definitions range_dispach, filling in gaps between CMD values"""
-    pad_model_overrides_1_21_3(ctx, ctx.assets.overlays["backport_57"]) # call legacy pad function
+    pad_model_overrides_1_21_3(ctx, ctx.assets.overlays["backport_42"]) # call legacy pad function
 
     for item_def in ctx.assets["minecraft"].item_models.values():
         vanilla_item_def = item_def.data["model"]["fallback"]
@@ -537,8 +537,6 @@ class GM4ResourcePack(MutatingReducer, InvokeOnJsonNbt):
 
             for model in models:
                 m = model.model[item_id] # model string, or predicate settings, for this particular item id
-                # NOTE only end fishing elytra utlize predicate specification here.
-                # TODO handle predicate format?
 
                 if isinstance(m, str):
                     model_json = {

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -343,7 +343,6 @@ def build(ctx: Context):
     rp.update_modeldata_registry()
     rp.generate_model_files()
     rp.process_optifine()
-    # rp.generate_model_overrides()
     rp.generate_item_definitions()
 
     if not ctx.assets.extra.get("pack.png") and ctx.data.extra.get("pack.png"):
@@ -548,7 +547,7 @@ class GM4ResourcePack(MutatingReducer, InvokeOnJsonNbt):
                         } | pred.get("predicate", {}),
                         "model": pred["model"] if pred.get("user_defined") else m # type:ignore , user-defined model predicates use their own model reference. m is a string in all other cases
                     })
-            self.ctx.assets.models[f"minecraft:item/{item_id}"] = Model(vanilla_model)
+            pack.models[f"minecraft:item/{item_id}"] = Model(vanilla_model)
 
     def retrieve_index(self, reference: str) -> tuple[int, KeyError|None]:
         """retrieves the CMD value for the given reference"""

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -432,7 +432,7 @@ def pad_model_overrides_1_21_3(ctx: Context, assets: ResourcePack):
 
     for name, model in assets["minecraft"].models.items():
         vanilla_overrides = [{"predicate":{},"model": f"minecraft:{name}"}] + vanilla_models_jar.assets["minecraft"].models[name].data.get("overrides", [])
-        overrides: list[Any] = model.data["overrides"]
+        overrides: list[Any] = model.data.get("overrides", [])
         prior_cmd = 1e8
         for i, override in reversed(list(enumerate(overrides))):
             if "custom_model_data" in (pred:=override.get("predicate")):
@@ -1125,7 +1125,7 @@ class DropperContainerGui(CenteredContainerGui, ContainerGuiOptions):
 
 class ConditionBroken(ItemModelOptions):
     """Generator for item model definitions using the broken boolean condition (ie. Elytra textures variants)"""
-    # NOTE this format could be further generalized, but is not yet due to Elytra being the only current case required to implement.
+    # NOTE this format could be further generalized, but is not yet due to Elytra (and shamirs) being the only current case required to implement.
     type = "condition_broken"
     unbroken: str
     broken: str

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -575,14 +575,21 @@ class GM4ResourcePack(MutatingReducer, InvokeOnJsonNbt):
             for model in models:
                 m = model.model[item_id] # model string, or predicate settings, for this particular item id
 
+                has_manual_predicates = False
                 if isinstance(m, ItemModelOptions):
                     # This item uses a special-case logic, rebuilt for the 1.21.4 resource pack item-model-definitions.
                     # This model file will be manually provided and hardcoded (only case is end fishing elytra)
-                    break
 
-                # setup overrides to add CMD to
-                merge_overrides = unchanged_vanilla_overrides.copy() # get vanilla overrides
-                merge_overrides.append({}) # add an empty predicate to add CMD onto, without all other case checks
+                    # Metallurgy shamirs still utilize this function for backwards compatability generation via _complex_bypass
+                    if m.type == "_complex_bypass":
+                        merge_overrides = [o|{"user_defined": True} for o in m.payload_1_21_3]
+                        has_manual_predicates = True
+                    else:
+                        break
+                
+                if not has_manual_predicates:
+                    merge_overrides = unchanged_vanilla_overrides.copy() # get vanilla overrides
+                    merge_overrides.append({}) # add an empty predicate to add CMD onto, without all other case checks
 
                 for pred in merge_overrides:
                     if not pred.get("model") and not isinstance(m, str): # type:ignore ; new ItemModelOptions structure does not store required predicate information anymore. 

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -992,9 +992,11 @@ class VanillaTemplate(TemplateOptions):
             ret_list.append(m)
             model_def_map[item] = {
                 "type": "minecraft:special" if special_model else "minecraft:model",
-                "model": model_compound["model"] if special_model else model_name
+                "model": model_compound["model"] if special_model else model_name,
             } | (
-                {"tints": t if (t:=model_compound.get("tints")) else {}}
+                {"base": model_name} if special_model else {}
+            ) | (
+                {"tints": t} if (t:=model_compound.get("tints")) else {}
             )
         self._item_def_map.update(model_def_map)
         return ret_list
@@ -1015,28 +1017,32 @@ class AdvancementIconTemplate(VanillaTemplate, TemplateOptions): # TODO make thi
         if not self.forward:
             # then we use the vanilla item's model and settings - inheriting from VanillaTemplate for this
             item = config.item.entries()[0]
-            config_copy = config.copy(update={"model": MapOption(__root__={config.item.entries()[0]: f"gm4:gui/advancements/{advancement_name}"})})
-            TemplateOptions.create_models(self, config_copy, models_container)
-
-        m = models_container[f"gm4:gui/advancements/{advancement_name}"] = Model({
-            "parent": self.forward
-        })
-        # config.model = MapOption(__root__={config.item.entries()[0]: f"gm4:gui/advancements/{advancement_name}"})
+            config_copy = config.copy(update={"model": MapOption(__root__={config.item.entries()[0]: f"gm4:gui/advancement/{advancement_name}"})})
+            m = VanillaTemplate.create_models(self, config_copy, models_container)[0]
+        
+        else:
+            m = models_container[f"gm4:gui/advancement/{advancement_name}"] = Model({
+                "parent": self.forward
+            })
+        config.model = MapOption(__root__={config.item.entries()[0]: f"gm4:gui/advancement/{advancement_name}"})
         return [m]
     
     def get_item_def_entry(self, config: ModelData, item: str):
-        if self.tints:
-            return {
-                "type": "model",
-                "model": config.model.entries()[0],
-                "tints": [
-                    {
-                        "type": "minecraft:constant",
-                        "value": tint
-                    }
-                    for tint in self.tints.entries()
-                ]
-            }
+        if not self.forward: # use item def from VanillaTemplate
+            return VanillaTemplate.get_item_def_entry(self, config, item)
+        else:
+            if self.tints:
+                return {
+                    "type": "model",
+                    "model": config.model.entries()[0],
+                    "tints": [
+                        {
+                            "type": "minecraft:constant",
+                            "value": tint
+                        }
+                        for tint in self.tints.entries()
+                    ]
+                }
         return None
     
     def add_namespace(self, namespace: str):

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -334,9 +334,6 @@ def beet_default(ctx: Context):
     VanillaTemplate.vanilla = Vanilla(ctx)
     VanillaTemplate.vanilla.minecraft_version = '1.21.4'
     VanillaTemplate.vanilla_jar = VanillaTemplate.vanilla.mount("assets/minecraft/items")
-    AdvancementIconTemplate.vanilla = Vanilla(ctx)
-    AdvancementIconTemplate.vanilla.minecraft_version = '1.21.4'
-    AdvancementIconTemplate.vanilla_jar = AdvancementIconTemplate.vanilla.mount("assets/minecraft/items")
 
     yield
     tl.warn_unused_translations()
@@ -975,86 +972,40 @@ class VanillaTemplate(TemplateOptions):
 
     def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]):
         model_names = config.model.entries()
-        if any([isinstance(m, list) for m in model_names]):
-            raise InvalidOptions("gm4.model_data", f"{config.reference}; Template 'vanilla' does not support predicate override 'model' fields.")
         if len(set(model_names)) == 1 and len(config.item.entries()) > 1:
             model_names = [f"{model_names[0]}_{item}" for item in config.item.entries()] # if only one model name given, make one model per item id
         
-        model_def_entries = [
-            {
-                "type": "minecraft:model",
-                "model": m
-            }
-        for m in model_names]
+        model_def_map: dict[str,JsonType] = {}
 
         ret_list: list[Model] = []
         for item, model_name in zip(config.item.entries(), model_names):
             model_compound = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {})
             if model_compound["type"] == "minecraft:special": # uses some special handling
                 vanilla_model_path: str = model_compound["base"] # covers player_head use case. Others may not be handled properly yet.
+                special_model = True
             else:
                 vanilla_model_path: str = model_compound.get("model", "")
+                special_model = False
             m = models_container[model_name] = Model({
                 "parent": vanilla_model_path
             })
             ret_list.append(m)
-        self._item_def_map.update(dict(zip(config.item.entries(), model_def_entries)))
+            model_def_map[item] = {
+                "type": "minecraft:special" if special_model else "minecraft:model",
+                "model": model_compound["model"] if special_model else model_name
+            } | (
+                {"tints": t if (t:=model_compound.get("tints")) else {}}
+            )
+        self._item_def_map.update(model_def_map)
         return ret_list
     
     def get_item_def_entry(self, config: ModelData, item: str):
-        return 
+        return self._item_def_map.get(item)
 
-class BlockTemplate(TemplateOptions):
-    name = "block"
-    texture_map = ["top", "bottom", "front", "side"]
-
-    def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]):
-        model_name = ensure_single_model_config(self.name, config)
-        m = models_container[model_name] = Model({
-            "parent": "minecraft:block/cube",
-            "textures": {
-                "down":  config.textures['bottom'],
-                "up":    config.textures['top'],
-                "north": config.textures['front'],
-                "south": config.textures['side'],
-                "west":  config.textures['side'],
-                "east":  config.textures['side']
-            }
-        })
-        return [m]
-
-class ConditionTemplate(BlankTemplate, TemplateOptions):
-    """Custom models using boolean condition variants (ie. broken/repaired elytra, cast/uncast fishing rods...)"""
-    name = "condition"
-    property: str
-    on_true: str
-    on_false: str
-
-    def get_item_def_entry(self, config: ModelData, item: str) -> JsonType:
-        return {
-            "type": "minecraft:condition",
-            "property": self.property,
-            "on_false": {
-                "type": "minecraft:model",
-                "model": self.on_false
-            },
-            "on_true": {
-                "type": "minecraft:model",
-                "model": self.on_true
-            }
-        }
-    
-    def add_namespace(self, namespace: str):
-        return self.dict() | {"on_true": add_namespace(self.on_true, namespace),
-                              "on_false": add_namespace(self.on_false, namespace)}
-
-
-class AdvancementIconTemplate(TemplateOptions):
+class AdvancementIconTemplate(VanillaTemplate, TemplateOptions): # TODO make this inheritance work properly. Treat as single-vanilla forward or create new where needed
     name = "advancement"
     forward: Optional[str]
     tints: Optional[ListOption[int|tuple[float,float,float]]] # optional constant tints to apply to the item model
-    vanilla: ClassVar[Vanilla] # mounted to by beet plugin since it requires context access
-    vanilla_jar: ClassVar[ClientJar]
 
     # NOTE since advancements are all in the gm4 namespace, so are these models. This template ignores the 'model' field of ModelData
     def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
@@ -1086,6 +1037,50 @@ class AdvancementIconTemplate(TemplateOptions):
     
     def add_namespace(self, namespace: str):
         return self.dict() | ({"forward": add_namespace(self.forward, namespace)} if self.forward else {})
+
+class BlockTemplate(TemplateOptions):
+    name = "block"
+    texture_map = ["top", "bottom", "front", "side"]
+
+    def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]):
+        model_name = ensure_single_model_config(self.name, config)
+        m = models_container[model_name] = Model({
+            "parent": "minecraft:block/cube",
+            "textures": {
+                "down":  config.textures['bottom'],
+                "up":    config.textures['top'],
+                "north": config.textures['front'],
+                "south": config.textures['side'],
+                "west":  config.textures['side'],
+                "east":  config.textures['side']
+            }
+        })
+        return [m]
+    
+class ConditionTemplate(BlankTemplate, TemplateOptions):
+    """Custom models using boolean condition variants (ie. broken/repaired elytra, cast/uncast fishing rods...)"""
+    name = "condition"
+    property: str
+    on_true: str
+    on_false: str
+
+    def get_item_def_entry(self, config: ModelData, item: str) -> JsonType:
+        return {
+            "type": "minecraft:condition",
+            "property": self.property,
+            "on_false": {
+                "type": "minecraft:model",
+                "model": self.on_false
+            },
+            "on_true": {
+                "type": "minecraft:model",
+                "model": self.on_true
+            }
+        }
+    
+    def add_namespace(self, namespace: str):
+        return self.dict() | {"on_true": add_namespace(self.on_true, namespace),
+                              "on_false": add_namespace(self.on_false, namespace)}
 
 class ItemDisplayModel(TransformOptions):
     """Calculates the model transform for an item_display entity, located at the specified origin, facing south, for the model to align with the block-grid"""

--- a/gm4/plugins/resource_pack.py
+++ b/gm4/plugins/resource_pack.py
@@ -559,6 +559,10 @@ class GM4ResourcePack(MutatingReducer, InvokeOnJsonNbt):
             for model in models:
                 m = model.model[item_id] # model string, or predicate settings, for this particular item id
 
+                if model.reference in ("gm4_end_fishing:item/captains_wings", "gm4_end_fishing:item/ravaged_wings"):
+                    # hardcode a skip for this entry, used to prevent conflicts between hardcoded 1.21.3 files and the new 1.21.4 format.
+                    continue
+
                 has_manual_predicates = False
                 if model.template.name == "shamir" and item_id in model.template._model_overrides_1_21_3: # type: ignore
                     # This item uses a special-case logic, rebuilt for the 1.21.4 resource pack item-model-definitions.
@@ -980,6 +984,9 @@ class VanillaTemplate(TemplateOptions):
         ret_list: list[Model] = []
         for item, model_name in zip(config.item.entries(), model_names):
             model_compound = self.vanilla_jar.assets.item_models[add_namespace(item, "minecraft")].data.get("model", {})
+            if model_compound["type"] == "minecraft:select": # template off the fallback model, (e.g. non-festive chest)
+                model_compound = model_compound["fallback"]
+
             if model_compound["type"] == "minecraft:special": # uses some special handling
                 vanilla_model_path: str = model_compound["base"] # covers player_head use case. Others may not be handled properly yet.
                 special_model = True

--- a/gm4_better_armour_stands/beet.yaml
+++ b/gm4_better_armour_stands/beet.yaml
@@ -38,6 +38,4 @@ meta:
     model_data:
       - item: armor_stand
         reference: gui/advancement/better_armour_stands
-        template:
-          name: advancement
-          forward: minecraft:item/armor_stand
+        template: advancement

--- a/gm4_better_fire/beet.yaml
+++ b/gm4_better_fire/beet.yaml
@@ -39,6 +39,4 @@ meta:
         template: generated
       - item: bow
         reference: gui/advancement/better_fire
-        template:
-          name: advancement
-          forward: minecraft:item/bow
+        template: advancement

--- a/gm4_end_fishing/backport_42/assets/minecraft/models/item/elytra.json
+++ b/gm4_end_fishing/backport_42/assets/minecraft/models/item/elytra.json
@@ -25,19 +25,6 @@
         },
         {
             "predicate": {
-                "custom_model_data": 3420002
-            },
-            "model": "minecraft:item/elytra"
-        },
-        {
-            "predicate": {
-                "broken": 1,
-                "custom_model_data": 3420002
-            },
-            "model": "item/broken_elytra"
-        },
-        {
-            "predicate": {
                 "custom_model_data": 3420010,
                 "broken": 0
             },
@@ -63,97 +50,6 @@
                 "broken": 1
             },
             "model": "gm4_end_fishing:item/elytra/broken_ravaged_wings"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420012
-            },
-            "model": "minecraft:item/elytra"
-        },
-        {
-            "predicate": {
-                "broken": 1,
-                "custom_model_data": 3420012
-            },
-            "model": "item/broken_elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420113
-            },
-            "model": "gm4_metallurgy:shamir/moneo/elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420113,
-                "broken": 1
-            },
-            "model": "gm4_metallurgy:shamir/moneo/broken_elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420114
-            },
-            "model": "minecraft:item/elytra"
-        },
-        {
-            "predicate": {
-                "broken": 1,
-                "custom_model_data": 3420114
-            },
-            "model": "item/broken_elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420124
-            },
-            "model": "gm4_animi_shamir:shamir/animi/elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420124,
-                "broken": 1
-            },
-            "model": "gm4_animi_shamir:shamir/animi/broken_elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420125
-            },
-            "model": "minecraft:item/elytra"
-        },
-        {
-            "predicate": {
-                "broken": 1,
-                "custom_model_data": 3420125
-            },
-            "model": "item/broken_elytra"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420200
-            },
-            "model": "gm4:gui/advancements/orb_of_ankou_soaring_pneuma"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420200,
-                "broken": 1
-            },
-            "model": "gm4:gui/advancements/orb_of_ankou_soaring_pneuma"
-        },
-        {
-            "predicate": {
-                "custom_model_data": 3420201
-            },
-            "model": "minecraft:item/elytra"
-        },
-        {
-            "predicate": {
-                "broken": 1,
-                "custom_model_data": 3420201
-            },
-            "model": "item/broken_elytra"
         }
     ]
 }

--- a/gm4_end_fishing/backport_42/assets/minecraft/models/item/elytra.json
+++ b/gm4_end_fishing/backport_42/assets/minecraft/models/item/elytra.json
@@ -1,0 +1,159 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/elytra"
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "broken": 1
+            },
+            "model": "minecraft:item/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420001
+            },
+            "model": "gm4:gui/advancements/end_fishing_phantom"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420001,
+                "broken": 1
+            },
+            "model": "gm4:gui/advancements/end_fishing_phantom"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420002
+            },
+            "model": "minecraft:item/elytra"
+        },
+        {
+            "predicate": {
+                "broken": 1,
+                "custom_model_data": 3420002
+            },
+            "model": "item/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420010,
+                "broken": 0
+            },
+            "model": "gm4_end_fishing:item/elytra/captains_wings"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420010,
+                "broken": 1
+            },
+            "model": "gm4_end_fishing:item/elytra/broken_captains_wings"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420011,
+                "broken": 0
+            },
+            "model": "gm4_end_fishing:item/elytra/ravaged_wings"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420011,
+                "broken": 1
+            },
+            "model": "gm4_end_fishing:item/elytra/broken_ravaged_wings"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420012
+            },
+            "model": "minecraft:item/elytra"
+        },
+        {
+            "predicate": {
+                "broken": 1,
+                "custom_model_data": 3420012
+            },
+            "model": "item/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420113
+            },
+            "model": "gm4_metallurgy:shamir/moneo/elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420113,
+                "broken": 1
+            },
+            "model": "gm4_metallurgy:shamir/moneo/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420114
+            },
+            "model": "minecraft:item/elytra"
+        },
+        {
+            "predicate": {
+                "broken": 1,
+                "custom_model_data": 3420114
+            },
+            "model": "item/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420124
+            },
+            "model": "gm4_animi_shamir:shamir/animi/elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420124,
+                "broken": 1
+            },
+            "model": "gm4_animi_shamir:shamir/animi/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420125
+            },
+            "model": "minecraft:item/elytra"
+        },
+        {
+            "predicate": {
+                "broken": 1,
+                "custom_model_data": 3420125
+            },
+            "model": "item/broken_elytra"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420200
+            },
+            "model": "gm4:gui/advancements/orb_of_ankou_soaring_pneuma"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420200,
+                "broken": 1
+            },
+            "model": "gm4:gui/advancements/orb_of_ankou_soaring_pneuma"
+        },
+        {
+            "predicate": {
+                "custom_model_data": 3420201
+            },
+            "model": "minecraft:item/elytra"
+        },
+        {
+            "predicate": {
+                "broken": 1,
+                "custom_model_data": 3420201
+            },
+            "model": "item/broken_elytra"
+        }
+    ]
+}

--- a/gm4_end_fishing/beet.yaml
+++ b/gm4_end_fishing/beet.yaml
@@ -7,6 +7,11 @@ data_pack:
 
 resource_pack:
   load: .
+  overlays:
+    - formats:
+        min_inclusive: 0
+        max_inclusive: 42
+      directory: backport_42
 
 pipeline:
   - register_model_data

--- a/gm4_end_fishing/beet.yaml
+++ b/gm4_end_fishing/beet.yaml
@@ -31,16 +31,18 @@ meta:
         reference: item/enderpuff
       - item: elytra
         reference: item/captains_wings
-        model:
-          type: condition_broken
-          unbroken: item/elytra/captains_wings
-          broken: item/elytra/broken_captains_wings
+        template:
+          name: condition
+          property: minecraft:broken
+          on_true: item/elytra/broken_captains_wings
+          on_false: item/elytra/captains_wings
       - item: elytra
         reference: item/ravaged_wings
-        model:
-          type: condition_broken
-          unbroken: item/elytra/ravaged_wings
-          broken: item/elytra/broken_ravaged_wings
+        template:
+          name: condition
+          property: minecraft:broken
+          on_true: item/elytra/broken_ravaged_wings
+          on_false: item/elytra/ravaged_wings
       - item: fishing_rod
         reference: gui/advancement/end_fishing
         template: advancement

--- a/gm4_end_fishing/beet.yaml
+++ b/gm4_end_fishing/beet.yaml
@@ -27,17 +27,15 @@ meta:
       - item: elytra
         reference: item/captains_wings
         model:
-          - predicate: {broken: 0}
-            model: item/elytra/captains_wings
-          - predicate: {broken: 1}
-            model: item/elytra/broken_captains_wings
+          type: condition_broken
+          unbroken: item/elytra/captains_wings
+          broken: item/elytra/broken_captains_wings
       - item: elytra
         reference: item/ravaged_wings
         model:
-          - predicate: {broken: 0}
-            model: item/elytra/ravaged_wings
-          - predicate: {broken: 1}
-            model: item/elytra/broken_ravaged_wings
+          type: condition_broken
+          unbroken: item/elytra/ravaged_wings
+          broken: item/elytra/broken_ravaged_wings
       - item: fishing_rod
         reference: gui/advancement/end_fishing
         template: advancement

--- a/gm4_guidebook/backport_42/assets/gm4/font/vanilla_items.json
+++ b/gm4_guidebook/backport_42/assets/gm4/font/vanilla_items.json
@@ -398,7 +398,7 @@
         },
         {
             "type": "bitmap",
-            "file": "minecraft:item/elytra_broken.png",
+            "file": "minecraft:item/broken_elytra.png",
             "ascent": -32768,
             "height": -16,
             "chars": [
@@ -4402,7 +4402,7 @@
         },
         {
             "type": "bitmap",
-            "file": "minecraft:item/elytra_broken.png",
+            "file": "minecraft:item/broken_elytra.png",
             "ascent": 8,
             "height": 16,
             "chars": [

--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -7,6 +7,11 @@ data_pack:
 
 resource_pack:
   load: .
+  overlays:
+    - formats:
+        min_inclusive: 0
+        max_inclusive: 42
+      directory: backport_42
   
 require:
   - bolt

--- a/gm4_metallurgy/shamir_model_template.py
+++ b/gm4_metallurgy/shamir_model_template.py
@@ -1,7 +1,7 @@
 from beet import Context, Model, NamespaceProxy, ListOption, ResourcePack
 from beet.contrib.vanilla import Vanilla, ClientJar
 from beet.contrib.optifine import OptifineProperties
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, Optional
 from itertools import product, chain, count
 import re
 import logging
@@ -66,6 +66,7 @@ class ShamirTemplate(TemplateOptions):
     bound_ctx: ClassVar[Context]
     metallurgy_assets: ClassVar[ResourcePack] = ResourcePack(path="gm4_metallurgy") # load metallurgy textures so expansion shamirs can fall back on their
     vanilla_models_jar: ClassVar[ClientJar]
+    vanilla_models_jar_1_21_3: ClassVar[ClientJar]
 
     def process(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
         logger = parent_logger.getChild(self.bound_ctx.project_id)
@@ -163,8 +164,18 @@ class ShamirTemplate(TemplateOptions):
 
                 itemdef_compound["model"] = variant_path # update our copy to point to the new model
 
+            # 1.21.3 Backwards Comparability - Remove in 1.21.5!
+            variants: Any = [{"model": f"{models_loc}/{item}"}]
+            for override in self.vanilla_models_jar_1_21_3.assets.models[f"minecraft:item/{item}"].data.get('overrides', []):
+                item_variant = override['model'].split('/')[-1]
+
+                variants.append({
+                    "predicate": override['predicate'],
+                    "model": f"{models_loc}/{item_variant}"
+                })
+
             if item_variants:
-                models.update({item: ComplexBypass(payload=mutatable_itemdef_copy)})
+                models.update({item: ComplexBypass(payload=mutatable_itemdef_copy, payload_1_21_3=variants)})
             else:
                 models.update({item: f"{models_loc}/{item}"})
 
@@ -213,6 +224,7 @@ class ComplexBypass(ItemModelOptions):
     # NOTE should this be in the base resource_pack file? Depends if any other modules use this approach
     type = "_complex_bypass"
     payload: dict[str, Any]
+    payload_1_21_3: Optional[Any] = [] # NOTE backwards compatability field. Will be removed in 1.21.5 update
 
     def generate_json(self) -> dict[str, Any]:
         return self.payload
@@ -248,6 +260,10 @@ def beet_default(ctx: Context):
     vanilla.minecraft_version = '1.21.4'
     ShamirTemplate.vanilla_models_jar = vanilla.mount("assets/minecraft/items")
     merge_policy(ctx)
+
+    # 1.21.3 Backwards Compat
+    vanilla.minecraft_version = '1.21.3'
+    ShamirTemplate.vanilla_models_jar_1_21_3 = vanilla.mount("assets/minecraft/models/item")
 
 def merge_policy(ctx: Context):
     ctx.assets.merge_policy.extend_namespace(OptifineProperties, optifine_armor_properties_merging)

--- a/gm4_metallurgy/shamir_model_template.py
+++ b/gm4_metallurgy/shamir_model_template.py
@@ -1,13 +1,13 @@
 from beet import Context, Model, NamespaceProxy, ListOption, ResourcePack
 from beet.contrib.vanilla import Vanilla, ClientJar
 from beet.contrib.optifine import OptifineProperties
-from typing import Any, ClassVar, Literal, Optional
+from typing import Any, ClassVar, Literal
 from itertools import product, chain, count
 import re
 import logging
 from copy import deepcopy
 
-from gm4.plugins.resource_pack import ModelData, TemplateOptions, ItemModelOptions
+from gm4.plugins.resource_pack import ModelData, TemplateOptions, JsonType
 from gm4.utils import add_namespace, MapOption
 
 parent_logger = logging.getLogger("gm4."+__name__)
@@ -63,15 +63,18 @@ class ShamirTemplate(TemplateOptions):
     textures_path: str = "" # directory of texture files to use for shamirs, falling back to the default metallurgy textures
     metal: Literal["aluminium", "barimium", "barium", "bismuth", "curies_bismium", "thorium"] # the metallurgy metal this shamir is made of
 
+    _item_def_map: dict[str, JsonType] = {}
+    _model_overrides_1_21_3: dict[str, list[JsonType]] = {} # NOTE to be removed in 1.21.5
+
     bound_ctx: ClassVar[Context]
     metallurgy_assets: ClassVar[ResourcePack] = ResourcePack(path="gm4_metallurgy") # load metallurgy textures so expansion shamirs can fall back on their
     vanilla_models_jar: ClassVar[ClientJar]
     vanilla_models_jar_1_21_3: ClassVar[ClientJar]
 
-    def process(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
+    def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
         logger = parent_logger.getChild(self.bound_ctx.project_id)
         models_loc = f"{config.reference}"
-        models: dict[str, str|ItemModelOptions] = {} # the value of config.models to be applied after going through special cases
+        models: dict[str, str] = {} # the value of config.models to be applied after going through special cases
         ret_list: list[Model] = []
 
         for item in config.item.entries():
@@ -165,7 +168,7 @@ class ShamirTemplate(TemplateOptions):
                 itemdef_compound["model"] = variant_path # update our copy to point to the new model
 
             # 1.21.3 Backwards Comparability - Remove in 1.21.5!
-            variants: Any = [{"model": f"{models_loc}/{item}"}]
+            variants: list[JsonType] = [{"model": f"{models_loc}/{item}"}]
             for override in self.vanilla_models_jar_1_21_3.assets.models[f"minecraft:item/{item}"].data.get('overrides', []):
                 item_variant = override['model'].split('/')[-1]
 
@@ -175,7 +178,9 @@ class ShamirTemplate(TemplateOptions):
                 })
 
             if item_variants:
-                models.update({item: ComplexBypass(payload=mutatable_itemdef_copy, payload_1_21_3=variants)})
+                self._item_def_map[item] = mutatable_itemdef_copy
+                self._model_overrides_1_21_3[item] = variants
+                models.update({item: "NULL"}) # actual model paths contained within itemdef compound
             else:
                 models.update({item: f"{models_loc}/{item}"})
 
@@ -209,6 +214,10 @@ class ShamirTemplate(TemplateOptions):
         config.model = MapOption(__root__=models)
         return ret_list
     
+    def get_item_def_entry(self, config: ModelData, item: str) -> None|JsonType:
+        # TODO fill me out, replacing ComplexBypass
+        return self._item_def_map.get(item)
+    
     def mutate_config(self, config: ModelData):
         expanded_items = set(chain.from_iterable([GROUP_LOOKUP.get(group, [group]) for group in config.item.entries()])) | {"player_head"}
         config.item = ListOption(__root__=list(expanded_items))
@@ -217,17 +226,6 @@ class ShamirTemplate(TemplateOptions):
             config.textures = MapOption(__root__={"band": f"gm4_metallurgy:item/band/{self.metal}_band"})
         else: # isinstance(.., dict):
             config.textures = MapOption(__root__={"band": f"gm4_metallurgy:item/band/{self.metal}_band"}|config.textures.__root__)
-
-class ComplexBypass(ItemModelOptions):
-    """Generator for item model definitions on trimed armor, compasses with complex vanilla display conditions.
-    NOT INTENDED FOR USAGE IN CONFIG FILES. Used by config-mutating templates to pass item-model-def variants upstream to the file creation stage"""
-    # NOTE should this be in the base resource_pack file? Depends if any other modules use this approach
-    type = "_complex_bypass"
-    payload: dict[str, Any]
-    payload_1_21_3: Optional[Any] = [] # NOTE backwards compatability field. Will be removed in 1.21.5 update
-
-    def generate_json(self) -> dict[str, Any]:
-        return self.payload
 
 def optifine_armor_properties_merging(pack: ResourcePack, path: str, current: OptifineProperties, conflict: OptifineProperties) -> bool:
     if not path.startswith("gm4_metallurgy:cit"): # only apply this rule to metallurgy files

--- a/gm4_metallurgy/shamir_model_template.py
+++ b/gm4_metallurgy/shamir_model_template.py
@@ -20,6 +20,8 @@ BUCKETABLE = ["water", "lava", "milk", "powder_snow", "cod", "salmon", "pufferfi
 
 TEXTURELESS = ["shield"] # item model is unable to receive layer in vanilla
 
+SPECIAL_MODEL_IGNORES = ["shield"] # models with special case handling, that cannot be customized with resource packs the way we want.
+
 # define item group lookups
 GROUP_LOOKUP = {
     "armor": [f"{material}_{armor}" for material, armor in product(ARMOR_MATERIALS, ARMOR)] + ["turtle_helmet"],
@@ -180,6 +182,10 @@ class ShamirTemplate(TemplateOptions):
             if item_variants:
                 self._item_def_map[item] = mutatable_itemdef_copy
                 self._model_overrides_1_21_3[item] = variants
+                models.update({item: "NULL"}) # actual model paths contained within itemdef compound
+            elif item in SPECIAL_MODEL_IGNORES:
+                # use the vanilla item-def anyway
+                self._item_def_map[item] = mutatable_itemdef_copy
                 models.update({item: "NULL"}) # actual model paths contained within itemdef compound
             else:
                 models.update({item: f"{models_loc}/{item}"})

--- a/gm4_metallurgy/shamir_model_template.py
+++ b/gm4_metallurgy/shamir_model_template.py
@@ -5,8 +5,9 @@ from typing import Any, ClassVar, Literal
 from itertools import product, chain, count
 import re
 import logging
+from copy import deepcopy
 
-from gm4.plugins.resource_pack import ModelData, TemplateOptions
+from gm4.plugins.resource_pack import ModelData, TemplateOptions, ItemModelOptions
 from gm4.utils import add_namespace, MapOption
 
 parent_logger = logging.getLogger("gm4."+__name__)
@@ -69,7 +70,7 @@ class ShamirTemplate(TemplateOptions):
     def process(self, config: ModelData, models_container: NamespaceProxy[Model]) -> list[Model]:
         logger = parent_logger.getChild(self.bound_ctx.project_id)
         models_loc = f"{config.reference}"
-        models: dict[str, str|list[dict[str,Any]]] = {} # the value of config.models to be applied after going through special cases
+        models: dict[str, str|ItemModelOptions] = {} # the value of config.models to be applied after going through special cases
         ret_list: list[Model] = []
 
         for item in config.item.entries():
@@ -123,26 +124,49 @@ class ShamirTemplate(TemplateOptions):
             models_container[f"{models_loc}/{item}"] = m
             ret_list.append(m)
 
-            variants: Any = [{"model": f"{models_loc}/{item}"}] # the base model is just a regular model reference
-            for override in self.vanilla_models_jar.assets.models[f"minecraft:item/{item}"].data.get('overrides', []):
-                item_variant = override['model'].split('/')[-1] # ie, iron_chestplate_quartz_trim, fishing_rod_cast, compass_00, elytra_broken ect...
+            # define recursive search function for looking at vanilla item definitions to copy/modify
+            def recursive_extract_variants(json: dict[str, Any]) -> tuple[list[str], list[Any]]:
+                ret_variants: list[str] = []
+                ret_pointers: list[Any] = []
+                for val in json.values():
+                    match val:
+                        case {"type": "minecraft:model", "model": str(m)}:
+                            ret_variants.append(m.split('/')[-1]) # ie, iron_chestplate_quartz_trim, fishing_rod_cast, compass_00, elytra_broken ect...
+                            ret_pointers.append(val)
+                        case list()|dict(): # val is dict, or list of dicts
+                            for elem in val if isinstance(val, list) else [val]: # type: ignore ; this is json
+                                if isinstance(elem, dict):
+                                    rec_varis, rec_pts = recursive_extract_variants(elem) # type: ignore ; this is json
+                                    ret_variants.extend(rec_varis)
+                                    ret_pointers.extend(rec_pts)
+                        case _:
+                            pass
+                        
+                return ret_variants, ret_pointers
 
+            # create texture variants, using the vanilla item definition as a template
+            mutatable_itemdef_copy = deepcopy(self.vanilla_models_jar.assets.item_models[f"minecraft:{item}"].data["model"])
+            item_variants, itemdef_compounds = recursive_extract_variants(mutatable_itemdef_copy)
+            for item_variant, itemdef_compound in zip(item_variants, itemdef_compounds):
                 texture_variant = ('/'.join(texture.split('/')[0:-1] + [item_variant])) # is there an explicit texture for this variant. ie broken_elytra.png?
                 variant_tex_exists = texture_variant in self.bound_ctx.assets.textures or texture_variant in self.metallurgy_assets.textures
 
-                m = Model({
-                    "parent": f"minecraft:item/{item_variant}",
-                    "textures": {
-                        f"layer{total_layers+1}": texture_variant if variant_tex_exists else texture
-                    }
-                })
-                models_container[f"{models_loc}/{item_variant}"] = m
-                ret_list.append(m)
-                variants.append({
-                    "predicate": override['predicate'],
-                    "model": f"{models_loc}/{item_variant}"
-                })
-            models.update({item: variants})
+                if (variant_path:=f"{models_loc}/{item_variant}") not in models_container: # create a new model file if one does not exist
+                    m = Model({
+                        "parent": f"minecraft:item/{item_variant}",
+                        "textures": {
+                            f"layer{total_layers+1}": texture_variant if variant_tex_exists else texture
+                        }
+                    })
+                    models_container[f"{models_loc}/{item_variant}"] = m
+                    ret_list.append(m)
+
+                itemdef_compound["model"] = variant_path # update our copy to point to the new model
+
+            if item_variants:
+                models.update({item: ComplexBypass(payload=mutatable_itemdef_copy)})
+            else:
+                models.update({item: f"{models_loc}/{item}"})
 
             # optifine .properties handling
             if item in GROUP_LOOKUP["armor"]:
@@ -183,6 +207,15 @@ class ShamirTemplate(TemplateOptions):
         else: # isinstance(.., dict):
             config.textures = MapOption(__root__={"band": f"gm4_metallurgy:item/band/{self.metal}_band"}|config.textures.__root__)
 
+class ComplexBypass(ItemModelOptions):
+    """Generator for item model definitions on trimed armor, compasses with complex vanilla display conditions.
+    NOT INTENDED FOR USAGE IN CONFIG FILES. Used by config-mutating templates to pass item-model-def variants upstream to the file creation stage"""
+    # NOTE should this be in the base resource_pack file? Depends if any other modules use this approach
+    type = "_complex_bypass"
+    payload: dict[str, Any]
+
+    def generate_json(self) -> dict[str, Any]:
+        return self.payload
 
 def optifine_armor_properties_merging(pack: ResourcePack, path: str, current: OptifineProperties, conflict: OptifineProperties) -> bool:
     if not path.startswith("gm4_metallurgy:cit"): # only apply this rule to metallurgy files
@@ -212,8 +245,8 @@ def beet_default(ctx: Context):
     # bind context object to a ClassVar so it can be accessed later during template processing
     ShamirTemplate.bound_ctx = ctx
     vanilla = ctx.inject(Vanilla)
-    vanilla.minecraft_version = '1.21.3'
-    ShamirTemplate.vanilla_models_jar = vanilla.mount("assets/minecraft/models/item")
+    vanilla.minecraft_version = '1.21.4'
+    ShamirTemplate.vanilla_models_jar = vanilla.mount("assets/minecraft/items")
     merge_policy(ctx)
 
 def merge_policy(ctx: Context):

--- a/gm4_orb_of_ankou/pneuma_model_template.py
+++ b/gm4_orb_of_ankou/pneuma_model_template.py
@@ -9,7 +9,7 @@ class PneumaTemplate(TemplateOptions):
     """model template to generate the models for shards and essences"""
     name = "pneuma"
 
-    def process(self, config: ModelData, models_container: NamespaceProxy[Model]):
+    def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]):
         pneuma = config.reference.split("/")[-1] # eg agile, anchoring ect...
         shard = models_container[f"gm4_orb_of_ankou:item/shards/{pneuma}"] = Model({
             "parent": "item/generated",

--- a/gm4_smelteries/ore_display.py
+++ b/gm4_smelteries/ore_display.py
@@ -14,7 +14,7 @@ class OreDisplayTemplate(TemplateOptions):
         )
     ]
 
-    def process(self, config: ModelData, models_container: NamespaceProxy[Model]):
+    def create_models(self, config: ModelData, models_container: NamespaceProxy[Model]):
         model_name = ensure_single_model_config(self.name, config)
         reference = config.reference.split('/')[-1]
         m = models_container[model_name] = Model({

--- a/gm4_zauber_cauldrons/assets/model_data.yaml
+++ b/gm4_zauber_cauldrons/assets/model_data.yaml
@@ -66,7 +66,9 @@ model_data:
       forward: item/bottled_magicol/temperate_potion
   - item: clock
     reference: gui/advancement/zauber_cauldrons_make_magicol
-    template: advancement
+    template: 
+      name: advancement
+      forward: minecraft:clock_00
   - item: grass_block
     reference: gui/advancement/zauber_cauldrons_paint_biome
     template: advancement

--- a/lib_custom_crafters/beet.yaml
+++ b/lib_custom_crafters/beet.yaml
@@ -13,6 +13,7 @@ resource_pack:
 
 require:
   - gm4.plugins.resource_pack
+  - gm4.plugins.backwards.resource_pack
   - gm4_guidebook.generate_guidebooks.load_page_data
   - gm4_guidebook.generate_guidebooks.load_custom_recipes
   - gm4.plugins.player_heads

--- a/resource_pack/beet.yaml
+++ b/resource_pack/beet.yaml
@@ -6,7 +6,12 @@ resource_pack:
   load:
     pack.png: pack.png
     # other files are inherited by the full-project build
-
+  overlays:
+    - formats:
+        min_inclusive: 0
+        max_inclusive: 42
+      directory: backport_42
+      
 pipeline:
   - dev_warning
 


### PR DESCRIPTION
Adds 1.21.4. item model definition files to the resource pack, and moves existing models to an overlay for backwards compatibility. 

Remaining tasks:
- [ ] Testing in-game
- [x] RP marked valid versions (1.21.3 should not throw warning)
- [x] Restore backwards compatibility for shamir textures
- [ ] Fix vanilla item-model forwarding