### PR TITLE
Add Feather Falling Interaction to Desire Lines

### DIFF
--- a/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/player.mcfunction
@@ -10,7 +10,7 @@ execute unless predicate gm4_desire_lines:is_affected run return fail
 scoreboard players operation $probability gm4_desire_lines = #base_probability gm4_desire_lines
 execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"flags":{"is_sneaking":true}}} run scoreboard players operation $probability gm4_desire_lines += #sneak_penality gm4_desire_lines
 execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"flags":{"is_sprinting":true}}} run scoreboard players operation $probability gm4_desire_lines += #sprint_penalty gm4_desire_lines
-execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"movement":{"vertical_speed":{"min":2}}}} run scoreboard players operation $probability gm4_desire_lines += #impact_penalty gm4_desire_lines
+execute if predicate {"condition":"minecraft:entity_properties","entity":"this","predicate":{"movement":{"vertical_speed":{"min":2}}}} if predicate gm4_desire_lines:feather_falling_fail run scoreboard players operation $probability gm4_desire_lines += #impact_penalty gm4_desire_lines
 function #gm4_desire_lines:expansion
 
 # | NOTE: if you are writing an expansion, do NOT 'set' $probability, as the order in which expansions are called is arbitrary.

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/feather_falling_fail.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/feather_falling_fail.json
@@ -115,7 +115,10 @@
                   "minecraft:enchantments": [
                     {
                       "enchantments": "minecraft:feather_falling",
-                      "levels": 4
+                      "levels": {
+                        "min": 4,
+                        "max": 255
+                      }
                     }
                   ]
                 }

--- a/gm4_desire_lines/data/gm4_desire_lines/predicate/feather_falling_fail.json
+++ b/gm4_desire_lines/data/gm4_desire_lines/predicate/feather_falling_fail.json
@@ -1,0 +1,133 @@
+{
+  "condition": "minecraft:any_of",
+  "terms": [
+    {
+      "condition": "minecraft:inverted",
+      "term": {
+        "condition": "minecraft:entity_properties",
+        "entity": "this",
+        "predicate": {
+          "equipment": {
+            "feet": {
+              "predicates": {
+                "minecraft:enchantments": [
+                  {
+                    "enchantments": "minecraft:feather_falling"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:feather_falling",
+                      "levels": 1
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.7
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:feather_falling",
+                      "levels": 2
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.5
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:feather_falling",
+                      "levels": 3
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.3
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:feather_falling",
+                      "levels": 4
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.1
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a chance to fail the impact penalty when falling, scaled for each level of feather falling, making each level reduce the likelihood of creating a desire line when falling.

This will need to be tested in game to fine-tune the probability.