### PR TITLE
Fix Boots of Ostara not blocking Desire Lines

### DIFF
--- a/gm4_boots_of_ostara/data/gm4_boots_of_ostara/function/block_desire_lines.mcfunction
+++ b/gm4_boots_of_ostara/data/gm4_boots_of_ostara/function/block_desire_lines.mcfunction
@@ -1,1 +1,6 @@
-scoreboard players set @s[predicate=gm4_boots_of_ostara:boots_equipped] gm4_desire_lines 0
+# @s = any survival player
+# at unspecified
+# run from #gm4_desire_lines:expansion
+
+# semi-ensure desire lines is disabled ($probability should only be modified NOT SET, as the modification order is load dependent)
+execute if predicate gm4_boots_of_ostara:boots_equipped run scoreboard players remove $probability gm4_desire_lines 1000


### PR DESCRIPTION
The blocking function wasn't properly updated with the Desire Lines rework