### PR TITLE
Fix : Enable Orbis Dungeon Loot Table for Enchanted Books

### DIFF
--- a/pfb_orbis/data/gm4_orbis/loot_table/chests/dungeon.json
+++ b/pfb_orbis/data/gm4_orbis/loot_table/chests/dungeon.json
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "rolls": 0,
+      "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",


### PR DESCRIPTION
This loot pool has `"rolls":0` ? I think that means it doesn't run at all. Which means since #790 there's been no enchanted books in the dungeon loot table. 

More discussion likely needed, since this is a really old bug.