### PR TITLE
Fix balloon animal rarity weighting

### DIFF
--- a/gm4_balloon_animals/data/gm4_balloon_animals/loot_table/technical/random/enumeration_value.json
+++ b/gm4_balloon_animals/data/gm4_balloon_animals/loot_table/technical/random/enumeration_value.json
@@ -5,12 +5,12 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "weight": 3,
+          "weight": 7,
           "value": "gm4_balloon_animals:technical/random/pick_common"
         },
         {
           "type": "minecraft:loot_table",
-          "weight": 7,
+          "weight": 3,
           "value": "gm4_balloon_animals:technical/random/pick_rare"
         }
       ]


### PR DESCRIPTION
Noticed that the loot table for whether to choose a rare or common balloon animal had the weights set up in a way that didn't make much sense.
Rare was weighted as 7, Common was weighted as 3.
This PR swaps this so the names common and rare align with the chances.