### PR TITLE
Fix Gemini Shamir extra wolf baby not matching variant of other baby / parents

### DIFF
--- a/gm4_metallurgy/data/gm4_gemini_shamir/function/baby/spawn_wolf.mcfunction
+++ b/gm4_metallurgy/data/gm4_gemini_shamir/function/baby/spawn_wolf.mcfunction
@@ -3,4 +3,5 @@
 
 summon wolf ~ ~ ~ {Tags:["gm4_gemini_baby"],Age:-23999}
 data modify entity @e[type=wolf,tag=gm4_gemini_baby,distance=..2,sort=nearest,limit=1] Owner set from entity @s Owner
+data modify entity @e[type=wolf,tag=gm4_gemini_baby,distance=..2,sort=nearest,limit=1] variant set from entity @s variant
 tag @e[type=wolf,tag=gm4_gemini_baby,sort=nearest,limit=1] remove gm4_gemini_baby


### PR DESCRIPTION
Adds a command to set the variant of the extra baby from the first baby in `baby/spawn_wolf.mcfunction`