### PR TITLE
[1.21] Add bogged to `#gm4:undead` for Metallurgy and Orb of Ankou

### DIFF
--- a/gm4_metallurgy/data/gm4/tags/entity_type/undead.json
+++ b/gm4_metallurgy/data/gm4/tags/entity_type/undead.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "minecraft:bogged",
         "minecraft:drowned",
         "minecraft:husk",
         "minecraft:phantom",

--- a/gm4_orb_of_ankou/data/gm4/tags/entity_type/undead.json
+++ b/gm4_orb_of_ankou/data/gm4/tags/entity_type/undead.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "minecraft:bogged",
         "minecraft:drowned",
         "minecraft:husk",
         "minecraft:phantom",


### PR DESCRIPTION
This tag wasn't updated for these modules.
There exists a `#gm4:undead` in Combat Expanded, but for this version CE is hidden, so it is not included in this PR.