### PR TITLE
Add pale oak log & wood to Arborenda Shamir

### DIFF
--- a/gm4_metallurgy/data/gm4_arborenda_shamir/tags/block/trunks.json
+++ b/gm4_metallurgy/data/gm4_arborenda_shamir/tags/block/trunks.json
@@ -17,6 +17,8 @@
 		"minecraft:mangrove_wood",
 		"minecraft:oak_log",
 		"minecraft:oak_wood",
+		{ "id": "minecraft:pale_oak_log", "required": false },
+		{ "id": "minecraft:pale_oak_wood", "required": false },
 		"minecraft:spruce_log",
 		"minecraft:spruce_wood",
 		"minecraft:warped_stem",


### PR DESCRIPTION
Adds pale oak log & wood to `trunks.json`

I'm not entirely familiar with the format used here, but I've copied it from the base tag lists and how they did 1.21.4 blocks