### PR TITLE
Crossbow Cartridges 1.21: Torch place fix #2

### DIFF
--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/redstone_torch/place.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/redstone_torch/place.mcfunction
@@ -3,8 +3,8 @@
 # at @s
 # run from projectile/redstone_torch/check
 
-execute positioned ~.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.1 ~ ~ minecraft:redstone_wall_torch[facing=west]
-execute positioned ~ ~ ~.05 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.1 minecraft:redstone_wall_torch[facing=north]
-execute positioned ~-.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.1 ~ ~ minecraft:redstone_wall_torch[facing=east]
-execute positioned ~ ~ ~-.05 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.1 minecraft:redstone_wall_torch[facing=south]
-execute positioned ~ ~-.05 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.1 ~ minecraft:redstone_torch
+execute positioned ~.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.15 ~ ~ minecraft:redstone_wall_torch[facing=west]
+execute positioned ~ ~ ~.1 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.15 minecraft:redstone_wall_torch[facing=north]
+execute positioned ~-.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.15 ~ ~ minecraft:redstone_wall_torch[facing=east]
+execute positioned ~ ~ ~-.1 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.15 minecraft:redstone_wall_torch[facing=south]
+execute positioned ~ ~-.1 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.15 ~ minecraft:redstone_torch

--- a/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/soul_torch/place.mcfunction
+++ b/gm4_crossbow_cartridges/data/gm4_crossbow_cartridges/function/projectile/soul_torch/place.mcfunction
@@ -3,8 +3,8 @@
 # at @s
 # run from projectile/soul_torch/check
 
-execute positioned ~.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.1 ~ ~ minecraft:soul_wall_torch[facing=west]
-execute positioned ~ ~ ~.05 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.1 minecraft:soul_wall_torch[facing=north]
-execute positioned ~-.05 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.1 ~ ~ minecraft:soul_wall_torch[facing=east]
-execute positioned ~ ~ ~-.05 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.1 minecraft:soul_wall_torch[facing=south]
-execute positioned ~ ~-.05 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.1 ~ minecraft:soul_torch
+execute positioned ~.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/east run setblock ~-.15 ~ ~ minecraft:soul_wall_torch[facing=west]
+execute positioned ~ ~ ~.1 if predicate gm4_crossbow_cartridges:check_block/south run setblock ~ ~ ~-.15 minecraft:soul_wall_torch[facing=north]
+execute positioned ~-.1 ~ ~ if predicate gm4_crossbow_cartridges:check_block/west run setblock ~.15 ~ ~ minecraft:soul_wall_torch[facing=east]
+execute positioned ~ ~ ~-.1 if predicate gm4_crossbow_cartridges:check_block/north run setblock ~ ~ ~.15 minecraft:soul_wall_torch[facing=south]
+execute positioned ~ ~-.1 ~ if predicate gm4_crossbow_cartridges:check_block/below run setblock ~ ~.15 ~ minecraft:soul_torch


### PR DESCRIPTION
Continuation #1081 , but for 1.21 branch
Soul torch and redstone torch were forgotten