### PR TITLE
Decrease Orbis Tower Frequency

### DIFF
--- a/gm4_tower_structures/data/gm4_tower_structures/worldgen/structure_set/towers.json
+++ b/gm4_tower_structures/data/gm4_tower_structures/worldgen/structure_set/towers.json
@@ -40,7 +40,8 @@
   "placement": {
     "type": "minecraft:random_spread",
     "salt": 1948932716,
-    "spacing": 13,
-    "separation": 5
+    "spacing": 30,
+    "separation": 12,
+    "frequency": 0.8
   }
 }


### PR DESCRIPTION
Closes #1195 

Updates the orbis tower structure set to dramatically reduce the frequency.
Currently, in a 512*512 block region, there is an average of 7 ish towers. This PR changes that to around 1. They are still somewhat common, but not so much that you're constantly tripping over them.