### PR TITLE
1.21.5 heart canisters update

### DIFF
--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/apply_health_boost.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/apply_health_boost.mcfunction
@@ -2,16 +2,9 @@
 # run from check_heart_canisters
 attribute @s minecraft:max_health modifier remove minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72
 
-attribute @s[scores={gm4_heart_can=1}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 4 add_value
-attribute @s[scores={gm4_heart_can=2}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 8 add_value
-attribute @s[scores={gm4_heart_can=3}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 12 add_value
-attribute @s[scores={gm4_heart_can=4}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 16 add_value
-attribute @s[scores={gm4_heart_can=5}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 20 add_value
-attribute @s[scores={gm4_heart_can=6}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 24 add_value
-attribute @s[scores={gm4_heart_can=7}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 28 add_value
-attribute @s[scores={gm4_heart_can=8}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 32 add_value
-attribute @s[scores={gm4_heart_can=9}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 36 add_value
-attribute @s[scores={gm4_heart_can=10}] minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 40 add_value
+execute store result storage gm4_heart_cannisters:temp amount int 4 run scoreboard players get @s gm4_heart_can
+function gm4_heart_canisters:eval_health_boost with storage gm4_heart_cannisters:temp
+data remove storage gm4_heart_cannisters:temp amount
 
 tag @s[predicate=gm4_heart_canisters:has_health_boost] add gm4_hc_has_effect
 effect give @s[tag=!gm4_hc_has_effect] health_boost 1

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/check_heart_canisters.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/check_heart_canisters.mcfunction
@@ -1,13 +1,21 @@
-# gets called for every player with at least 1 heart canister tier 1 item
+# gets called for every player with at least 1 heart canister item
 
-scoreboard players set @s[nbt={Inventory:[{count:1,components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]}] gm4_heart_can 1
-scoreboard players set @s[nbt={Inventory:[{count:2,components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]}] gm4_heart_can 2
-scoreboard players set @s[nbt={Inventory:[{count:3,components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]}] gm4_heart_can 3
-scoreboard players set @s[nbt={Inventory:[{count:4,components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]}] gm4_heart_can 4
-scoreboard players set @s[nbt={Inventory:[{count:5,components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]}] gm4_heart_can 5
+# tier 1
+scoreboard players set $count_total gm4_heart_can 0
+data modify storage gm4_heart_cannisters:temp heart_cannister_data set value []
+data modify storage gm4_heart_cannisters:temp heart_cannister_data append from entity @s Inventory[{components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]
+execute store result score $count_add gm4_heart_can run data get entity @s equipment.offhand{components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}.count
+scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
+function gm4_heart_canisters:count_heart_canisters
+scoreboard players operation $count_total gm4_heart_can < $heart_cannister_cap gm4_heart_can
+scoreboard players operation @s gm4_heart_can += $count_total gm4_heart_can
 
-scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{count:1,components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]}] gm4_heart_can 6
-scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{count:2,components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]}] gm4_heart_can 7
-scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{count:3,components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]}] gm4_heart_can 8
-scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{count:4,components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]}] gm4_heart_can 9
-scoreboard players set @s[scores={gm4_heart_can=5..},nbt={Inventory:[{count:5,components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]}] gm4_heart_can 10
+# tier 2
+scoreboard players set $count_total gm4_heart_can 0
+data modify storage gm4_heart_cannisters:temp heart_cannister_data set value []
+data modify storage gm4_heart_cannisters:temp heart_cannister_data append from entity @s Inventory[{components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]
+execute store result score $count_add gm4_heart_can run data get entity @s equipment.offhand{components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}.count
+scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
+function gm4_heart_canisters:count_heart_canisters
+scoreboard players operation $count_total gm4_heart_can < $heart_cannister_cap gm4_heart_can
+scoreboard players operation @s gm4_heart_can += $count_total gm4_heart_can

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/check_heart_canisters.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/check_heart_canisters.mcfunction
@@ -1,21 +1,14 @@
 # gets called for every player with at least 1 heart canister item
 
 # tier 1
-scoreboard players set $count_total gm4_heart_can 0
-data modify storage gm4_heart_cannisters:temp heart_cannister_data set value []
-data modify storage gm4_heart_cannisters:temp heart_cannister_data append from entity @s Inventory[{components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}]
-execute store result score $count_add gm4_heart_can run data get entity @s equipment.offhand{components:{"minecraft:custom_data":{gm4_heart_canister_tier:1b}}}.count
-scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
-function gm4_heart_canisters:count_heart_canisters
-scoreboard players operation $count_total gm4_heart_can < $heart_cannister_cap gm4_heart_can
-scoreboard players operation @s gm4_heart_can += $count_total gm4_heart_can
+execute store result score @s gm4_heart_can if items entity @s container.* player_head[custom_data~{gm4_heart_canister_tier:1b}]
+execute store result score $count_add gm4_heart_can if items entity @s weapon.offhand player_head[custom_data~{gm4_heart_canister_tier:1b}]
+scoreboard players operation @s gm4_heart_can += $count_add gm4_heart_can
+scoreboard players operation @s gm4_heart_can < $heart_cannister_cap gm4_heart_can
 
 # tier 2
-scoreboard players set $count_total gm4_heart_can 0
-data modify storage gm4_heart_cannisters:temp heart_cannister_data set value []
-data modify storage gm4_heart_cannisters:temp heart_cannister_data append from entity @s Inventory[{components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}]
-execute store result score $count_add gm4_heart_can run data get entity @s equipment.offhand{components:{"minecraft:custom_data":{gm4_heart_canister_tier:2b}}}.count
-scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
-function gm4_heart_canisters:count_heart_canisters
-scoreboard players operation $count_total gm4_heart_can < $heart_cannister_cap gm4_heart_can
-scoreboard players operation @s gm4_heart_can += $count_total gm4_heart_can
+execute store result score $count_tier2 gm4_heart_can if items entity @s container.* player_head[custom_data~{gm4_heart_canister_tier:2b}]
+execute store result score $count_add gm4_heart_can if items entity @s weapon.offhand player_head[custom_data~{gm4_heart_canister_tier:2b}]
+scoreboard players operation $count_tier2 gm4_heart_can += $count_add gm4_heart_can
+scoreboard players operation $count_tier2 gm4_heart_can < $heart_cannister_cap gm4_heart_can
+scoreboard players operation @s gm4_heart_can += $count_tier2 gm4_heart_can

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/count_heart_canisters.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/count_heart_canisters.mcfunction
@@ -1,0 +1,6 @@
+# count all heart canisters of this tier in the inventory
+
+execute store result score $count_add gm4_heart_can run data get storage gm4_heart_cannisters:temp heart_cannister_data[0].count
+scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
+data remove storage gm4_heart_cannisters:temp heart_cannister_data[0]
+execute if data storage gm4_heart_cannisters:temp heart_cannister_data[0] run function gm4_heart_canisters:count_heart_canisters

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/count_heart_canisters.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/count_heart_canisters.mcfunction
@@ -1,6 +1,0 @@
-# count all heart canisters of this tier in the inventory
-
-execute store result score $count_add gm4_heart_can run data get storage gm4_heart_cannisters:temp heart_cannister_data[0].count
-scoreboard players operation $count_total gm4_heart_can += $count_add gm4_heart_can
-data remove storage gm4_heart_cannisters:temp heart_cannister_data[0]
-execute if data storage gm4_heart_cannisters:temp heart_cannister_data[0] run function gm4_heart_canisters:count_heart_canisters

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/eval_health_boost.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/eval_health_boost.mcfunction
@@ -1,0 +1,2 @@
+
+$attribute @s minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 $(amount) add_value

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/eval_health_boost.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/eval_health_boost.mcfunction
@@ -1,2 +1,3 @@
+# apply the health boost
 
 $attribute @s minecraft:max_health modifier add minecraft:38a576e7-341b-46ed-a9e3-7b7291beae72 $(amount) add_value

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/init.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/init.mcfunction
@@ -4,6 +4,8 @@ execute unless score heart_canisters gm4_modules matches 1 run data modify stora
 execute unless score heart_canisters gm4_earliest_version < heart_canisters gm4_modules run scoreboard players operation heart_canisters gm4_earliest_version = heart_canisters gm4_modules
 scoreboard players set heart_canisters gm4_modules 1
 
+scoreboard players set $heart_cannister_cap gm4_heart_can 5
+
 schedule function gm4_heart_canisters:main 1t
 
 #$moduleUpdateList

--- a/gm4_heart_canisters/data/gm4_heart_canisters/function/player.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/function/player.mcfunction
@@ -1,6 +1,6 @@
 # check how many heart canisters the player has
 scoreboard players operation $heart_can_last gm4_heart_can = @s gm4_heart_can
 scoreboard players set @s gm4_heart_can 0
-execute if predicate gm4_heart_canisters:carries_tier_1 run function gm4_heart_canisters:check_heart_canisters
+execute if predicate gm4_heart_canisters:carries_heart_canister run function gm4_heart_canisters:check_heart_canisters
 
 execute unless score @s gm4_heart_can = $heart_can_last gm4_heart_can run function gm4_heart_canisters:apply_health_boost

--- a/gm4_heart_canisters/data/gm4_heart_canisters/loot_table/items/tier_1_heart_canister.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/loot_table/items/tier_1_heart_canister.json
@@ -11,12 +11,19 @@
                             "function": "minecraft:set_components",
                             "components": {
                                 "minecraft:custom_model_data": "item/heart_canister_tier_1",
-                                "minecraft:profile": "$heart_canister_tier_1" 
+                                "minecraft:profile": "$heart_canister_tier_1"
                             }
                         },
                         {
                             "function": "minecraft:set_custom_data",
                             "tag": "{gm4_heart_canister:1b,gm4_heart_canister_tier:1b}"
+                        },
+                        {
+                            "function": "set_components",
+                            "components": {
+                                "max_stack_size": 5,
+                                "!equippable": {}
+                            }
                         },
                         {
                             "function": "minecraft:set_name",

--- a/gm4_heart_canisters/data/gm4_heart_canisters/loot_table/items/tier_2_heart_canister.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/loot_table/items/tier_2_heart_canister.json
@@ -19,6 +19,13 @@
                             "tag": "{gm4_heart_canister:1b,gm4_heart_canister_tier:2b}"
                         },
                         {
+                            "function": "set_components",
+                            "components": {
+                                "max_stack_size": 5,
+                                "!equippable": {}
+                            }
+                        },
+                        {
                             "function": "minecraft:set_name",
                             "name": {
                                 "translate": "item.gm4.heart_canister",

--- a/gm4_heart_canisters/data/gm4_heart_canisters/predicate/carries_heart_canister.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/predicate/carries_heart_canister.json
@@ -9,7 +9,7 @@
           "container.*": {
             "items": "minecraft:player_head",
             "predicates": {
-              "minecraft:custom_data": "{gm4_heart_canister_tier:1b}"
+              "minecraft:custom_data": "{gm4_heart_canister:1b}"
             }
           }
         }
@@ -23,7 +23,7 @@
           "armor.*": {
             "items": "minecraft:player_head",
             "predicates": {
-              "minecraft:custom_data": "{gm4_heart_canister_tier:1b}"
+              "minecraft:custom_data": "{gm4_heart_canister:1b}"
             }
           }
         }
@@ -37,7 +37,7 @@
           "player.cursor": {
             "items": "minecraft:player_head",
             "predicates": {
-              "minecraft:custom_data": "{gm4_heart_canister_tier:1b}"
+              "minecraft:custom_data": "{gm4_heart_canister:1b}"
             }
           }
         }
@@ -51,7 +51,7 @@
           "player.crafting.*": {
             "items": "minecraft:player_head",
             "predicates": {
-              "minecraft:custom_data": "{gm4_heart_canister_tier:1b}"
+              "minecraft:custom_data": "{gm4_heart_canister:1b}"
             }
           }
         }
@@ -65,7 +65,7 @@
           "weapon.*": {
             "items": "minecraft:player_head",
             "predicates": {
-              "minecraft:custom_data": "{gm4_heart_canister_tier:1b}"
+              "minecraft:custom_data": "{gm4_heart_canister:1b}"
             }
           }
         }

--- a/gm4_heart_canisters/data/gm4_heart_canisters/recipe/heart_canister_tier_1.json
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/recipe/heart_canister_tier_1.json
@@ -16,6 +16,8 @@
     "id": "minecraft:player_head",
     "components": {
       "minecraft:custom_model_data": "item/heart_canister_tier_1",
+      "minecraft:max_stack_size": 5,
+      "!minecraft:equippable": {},
       "minecraft:profile": "$heart_canister_tier_1",
       "minecraft:custom_data": "{gm4_heart_canister:1b,gm4_heart_canister_tier:1b}",
       "minecraft:custom_name": {"translate":"item.gm4.heart_canister","fallback":"Heart Canister","italic":false},

--- a/gm4_heart_canisters/data/gm4_heart_canisters/test/apply_tier_1.mcfunction
+++ b/gm4_heart_canisters/data/gm4_heart_canisters/test/apply_tier_1.mcfunction
@@ -7,7 +7,6 @@ scoreboard objectives add gm4_test dummy
 execute store result score $max_health gm4_test run attribute @s minecraft:max_health get
 assert score $max_health gm4_test matches 24
 
-loot give @s loot gm4_heart_canisters:items/tier_2_heart_canister
 loot give @s loot gm4_heart_canisters:items/tier_1_heart_canister
 
 await delay 1s
@@ -21,4 +20,4 @@ loot give @s loot gm4_heart_canisters:items/tier_1_heart_canister
 
 await delay 1s
 execute store result score $max_health gm4_test run attribute @s minecraft:max_health get
-assert score $max_health gm4_test matches 20
+assert score $max_health gm4_test matches 40


### PR DESCRIPTION
Heart Canisters no longer equip to the head slot and stack to a max of 5.

Tier 2 Canisters now work regardless of the amount of Tier 1 Canisters in the inventory

Heart Canisters now work even when spread around the inventory