### PR TITLE
fix relocator recipe in guidebook

### DIFF
--- a/gm4_relocators/data/gm4_relocators/gm4_recipes/relocator.json
+++ b/gm4_relocators/data/gm4_relocators/gm4_recipes/relocator.json
@@ -2,13 +2,13 @@
   "input": {
     "type": "shaped",
     "recipe": [
-      "OSO",
+      "CSC",
       "ABA",
-      "OSO"
+      "CSC"
     ],
     "key": {
-      "O": {
-        "item": "minecraft:obsidian"
+      "C": {
+        "item": "minecraft:crying_obsidian"
       },
       "S": {
         "item": "minecraft:shulker_shell"


### PR DESCRIPTION
The guidebook shows that the relocator is crafted with obsidian, but it's supposed to be crying obsidian