### PR TITLE
Live Catch - Add salmon sizes

### DIFF
--- a/gm4_live_catch/data/gm4_live_catch/function/fish/salmon/summon.mcfunction
+++ b/gm4_live_catch/data/gm4_live_catch/function/fish/salmon/summon.mcfunction
@@ -14,7 +14,10 @@ execute store result storage gm4_live_catch:temp/output Target.Motion[1] double 
 execute store result storage gm4_live_catch:temp/output Target.Motion[2] double 0.0001 run data get storage gm4_live_catch:temp/input Target.Motion[2] 15000
 
 # summon fish / store data
-summon salmon ~ ~1 ~ {Health:1f,Tags:["gm4_lc_salmon_new"]}
+execute store result score $salmon_size gm4_live_catch.data run random value 1..1000
+execute if score $salmon_size gm4_live_catch.data matches 1..316 run summon salmon ~ ~1 ~ {Health:1f,Tags:["gm4_lc_salmon_new"],type:"small"}
+execute if score $salmon_size gm4_live_catch.data matches 317..842 run summon salmon ~ ~1 ~ {Health:1f,Tags:["gm4_lc_salmon_new"],type:"medium"}
+execute if score $salmon_size gm4_live_catch.data matches 843..1000 run summon salmon ~ ~1 ~ {Health:1f,Tags:["gm4_lc_salmon_new"],type:"large"}
 data modify entity @e[type=salmon,limit=1,tag=gm4_lc_salmon_new] {} merge from storage gm4_live_catch:temp/output Target
 
 # remove 

--- a/gm4_live_catch/data/gm4_live_catch/function/init.mcfunction
+++ b/gm4_live_catch/data/gm4_live_catch/function/init.mcfunction
@@ -3,6 +3,6 @@ execute unless score live_catch gm4_modules matches 1 run data modify storage gm
 execute unless score live_catch gm4_earliest_version < live_catch gm4_modules run scoreboard players operation live_catch gm4_earliest_version = live_catch gm4_modules
 scoreboard players set live_catch gm4_modules 1
 
-
+scoreboard objectives add gm4_live_catch.data dummy
 
 #$moduleUpdateList


### PR DESCRIPTION
Adds salmon sizes (added in 1.21.2) to live catch.
The chances of each are pulled from the [minecraft wiki](https://minecraft.wiki/w/Salmon#Spawning).
> 31.6% spawn as small, 52.6% spawn as normal, and 15.8% spawn as large.