### PR TITLE
Fix Pig Tractors Unresponsive

### DIFF
--- a/gm4_pig_tractors/data/gm4_pig_tractors/advancement/block_detection/air.json
+++ b/gm4_pig_tractors/data/gm4_pig_tractors/advancement/block_detection/air.json
@@ -1,7 +1,7 @@
 {
     "criteria": {
         "requirement": {
-            "trigger": "minecraft:enter_block",
+            "trigger": "minecraft:tick",
             "conditions": {
                 "player": [
                     {

--- a/gm4_pig_tractors/data/gm4_pig_tractors/advancement/block_detection/empty_farmland.json
+++ b/gm4_pig_tractors/data/gm4_pig_tractors/advancement/block_detection/empty_farmland.json
@@ -1,7 +1,7 @@
 {
     "criteria": {
         "requirement": {
-            "trigger": "minecraft:enter_block",
+            "trigger": "minecraft:tick",
             "conditions": {
                 "player": [
                     {


### PR DESCRIPTION
 Fixes #1089

Switches the advancement triggers for `detect_block/air` and `detect_block/empty_farmland` from `minecraft:enter_block` to `minecraft:tick`
This is because `minecraft:enter_block` stopped triggering for air blocks at some point, causing these 2 advancements to trigger unreliably. This is currently tracked as a confirmed MC bug in [MC-279621](https://bugs.mojang.com/browse/MC-279621).