### PR TITLE
Fix Standard Crafting Missing Slab & Stair Uncrafting Recipes

### DIFF
--- a/gm4_standard_crafting/generate_recipes.py
+++ b/gm4_standard_crafting/generate_recipes.py
@@ -108,7 +108,7 @@ def beet_default(ctx: Context):
             })
 
             if since_61:
-                return
+                continue
             ctx.data[recipe_path] = CustomCrafterRecipe({
                 "name": f"gm4_standard_crafting:{dir}/{item}",
                 "input": {


### PR DESCRIPTION
This PR for Standard Crafting fixes an issue with the generate_recipes python script, where the recipes for a few wooden slabs and stairs were skipped for uncrafting in vanilla recipes.

`recursive_apply` returned early in case of since_61 on line 111, instead of continuing the loop. This caused everything after `pale_oak_slab` in `#minecraft:wooden_slabs` (and the equivalent in stair uncrafting) to be skipped, failing to generate the recipes for uncrafting for the following wood types: crimson, warped, mangrove, bamboo, cherry.