### PR TITLE
Make Monsters Unbound standalone

### DIFF
--- a/gm4_monsters_unbound/beet.yaml
+++ b/gm4_monsters_unbound/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_monsters_unbound
 name: Monsters Unbound
-version: 1.0.X
+version: 1.1.X
 
 data_pack:
   load: .
@@ -19,13 +19,14 @@ meta:
       required:
         lib_forceload: 1.3.0
         lib_lore: 1.1.0
-        gm4_survival_refightalized: 1.0.0
       schedule_loops: 
         - tick
         - main
         - slow_clock
     website:
       description: Mobs gain special effects based on their biome.
+      recommended:
+        - gm4_survival_refightalized
     video: null
     wiki: https://wiki.gm4.co/wiki/Monsters_Unbound
     credits:

--- a/gm4_monsters_unbound/data/gm4/advancement/monsters_unbound_elite_kill.json
+++ b/gm4_monsters_unbound/data/gm4/advancement/monsters_unbound_elite_kill.json
@@ -14,7 +14,7 @@
     },
     "frame": "task"
   },
-  "parent": "gm4:survival_refightalized_armor_damage",
+  "parent": "gm4:root",
   "criteria": {
     "kill_elite": {
       "trigger": "minecraft:player_killed_entity",

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/clocks/elite/zephyr_process.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/clocks/elite/zephyr_process.mcfunction
@@ -5,6 +5,6 @@
 # schedule from mob/process/elite/zephyr/skeleton/start
 
 scoreboard players set $keep_tick.elite_process_zephyr gm4_mu_keep_tick 0
-execute as @e[type=#gm4_survival_refightalized:skeleton_types,tag=gm4_mu_elite.zephyr_skeleton_burst] at @s run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/arrow_burst
+execute as @e[type=#gm4_monsters_unbound:skeleton_types,tag=gm4_mu_elite.zephyr_skeleton_burst] at @s run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/arrow_burst
 
 execute if score $keep_tick.elite_process_zephyr gm4_mu_keep_tick matches 1 run schedule function gm4_monsters_unbound:clocks/elite/zephyr_process 3t

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/blazing/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/blazing/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 46
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/blazing/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/blazing/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 46
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/gargantuan/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/gargantuan/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 96
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/gargantuan/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/gargantuan/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 96
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/glacial/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/glacial/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 1
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/glacial/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/glacial/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 1
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/mending/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/mending/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 16
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/mending/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/mending/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 16
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/pearlescent/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/pearlescent/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 86
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/pearlescent/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/pearlescent/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 86
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/splitting/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/splitting/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 66
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/splitting/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/splitting/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 66
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/volatile/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/volatile/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 76
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/volatile/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/volatile/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 76
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/vorpal/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/vorpal/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 56
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/vorpal/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/vorpal/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 56
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/zephyr/skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/zephyr/skeleton.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 31
 summon skeleton ~ ~ ~ {Tags:["gm4_mu_elite","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/zephyr/zombie.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/debug/spawn_elite/zephyr/zombie.mcfunction
@@ -1,4 +1,5 @@
 
 scoreboard players set $prepicked_elite gm4_mu_data 31
 summon zombie ~ ~ ~ {Tags:["gm4_sr_was_baby","gm4_mu_debug_mob"]}
-execute as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute unless score gm4_survival_refightalized load.status matches 1.. as @n[tag=gm4_mu_debug_mob] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/init.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/init.mcfunction
@@ -9,21 +9,24 @@ scoreboard objectives add gm4_mu_generation dummy
 scoreboard objectives add gm4_mu_frozen_time dummy
 scoreboard objectives add gm4_mu_feared_time dummy
 scoreboard objectives add gm4_mu_keep_tick dummy
+scoreboard objectives add gm4_mu_config dummy
+# add sr_data for compatibility
+scoreboard objectives add gm4_sr_data dummy
 
 # configs
-execute unless score $spawn_phantoms gm4_sr_config matches -2147483648..2147483647 run scoreboard players set $spawn_phantoms gm4_sr_config 1
+execute unless score $spawn_phantoms gm4_mu_config matches -2147483648..2147483647 run scoreboard players set $spawn_phantoms gm4_mu_config 1
 
 # disable natural phantom spawning
 execute unless score $phantoms_disabled gm4_mu_data matches 1 run gamerule doInsomnia false
 execute unless score $phantoms_disabled gm4_mu_data matches 1 run data modify storage gm4:log queue append value {type:"text",message:{"text":"[INFO] Monsters Unbound changed gamerule doInsomnia to false"}}
 scoreboard players set $phantoms_disabled gm4_mu_data 1
 execute store result score $doinsomnia gm4_mu_data run gamerule doInsomnia
-execute if score $spawn_phantoms gm4_sr_config matches 1 if score $doinsomnia gm4_mu_data matches 1 run data modify storage gm4:log queue append value {type:"text",message:[{"text":"[WARN]","color":"red"},{"text":" Monsters Unbound requires doInsomnia to be false, but it is true. ","color":"white"},{"text":"click here to fix","color":"red","clickEvent":{"action":"suggest_command","value":"/gamerule doInsomnia false"}}]}
+execute if score $spawn_phantoms gm4_mu_config matches 1 if score $doinsomnia gm4_mu_data matches 1 run data modify storage gm4:log queue append value {type:"text",message:[{"text":"[WARN]","color":"red"},{"text":" Monsters Unbound requires doInsomnia to be false, but it is true. ","color":"white"},{"text":"click here to fix","color":"red","clickEvent":{"action":"suggest_command","value":"/gamerule doInsomnia false"}}]}
 
 # mob caps
-execute unless score $mob_limit.husk_army gm4_sr_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.husk_army gm4_sr_config 128
-execute unless score $mob_limit.spore_zombie gm4_sr_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.spore_zombie gm4_sr_config 128
-execute unless score $mob_limit.phantom gm4_sr_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.phantom gm4_sr_config 48
+execute unless score $mob_limit.husk_army gm4_mu_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.husk_army gm4_mu_config 128
+execute unless score $mob_limit.spore_zombie gm4_mu_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.spore_zombie gm4_mu_config 128
+execute unless score $mob_limit.phantom gm4_mu_config matches -2147483648..2147483647 run scoreboard players set $mob_limit.phantom gm4_mu_config 48
 
 # elite teams
 team add gm4_mu_elite.glacial

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/main.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/main.mcfunction
@@ -1,11 +1,15 @@
 schedule function gm4_monsters_unbound:main 16t
 
+# modify mobs
+# if survival_refightalized is installed the modification is instead started from there
+execute unless score gm4_survival_refightalized load.status matches 1.. as @e[type=#gm4_monsters_unbound:modify,tag=!smithed.entity,tag=!gm4_mu_processed,nbt=!{PersistenceRequired:1b}] at @s run function gm4_monsters_unbound:mob/init/check_mob
+
 # process cloaked creepers
 execute as @e[type=creeper,tag=gm4_mu_cloaked_creeper] at @s if entity @a[gamemode=!spectator,gamemode=!creative,distance=..3.1] run function gm4_monsters_unbound:mob/process/cloaked_creeper
 
 # zombie spores
 execute as @e[type=item,tag=gm4_mu_spore] at @s run function gm4_monsters_unbound:mob/process/spore/advance
-execute as @e[type=#gm4_survival_refightalized:zombie_types,tag=gm4_mu_spore_zombie,predicate=gm4_monsters_unbound:technical/on_fire] run function gm4_monsters_unbound:mob/process/spore/burn_on_head
+execute as @e[type=#gm4_monsters_unbound:zombie_types,tag=gm4_mu_spore_zombie,predicate=gm4_monsters_unbound:technical/on_fire] run function gm4_monsters_unbound:mob/process/spore/burn_on_head
 
 # traps
 execute as @e[type=marker,tag=gm4_mu_snowy_trap] at @s if entity @a[gamemode=!spectator,gamemode=!creative,distance=..7] run function gm4_monsters_unbound:mob/process/reveal_snowy_trap

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/check_mob.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/check_mob.mcfunction
@@ -1,0 +1,17 @@
+# initiate newly spawned mobs (mobs without any tags)
+# @s = mobs that can be buffed
+# at @s
+# run from main
+
+# /!\ This function only runs if Survival Refightalized is not installed
+
+# pre-mark mob as processed if it spawned in the air (from a spawner), these do not get modified
+# mobs in the modify_in_air list are ignored here
+execute if block ~ ~-0.01 ~ #gm4:no_collision run tag @s[type=!#gm4_monsters_unbound:modify_in_air] add gm4_mu_processed
+
+# if the mob is riding another mob *do* modify them
+scoreboard players set $mounted gm4_mu_data 0
+execute if entity @s[tag=gm4_mu_processed] on vehicle run scoreboard players set $mounted gm4_mu_data 1
+execute if score $mounted gm4_mu_data matches 1 run tag @s remove gm4_mu_processed
+
+execute unless entity @s[tag=gm4_mu_processed] run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/blazing.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/blazing.mcfunction
@@ -11,10 +11,10 @@ attribute @s minecraft:attack_damage modifier add gm4_monsters_unbound:elite_buf
 attribute @s minecraft:movement_speed modifier add gm4_monsters_unbound:elite_buff.fire -0.45 add_multiplied_total
 attribute @s minecraft:burning_time modifier add gm4_monsters_unbound:elite_buff.fire -1 add_multiplied_total
 
-enchant @s[type=#gm4_survival_refightalized:skeleton_types] flame
-scoreboard players set @s[type=#gm4_survival_refightalized:skeleton_types] gm4_sr_arrow.damage_change -18
-scoreboard players add @s[type=#gm4_survival_refightalized:skeleton_types] gm4_sr_arrow.fire_delay 2
-item replace entity @s[type=!#gm4_survival_refightalized:skeleton_types] weapon.mainhand with blaze_rod[enchantments={fire_aspect:2}]
+enchant @s[type=#gm4_monsters_unbound:skeleton_types] flame
+scoreboard players set @s[type=#gm4_monsters_unbound:skeleton_types] gm4_sr_arrow.damage_change -18
+scoreboard players add @s[type=#gm4_monsters_unbound:skeleton_types] gm4_sr_arrow.fire_delay 2
+item replace entity @s[type=!#gm4_monsters_unbound:skeleton_types] weapon.mainhand with blaze_rod[enchantments={fire_aspect:2}]
 data modify entity @s drop_chances.mainhand set value 0
 
 item replace entity @s armor.head with magma_block[enchantments={binding_curse:1},enchantment_glint_override=false]

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/gargantuan.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/gargantuan.mcfunction
@@ -13,13 +13,13 @@ attribute @s minecraft:attack_knockback modifier add gm4_monsters_unbound:elite_
 attribute @s minecraft:water_movement_efficiency modifier add gm4_monsters_unbound:elite_buff.giant 0.85 add_value
 attribute @s minecraft:movement_speed modifier add gm4_monsters_unbound:elite_buff.giant -0.35 add_multiplied_total
 
-attribute @s[type=#gm4_survival_refightalized:skeleton_types] minecraft:scale modifier add gm4_monsters_unbound:elite_buff.giant_size 0.507537 add_multiplied_total
-attribute @s[type=!#gm4_survival_refightalized:skeleton_types] minecraft:scale modifier add gm4_monsters_unbound:elite_buff.giant_size 0.538461 add_multiplied_total
+attribute @s[type=#gm4_monsters_unbound:skeleton_types] minecraft:scale modifier add gm4_monsters_unbound:elite_buff.giant_size 0.507537 add_multiplied_total
+attribute @s[type=!#gm4_monsters_unbound:skeleton_types] minecraft:scale modifier add gm4_monsters_unbound:elite_buff.giant_size 0.538461 add_multiplied_total
 
-enchant @s[type=#gm4_survival_refightalized:skeleton_types] punch 2
-enchant @s[type=#gm4_survival_refightalized:skeleton_types] power 1
+enchant @s[type=#gm4_monsters_unbound:skeleton_types] punch 2
+enchant @s[type=#gm4_monsters_unbound:skeleton_types] power 1
 
-scoreboard players set @s[type=#gm4_survival_refightalized:skeleton_types] gm4_sr_arrow.fire_delay 7
+scoreboard players set @s[type=#gm4_monsters_unbound:skeleton_types] gm4_sr_arrow.fire_delay 7
 
 item replace entity @s armor.head with cobblestone[enchantment_glint_override=false,minecraft:enchantments={projectile_protection:5,binding_curse:1}] 1 
 data modify entity @s drop_chances.head set value 0

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/splitting.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/elite/type/splitting.mcfunction
@@ -8,8 +8,8 @@ tag @s add gm4_mu_elite.splitting
 
 attribute @s minecraft:max_health modifier add gm4_monsters_unbound:elite_buff.vorpal 2.5 add_multiplied_total
 
-loot replace entity @s[type=!#gm4_survival_refightalized:skeleton_types] armor.head loot gm4_monsters_unbound:elite/splitting_zombie
-loot replace entity @s[type=#gm4_survival_refightalized:skeleton_types] armor.head loot gm4_monsters_unbound:elite/splitting_skeleton
+loot replace entity @s[type=!#gm4_monsters_unbound:skeleton_types] armor.head loot gm4_monsters_unbound:elite/splitting_zombie
+loot replace entity @s[type=#gm4_monsters_unbound:skeleton_types] armor.head loot gm4_monsters_unbound:elite/splitting_skeleton
 data modify entity @s drop_chances.head set value 1
 
 team join gm4_mu_elite.splitting

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/initialize.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/initialize.mcfunction
@@ -1,0 +1,21 @@
+# initiate newly spawned mobs (mobs without any tags)
+# @s = mobs that can be buffed
+# at @s
+# run from mob/init/check_mob
+
+# /!\ This function only runs if Survival Refightalized is not installed
+
+scoreboard players reset $mob_extras gm4_sr_data
+
+# remove baby zombies except chicken jockeys (will be turned into Elites)
+scoreboard players set $was_baby gm4_mu_data 0
+execute if entity @s[type=zombie] if predicate {condition:"all_of",terms:[{condition:"entity_properties",entity:"this",predicate:{flags:{is_baby:1b}}},{condition:"inverted",term:{condition:"entity_properties",entity:"this",predicate:{vehicle:{}}}}]} store success score $was_baby gm4_mu_data run data modify entity @s IsBaby set value 0b
+execute if score $was_baby gm4_mu_data matches 1 run tag @s add gm4_sr_was_baby
+
+function gm4_monsters_unbound:mob/init/mob_type
+
+tag @s add gm4_mu_processed
+
+# process any spawned mobs (uses sr instead of mu to be compatible with survival_refightalized)
+execute if score $mob_extras gm4_sr_data matches 1.. unless entity @s[tag=gm4_sr_extra_mob] as @e[type=#gm4_monsters_unbound:modify,tag=gm4_sr_extra_mob] at @s run function gm4_monsters_unbound:mob/init/initialize
+tag @s remove gm4_sr_extra_mob

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type.mcfunction
@@ -1,12 +1,13 @@
 # check what mob is being processed
 # @s = mobs that can be buffed
 # at @s
+# run from mob/init/initialize
 # run from function call gm4_survival_refightalized:init_mob, from gm4_survival_refightalized:mob/init/initiate
 
 # zombie, zombie_villager, husk, drowned
-execute if entity @s[type=#gm4_survival_refightalized:zombie_types] run return run function gm4_monsters_unbound:mob/init/mob_type/zombie/base
+execute if entity @s[type=#gm4_monsters_unbound:zombie_types] run return run function gm4_monsters_unbound:mob/init/mob_type/zombie/base
 # skeleton, bogged, stray
-execute if entity @s[type=#gm4_survival_refightalized:skeleton_types,type=!wither_skeleton] run return run function gm4_monsters_unbound:mob/init/mob_type/skeleton/base
+execute if entity @s[type=#gm4_monsters_unbound:skeleton_types,type=!wither_skeleton] run return run function gm4_monsters_unbound:mob/init/mob_type/skeleton/base
 execute if entity @s[type=spider] run return run function gm4_monsters_unbound:mob/init/mob_type/spider/spider
 execute if entity @s[type=creeper] run return run function gm4_monsters_unbound:mob/init/mob_type/creeper/base
 execute if entity @s[type=cave_spider] run return run function gm4_monsters_unbound:mob/init/mob_type/spider/cave_spider

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/creeper/base.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/creeper/base.mcfunction
@@ -18,6 +18,6 @@ execute if entity @s[tag=gm4_mu_toxic_creeper] run function gm4_monsters_unbound
 # growth
 attribute @s[predicate=gm4_monsters_unbound:biome/growth] minecraft:movement_speed modifier add gm4_monsters_unbound:stat_change.growth 0.2 add_multiplied_base
 # underground
-data modify entity @s[predicate=gm4_survival_refightalized:mob/underground] ExplosionRadius set value 4s
+data modify entity @s[predicate=gm4_monsters_unbound:mob/underground] ExplosionRadius set value 4s
 # dripstone caves
 execute if biome ~ ~ ~ dripstone_caves if block ~.875 ~ ~.875 #gm4:no_collision if block ~.875 ~ ~-.875 #gm4:no_collision if block ~-.875 ~ ~.875 #gm4:no_collision if block ~-.875 ~ ~-.875 #gm4:no_collision run function gm4_monsters_unbound:mob/init/mob_type/creeper/dripstone_caves

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/enderman/base.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/enderman/base.mcfunction
@@ -11,10 +11,10 @@ execute if predicate gm4_monsters_unbound:biome/toxic if predicate {condition:"m
 # burned
 execute if entity @s[tag=!gm4_sr_extra_mob,predicate=gm4_monsters_unbound:biome/burned] store success score $mob_extras gm4_sr_data run summon enderman ~.05 ~ ~ {Tags:["gm4_sr_extra_mob"]}
 execute if entity @s[tag=!gm4_sr_extra_mob,predicate=gm4_monsters_unbound:biome/burned] store success score $mob_extras gm4_sr_data run summon enderman ~-.05 ~ ~.05 {Tags:["gm4_sr_extra_mob"]}
-# growth 
+# growth
 execute if predicate gm4_monsters_unbound:biome/growth run function gm4_monsters_unbound:mob/init/mob_type/enderman/growth
 # underground
-execute if entity @s[tag=!gm4_sr_extra_mob,predicate=gm4_survival_refightalized:mob/underground] if predicate {condition:"minecraft:random_chance",chance:0.15} run function gm4_monsters_unbound:mob/init/mob_type/enderman/underground
+execute if entity @s[tag=!gm4_sr_extra_mob,predicate=gm4_monsters_unbound:technical/underground] if predicate {condition:"minecraft:random_chance",chance:0.15} run function gm4_monsters_unbound:mob/init/mob_type/enderman/underground
 # dripstone caves
 execute if biome ~ ~ ~ dripstone_caves if block ~.875 ~ ~.875 #gm4:no_collision if block ~.875 ~ ~-.875 #gm4:no_collision if block ~-.875 ~ ~.875 #gm4:no_collision if block ~-.875 ~ ~-.875 #gm4:no_collision run function gm4_monsters_unbound:mob/init/mob_type/enderman/dripstone_caves
 

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/skeleton/base.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/skeleton/base.mcfunction
@@ -13,7 +13,7 @@ execute if entity @s[tag=gm4_mu_elite] run return run function gm4_monsters_unbo
 execute if entity @s[type=stray,predicate=gm4_monsters_unbound:biome/snowy,predicate=!gm4_monsters_unbound:biome/growth] run loot replace entity @s weapon.offhand loot gm4_monsters_unbound:mob/equip_arrow/stray_snowy
 # mountainous
 execute if predicate gm4_monsters_unbound:biome/mountainous positioned ~ ~35 ~ store result score $phantom_count gm4_mu_data if entity @e[type=phantom,distance=..32]
-execute if score $spawn_phantoms gm4_sr_config matches 1 if score $phantom_count gm4_mu_data < $mob_limit.phantom gm4_sr_config if predicate gm4_monsters_unbound:chance/spawn_phantom run function gm4_monsters_unbound:mob/init/mob_type/zombie/spawn_phantoms
+execute if score $spawn_phantoms gm4_mu_config matches 1 if score $phantom_count gm4_mu_data < $mob_limit.phantom gm4_mu_config if predicate gm4_monsters_unbound:chance/spawn_phantom run function gm4_monsters_unbound:mob/init/mob_type/zombie/spawn_phantoms
 # flowering
 execute if predicate {condition:"minecraft:all_of",terms:[{condition:"minecraft:random_chance",chance:0.85},{condition:"minecraft:reference",name:"gm4_monsters_unbound:biome/flowering"}]} run function gm4_monsters_unbound:mob/init/mob_type/skeleton/flowering
 # toxic
@@ -27,7 +27,7 @@ execute if entity @s[type=!bogged,predicate=gm4_monsters_unbound:biome/growth] r
 # dripstone caves
 execute if predicate {condition:"minecraft:all_of",terms:[{condition:"location_check",predicate:{biomes:"dripstone_caves"}},{condition:"random_chance",chance:0.6}]} run item replace entity @s weapon.mainhand with stone_pickaxe
 # underground
-execute if predicate gm4_survival_refightalized:mob/underground if predicate {condition:"minecraft:random_chance",chance:0.4} run function gm4_monsters_unbound:mob/init/mob_type/skeleton/underground
+execute if predicate gm4_monsters_unbound:technical/underground if predicate {condition:"minecraft:random_chance",chance:0.4} run function gm4_monsters_unbound:mob/init/mob_type/skeleton/underground
 
 # soul sand valley
 execute if biome ~ ~ ~ soul_sand_valley run effect give @s fire_resistance infinite 0 true

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/spider/spider.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/spider/spider.mcfunction
@@ -20,4 +20,4 @@ execute if entity @s[tag=!gm4_sr_extra_mob,predicate=gm4_monsters_unbound:biome/
 # dripstone caves
 execute if predicate {condition:"minecraft:all_of",terms:[{condition:"minecraft:random_chance",chance:0.1},{condition:"minecraft:location_check",predicate:{biomes:"dripstone_caves"}}]} run function gm4_monsters_unbound:mob/init/mob_type/spider/gargantuan
 # underground
-execute if predicate {condition:"minecraft:all_of",terms:[{condition:"minecraft:random_chance",chance:0.25},{condition:"minecraft:reference",name:"gm4_survival_refightalized:mob/underground"}]} run function gm4_monsters_unbound:mob/init/mob_type/spider/underground/pick
+execute if predicate {condition:"minecraft:all_of",terms:[{condition:"minecraft:random_chance",chance:0.25},{condition:"minecraft:reference",name:"gm4_monsters_unbound:technical/underground"}]} run function gm4_monsters_unbound:mob/init/mob_type/spider/underground/pick

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/base.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/base.mcfunction
@@ -28,4 +28,4 @@ execute if entity @s[type=!zombie_villager,tag=!gm4_mu_spore_zombie,predicate=gm
 # dripstone caves
 execute if entity @s[tag=!gm4_sr_extra_mob] if biome ~ ~ ~ dripstone_caves run function gm4_monsters_unbound:mob/init/mob_type/zombie/dripstone_caves/try
 # underground (not dripstone caves)
-execute if predicate {condition:"all_of",terms:[{condition:"reference",name:"gm4_survival_refightalized:mob/underground"},{condition:"inverted",term:{condition:"location_check",predicate:{"biomes":"dripstone_caves"}}},{condition:"random_chance",chance:0.5}]} run function gm4_monsters_unbound:mob/init/mob_type/zombie/underground/pick
+execute if predicate {condition:"all_of",terms:[{condition:"reference",name:"gm4_monsters_unbound:technical/underground"},{condition:"inverted",term:{condition:"location_check",predicate:{"biomes":"dripstone_caves"}}},{condition:"random_chance",chance:0.5}]} run function gm4_monsters_unbound:mob/init/mob_type/zombie/underground/pick

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/burned_husk.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/burned_husk.mcfunction
@@ -6,4 +6,4 @@
 attribute @s minecraft:max_health modifier add gm4_monsters_unbound:stat_change.burned_husk -0.65 add_multiplied_total
 attribute @s minecraft:attack_damage modifier add gm4_monsters_unbound:stat_change.burned_husk -0.25 add_multiplied_total
 execute at @p[gamemode=!spectator] store result score $husk_count gm4_mu_data if entity @e[type=husk,distance=..128]
-execute if entity @s[tag=!gm4_sr_extra_mob] unless score $husk_count gm4_mu_data > $mob_limit.husk_army gm4_sr_config run function gm4_monsters_unbound:mob/init/mob_type/zombie/burned_husk_army
+execute if entity @s[tag=!gm4_sr_extra_mob] unless score $husk_count gm4_mu_data > $mob_limit.husk_army gm4_mu_config run function gm4_monsters_unbound:mob/init/mob_type/zombie/burned_husk_army

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/mountainous.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/mountainous.mcfunction
@@ -4,7 +4,7 @@
 # run from mob/init/mob_type/zombie/base
 
 execute positioned ~ ~35 ~ store result score $phantom_count gm4_mu_data if entity @e[type=phantom,distance=..32]
-execute if score $spawn_phantoms gm4_sr_config matches 1 if score $phantom_count gm4_mu_data < $mob_limit.phantom gm4_sr_config if predicate gm4_monsters_unbound:chance/spawn_phantom run function gm4_monsters_unbound:mob/init/mob_type/zombie/spawn_phantoms
+execute if score $spawn_phantoms gm4_mu_config matches 1 if score $phantom_count gm4_mu_data < $mob_limit.phantom gm4_mu_config if predicate gm4_monsters_unbound:chance/spawn_phantom run function gm4_monsters_unbound:mob/init/mob_type/zombie/spawn_phantoms
 attribute @s minecraft:attack_knockback modifier add gm4_monsters_unbound:stat_change.mountainous 1 add_value
 attribute @s minecraft:attack_damage modifier add gm4_monsters_unbound:stat_change.mountainous 1 add_value
 

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/underground/replace_with_skeleton.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/init/mob_type/zombie/underground/replace_with_skeleton.mcfunction
@@ -3,6 +3,7 @@
 # at @s
 # run from mob/init/mob_type/zombie/underground/pick
 
+# gm4_sr_melee_skeleton tag is to avoid survival_refightalized treating this skeleton as holding a bow
 summon skeleton ~.05 ~ ~ {Tags:["gm4_sr_extra_mob","gm4_sr_melee_skeleton"],HandItems:[{},{}]}
 summon skeleton ~ ~ ~ {Tags:["gm4_sr_extra_mob","gm4_sr_melee_skeleton"],HandItems:[{},{}]}
 tp @s ~ ~-2050 ~

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/blazing/process.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/blazing/process.mcfunction
@@ -10,5 +10,5 @@ execute if score $has_target gm4_mu_data matches 0 run scoreboard players set @s
 scoreboard players set @s[scores={gm4_mu_timer=10..}] gm4_mu_timer 0
 
 execute if score @s gm4_mu_timer matches 3 anchored eyes positioned ^ ^-0.25 ^ on target facing entity @s eyes rotated ~ -75 summon block_display run function gm4_monsters_unbound:mob/process/elite/blazing/init_flare
-execute if score @s[type=#gm4_survival_refightalized:zombie_types] gm4_mu_timer matches 4 anchored eyes positioned ^ ^-0.25 ^ on target facing entity @s eyes rotated ~90 -75 summon block_display run function gm4_monsters_unbound:mob/process/elite/blazing/init_flare
-execute if score @s[type=#gm4_survival_refightalized:zombie_types] gm4_mu_timer matches 5 anchored eyes positioned ^ ^-0.25 ^ on target facing entity @s eyes rotated ~-90 -75 summon block_display run function gm4_monsters_unbound:mob/process/elite/blazing/init_flare
+execute if score @s[type=#gm4_monsters_unbound:zombie_types] gm4_mu_timer matches 4 anchored eyes positioned ^ ^-0.25 ^ on target facing entity @s eyes rotated ~90 -75 summon block_display run function gm4_monsters_unbound:mob/process/elite/blazing/init_flare
+execute if score @s[type=#gm4_monsters_unbound:zombie_types] gm4_mu_timer matches 5 anchored eyes positioned ^ ^-0.25 ^ on target facing entity @s eyes rotated ~-90 -75 summon block_display run function gm4_monsters_unbound:mob/process/elite/blazing/init_flare

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/gargantuan/update_stats.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/gargantuan/update_stats.mcfunction
@@ -13,11 +13,11 @@ scoreboard players operation $curr_health gm4_mu_data /= $max_health gm4_mu_data
 scoreboard players set $curr_health_percent_lost gm4_mu_data 100
 scoreboard players operation $curr_health_percent_lost gm4_mu_data -= $curr_health gm4_mu_data
 
-execute if score $curr_health_percent_lost gm4_mu_data matches 50.. run effect give @s[type=!#gm4_survival_refightalized:skeleton_types] minecraft:resistance infinite 0 true
-execute if score $curr_health_percent_lost gm4_mu_data matches 75.. run effect give @s[type=!#gm4_survival_refightalized:skeleton_types] minecraft:resistance infinite 1 true
+execute if score $curr_health_percent_lost gm4_mu_data matches 50.. run effect give @s[type=!#gm4_monsters_unbound:skeleton_types] minecraft:resistance infinite 0 true
+execute if score $curr_health_percent_lost gm4_mu_data matches 75.. run effect give @s[type=!#gm4_monsters_unbound:skeleton_types] minecraft:resistance infinite 1 true
 
-execute if score $curr_health_percent_lost gm4_mu_data matches 50.. run scoreboard players set @s[type=#gm4_survival_refightalized:skeleton_types] gm4_sr_arrow.fire_delay 4
-execute if score $curr_health_percent_lost gm4_mu_data matches 75.. run scoreboard players set @s[type=#gm4_survival_refightalized:skeleton_types] gm4_sr_arrow.fire_delay 6
+execute if score $curr_health_percent_lost gm4_mu_data matches 50.. run scoreboard players set @s[type=#gm4_monsters_unbound:skeleton_types] gm4_sr_arrow.fire_delay 4
+execute if score $curr_health_percent_lost gm4_mu_data matches 75.. run scoreboard players set @s[type=#gm4_monsters_unbound:skeleton_types] gm4_sr_arrow.fire_delay 6
 
 execute store result storage gm4_monsters_unbound:temp set.speed float 0.015 run scoreboard players get $curr_health_percent_lost gm4_mu_data
 execute store result storage gm4_monsters_unbound:temp set.damage float 0.005 run scoreboard players get $curr_health_percent_lost gm4_mu_data

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/splitting/init_entity.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/splitting/init_entity.mcfunction
@@ -12,7 +12,7 @@ attribute @s minecraft:max_health modifier add gm4_monsters_unbound:split_entity
 attribute @s minecraft:scale modifier add gm4_monsters_unbound:split_entity -0.5 add_multiplied_total
 attribute @s minecraft:step_height modifier add gm4_monsters_unbound:split_entity -0.5 add_multiplied_total
 attribute @s minecraft:movement_speed modifier add gm4_monsters_unbound:split_entity 0.33 add_multiplied_total
-attribute @s[type=#gm4_survival_refightalized:skeleton_types] minecraft:follow_range modifier add gm4_monsters_unbound:split_entity -0.66 add_multiplied_total
+attribute @s[type=#gm4_monsters_unbound:skeleton_types] minecraft:follow_range modifier add gm4_monsters_unbound:split_entity -0.66 add_multiplied_total
 
 scoreboard players set @s gm4_sr_arrow.fire_delay 6
 scoreboard players set @s gm4_sr_arrow.damage_change -14
@@ -25,11 +25,12 @@ execute store result entity @s Motion[2] double 0.01 run random value -30..30
 
 tag @s add gm4_mu_elite.split_entity
 tag @s add gm4_mu_split_entity
-execute if dimension minecraft:overworld run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
-execute unless dimension minecraft:overworld run function gm4_survival_refightalized:mob/init/calc_difficulty_else
+execute if score gm4_survival_refightalized load.status matches 1.. if dimension minecraft:overworld run function gm4_survival_refightalized:mob/init/calc_difficulty_overworld
+execute if score gm4_survival_refightalized load.status matches 1.. unless dimension minecraft:overworld run function gm4_survival_refightalized:mob/init/calc_difficulty_else
+execute unless score gm4_survival_refightalized load.status matches 1.. run function gm4_monsters_unbound:mob/init/initialize
 
 item replace entity @s armor.head with spawner
 data modify entity @s drop_chances.head set value 0
 
 team join gm4_mu_elite.split
-execute if score $has_bow gm4_mu_data matches 0 run item replace entity @s[type=#gm4_survival_refightalized:skeleton_types] weapon.mainhand with wooden_sword
+execute if score $has_bow gm4_mu_data matches 0 run item replace entity @s[type=#gm4_monsters_unbound:skeleton_types] weapon.mainhand with wooden_sword

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/activate.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/activate.mcfunction
@@ -7,7 +7,7 @@ execute anchored eyes positioned ^ ^-1.15 ^ run particle gust_emitter_small ~ ~ 
 playsound minecraft:entity.breeze.wind_burst hostile @a ~ ~ ~ 1 0
 
 # skeletons shoot arrows instead of speed burst
-execute if entity @s[type=#gm4_survival_refightalized:skeleton_types] run return run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/start
+execute if entity @s[type=#gm4_monsters_unbound:skeleton_types] run return run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/start
 
 summon breeze_wind_charge ~ ~ ~ {Motion:[0.0,-5.0,0.0]}
 attribute @s minecraft:movement_speed modifier remove gm4_monsters_unbound:elite_buff.speed.charging

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/process.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/process.mcfunction
@@ -5,7 +5,7 @@
 
 scoreboard players set $has_target gm4_mu_data 0
 execute on target run scoreboard players set $has_target gm4_mu_data 1
-execute if entity @s[type=#gm4_survival_refightalized:skeleton_types,scores={gm4_mu_timer=1..}] run scoreboard players set $has_target gm4_mu_data 1
+execute if entity @s[type=#gm4_monsters_unbound:skeleton_types,scores={gm4_mu_timer=1..}] run scoreboard players set $has_target gm4_mu_data 1
 
 # no target
 execute if score $has_target gm4_mu_data matches 0 if score @s gm4_mu_timer matches -2147483648..2147483647 run function gm4_monsters_unbound:mob/process/elite/zephyr/lose_charge
@@ -23,6 +23,6 @@ execute if score @s gm4_mu_timer matches 3 run playsound minecraft:entity.breeze
 execute if score @s gm4_mu_timer matches 4 run playsound minecraft:entity.breeze.idle_air hostile @a ~ ~ ~ 1 0.65
 
 execute if score @s gm4_mu_timer matches 5 run function gm4_monsters_unbound:mob/process/elite/zephyr/activate
-execute if score @s[type=#gm4_survival_refightalized:skeleton_types] gm4_mu_timer matches 6..10 run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/arrow_burst
+execute if score @s[type=#gm4_monsters_unbound:skeleton_types] gm4_mu_timer matches 6..10 run function gm4_monsters_unbound:mob/process/elite/zephyr/skeleton/arrow_burst
 
 scoreboard players reset @s[scores={gm4_mu_timer=14..},tag=!gm4_mu_charging_attack] gm4_mu_timer

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/skeleton/init_arrow.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/elite/zephyr/skeleton/init_arrow.mcfunction
@@ -3,7 +3,7 @@
 # at @s
 # run from mob/process/elite/zephyr/skeleton/arrow_burst
 
-# don't process this arrow
+# don't process this arrow in survival_refightalized
 tag @s add gm4_sr_arrow_checked
 
 # arrow deals half damage

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/reveal_dripstone_trap.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/reveal_dripstone_trap.mcfunction
@@ -18,4 +18,5 @@ execute if score $pick_entity gm4_mu_data matches 1 run summon skeleton ~ ~-0.8 
 execute if score $pick_entity gm4_mu_data matches 2 run summon zombie ~ ~-0.8 ~ {Tags:["gm4_sr_extra_mob"],Motion:[0.0d,-0.275d,0.0d],attributes:[{id:"fall_damage_multiplier",base:1,modifiers:[{id:"gm4_monsters_unbound:stat_change.dripstone_trap",amount:-0.95,operation:"add_multiplied_total"}]}]}
 execute if score $pick_entity gm4_mu_data matches 3 run summon spider ~ ~ ~ {Tags:["gm4_sr_extra_mob"],Motion:[0.0d,-0.275d,0.0d],attributes:[{id:"fall_damage_multiplier",base:1,modifiers:[{id:"gm4_monsters_unbound:stat_change.dripstone_trap",amount:-0.95,operation:"add_multiplied_total"}]}]}
 
-execute as @e[type=#gm4_survival_refightalized:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_survival_refightalized:mob/init/initiate
+execute if score gm4_survival_refightalized load.status matches 1.. as @e[type=#gm4_monsters_unbound:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_survival_refightalized:mob/init/initiate
+execute unless score gm4_survival_refightalized load.status matches 1.. as @e[type=#gm4_monsters_unbound:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/reveal_snowy_trap.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/reveal_snowy_trap.mcfunction
@@ -17,4 +17,5 @@ execute if score $pick_entity gm4_mu_data matches 1 run summon zombie ~ ~-0.75 ~
 execute if score $pick_entity gm4_mu_data matches 2 run summon stray ~ ~-0.75 ~ {Tags:["gm4_sr_extra_mob"],Motion:[0.0d,0.5d,0.0d]}
 execute if score $pick_entity gm4_mu_data matches 3 run summon creeper ~ ~-0.75 ~ {Tags:["gm4_sr_extra_mob"],Motion:[0.0d,0.5d,0.0d]}
 
-execute as @e[type=#gm4_survival_refightalized:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_survival_refightalized:mob/init/initiate
+execute if score gm4_survival_refightalized load.status matches 1.. as @e[type=#gm4_monsters_unbound:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_survival_refightalized:mob/init/initiate
+execute unless score gm4_survival_refightalized load.status matches 1.. as @e[type=#gm4_monsters_unbound:modify,tag=gm4_sr_extra_mob,distance=..1,limit=1] at @s run function gm4_monsters_unbound:mob/init/initialize

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/spore/activate.mcfunction
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/function/mob/process/spore/activate.mcfunction
@@ -4,9 +4,9 @@
 # run from mob/process/spore/advance
 
 # check for mob cap
-execute at @p[gamemode=!spectator] store result score $spore_zombie_count gm4_mu_data if entity @e[type=#gm4_survival_refightalized:zombie_types,tag=gm4_mu_spore_mob,distance=..32]
-execute if score $spore_zombie_count gm4_mu_data > $mob_limit.spore_zombie gm4_sr_config run kill @s
-execute if score $spore_zombie_count gm4_mu_data > $mob_limit.spore_zombie gm4_sr_config run return 0
+execute at @p[gamemode=!spectator] store result score $spore_zombie_count gm4_mu_data if entity @e[type=#gm4_monsters_unbound:zombie_types,tag=gm4_mu_spore_mob,distance=..32]
+execute if score $spore_zombie_count gm4_mu_data > $mob_limit.spore_zombie gm4_mu_config run kill @s
+execute if score $spore_zombie_count gm4_mu_data > $mob_limit.spore_zombie gm4_mu_config run return 0
 
 # get spores in stack and their generation
 execute store result score $spore_count gm4_mu_data run data get entity @s Item.count

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/guidebook/monsters_unbound.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/guidebook/monsters_unbound.json
@@ -12,7 +12,7 @@
         "player": [
           {
             "condition": "minecraft:reference",
-            "name": "gm4_survival_refightalized:mob/underground"
+            "name": "gm4_monsters_unbound:technical/underground"
           }
         ]
       }

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/burned.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/burned.json
@@ -3,7 +3,7 @@
     "condition": "minecraft:inverted",
     "term": {
       "condition": "minecraft:reference",
-      "name": "gm4_survival_refightalized:mob/underground"
+      "name": "gm4_monsters_unbound:technical/underground"
     }
   },
   {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/flowering.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/flowering.json
@@ -15,7 +15,7 @@
             "condition": "minecraft:inverted",
             "term": {
               "condition": "minecraft:reference",
-              "name": "gm4_survival_refightalized:mob/underground"
+              "name": "gm4_monsters_unbound:technical/underground"
             }
           },
           {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/growth.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/growth.json
@@ -3,7 +3,7 @@
     "condition": "minecraft:inverted",
     "term": {
       "condition": "minecraft:reference",
-      "name": "gm4_survival_refightalized:mob/underground"
+      "name": "gm4_monsters_unbound:technical/underground"
     }
   },
   {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/mountainous.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/mountainous.json
@@ -3,7 +3,7 @@
     "condition": "minecraft:inverted",
     "term": {
       "condition": "minecraft:reference",
-      "name": "gm4_survival_refightalized:mob/underground"
+      "name": "gm4_monsters_unbound:technical/underground"
     }
   },
   {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/reef.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/reef.json
@@ -6,7 +6,7 @@
         "condition": "minecraft:inverted",
         "term": {
           "condition": "minecraft:reference",
-          "name": "gm4_survival_refightalized:mob/underground"
+          "name": "gm4_monsters_unbound:technical/underground"
         }
       },
       {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/snowy.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/snowy.json
@@ -3,7 +3,7 @@
     "condition": "minecraft:inverted",
     "term": {
       "condition": "minecraft:reference",
-      "name": "gm4_survival_refightalized:mob/underground"
+      "name": "gm4_monsters_unbound:technical/underground"
     }
   },
   {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/toxic.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/biome/toxic.json
@@ -3,7 +3,7 @@
     "condition": "minecraft:inverted",
     "term": {
       "condition": "minecraft:reference",
-      "name": "gm4_survival_refightalized:mob/underground"
+      "name": "gm4_monsters_unbound:technical/underground"
     }
   },
   {

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/technical/underground.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/predicate/technical/underground.json
@@ -1,0 +1,22 @@
+[
+    {
+        "condition": "minecraft:inverted",
+        "term": {
+            "condition": "minecraft:location_check",
+            "predicate": {
+                "block": {
+                    "blocks": "#gm4:water"
+                }
+            }
+        }
+    },
+    {
+        "condition": "minecraft:location_check",
+        "offsetY": 1,
+        "predicate": {
+            "light": {
+                "light": 0
+            }
+        }
+    }
+]

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/modify.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/modify.json
@@ -1,0 +1,20 @@
+{
+    "values": [
+        "minecraft:bogged",
+        "minecraft:cave_spider",
+        "minecraft:creeper",
+        "minecraft:drowned",
+        "minecraft:enderman",
+        "minecraft:husk",
+        "minecraft:phantom",
+        "minecraft:piglin",
+        "minecraft:silverfish",
+        "minecraft:skeleton",
+        "minecraft:spider",
+        "minecraft:stray",
+        "minecraft:wither_skeleton",
+        "minecraft:zombie",
+        "minecraft:zombie_villager",
+        "minecraft:zombified_piglin"
+    ]
+}

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/modify_in_air.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/modify_in_air.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        "minecraft:cave_spider",
+        "minecraft:drowned",
+        "minecraft:phantom",
+        "minecraft:silverfish"
+    ]
+}

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/skeleton_types.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/skeleton_types.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        "minecraft:bogged",
+        "minecraft:skeleton",
+        "minecraft:stray",
+        "minecraft:wither_skeleton"
+    ]
+}

--- a/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/zombie_types.json
+++ b/gm4_monsters_unbound/data/gm4_monsters_unbound/tags/entity_type/zombie_types.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        "minecraft:drowned",
+        "minecraft:husk",
+        "minecraft:zombie",
+        "minecraft:zombie_villager"
+    ]
+}


### PR DESCRIPTION
This PR makes Monsters Unbound no longer require Survival Refightalized to work.

There should not be any changes in actual functionality of either module