### PR TITLE
End Fishing - Remove `OnGround` player NBT check from `main`

### DIFF
--- a/gm4_end_fishing/data/gm4_end_fishing/function/enderpuff/process.mcfunction
+++ b/gm4_end_fishing/data/gm4_end_fishing/function/enderpuff/process.mcfunction
@@ -6,6 +6,6 @@ tag @s remove gm4_enderpuff_equipped
 tag @s[predicate=gm4_end_fishing:holding_enderpuff] add gm4_enderpuff_equipped
 
 # apply levitation
-execute if predicate {condition:"minecraft:entity_properties",entity:"this",predicate:{flags:{is_on_ground:1b}}} run tag @s remove gm4_enderpuff_used
+execute if predicate gm4_end_fishing:on_ground run tag @s remove gm4_enderpuff_used
 execute if entity @s[tag=gm4_enderpuff_equipped,tag=!gm4_enderpuff_used] run function gm4_end_fishing:enderpuff/apply_levitation
 execute if entity @s[tag=gm4_enderpuff_levitation,tag=!gm4_enderpuff_equipped] run function gm4_end_fishing:enderpuff/clear_levitation

--- a/gm4_end_fishing/data/gm4_end_fishing/function/main.mcfunction
+++ b/gm4_end_fishing/data/gm4_end_fishing/function/main.mcfunction
@@ -5,6 +5,6 @@ execute as @a[tag=gm4_enderpuff_levitation,tag=!gm4_has_enderpuff] at @s run fun
 execute as @a[tag=gm4_has_enderpuff] at @s run function gm4_end_fishing:enderpuff/process
 
 effect give @a[tag=gm4_ef_fall] slow_falling 1 0
-tag @a[tag=gm4_ef_fall,nbt={OnGround:0b}] remove gm4_ef_fall
+tag @a[tag=gm4_ef_fall,predicate=!gm4_end_fishing:on_ground] remove gm4_ef_fall
 
 schedule function gm4_end_fishing:main 16t

--- a/gm4_end_fishing/data/gm4_end_fishing/predicate/on_ground.json
+++ b/gm4_end_fishing/data/gm4_end_fishing/predicate/on_ground.json
@@ -1,0 +1,9 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "flags": {
+      "is_on_ground": true
+    }
+  }
+}


### PR DESCRIPTION
Needed a predicate file for use in the selector; also swapped out the `enderpuff/process` predicate to refer to this file.

I am considering a PR to swap every `OnGround` nbt check over to a predicate where it makes sense. I was thinking about it because for metallurgy (#1192) I've already done a predicate conversion like this PR and there are more modules that are still using the nbt `OnGround` where they don't need to. If there's interest in that, I can cannibalize this PR for that and create a `gm4:on_ground` predicate in base. 