### PR TITLE
Mob Curing 1.21.5: Adds new potions to Potion Cleric trades

### DIFF
--- a/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/drinkable.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/drinkable.json
@@ -43,6 +43,17 @@
           "functions": [
             {
               "function": "minecraft:set_potion",
+              "id": "minecraft:infested"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
               "id": "minecraft:invisibility"
             }
           ]
@@ -91,6 +102,17 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:night_vision"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:oozing"
             }
           ]
         },
@@ -168,6 +190,39 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:water_breathing"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weakness"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weaving"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:wind_charged"
             }
           ]
         },

--- a/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/lingering.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/lingering.json
@@ -39,6 +39,17 @@
         {
           "type": "minecraft:item",
           "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:infested"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
           "name": "minecraft:lingering_potion",
           "functions": [
             {
@@ -91,6 +102,17 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:night_vision"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:oozing"
             }
           ]
         },
@@ -168,6 +190,39 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:water_breathing"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weakness"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weaving"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:wind_charged"
             }
           ]
         },

--- a/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/splash.json
+++ b/gm4_mob_curing/data/gm4_mob_curing/loot_table/technical/potion_cleric/base/splash.json
@@ -39,6 +39,17 @@
         {
           "type": "minecraft:item",
           "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:infested"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
           "name": "minecraft:splash_potion",
           "functions": [
             {
@@ -91,6 +102,17 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:night_vision"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:oozing"
             }
           ]
         },
@@ -168,6 +190,39 @@
             {
               "function": "minecraft:set_potion",
               "id": "minecraft:water_breathing"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weakness"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:weaving"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:potion",
+          "functions": [
+            {
+              "function": "minecraft:set_potion",
+              "id": "minecraft:wind_charged"
             }
           ]
         },


### PR DESCRIPTION
Adds the 4 newer potions (Infested, Oozing, Weaving, and Wind Charged) to the Potion Cleric's trade options.

Additionally, adds lv1 weakness to the trade options because it was missing.  I can't remember if there was a reason for this.