### PR TITLE
Add settings to Desire Lines

### DIFF
--- a/base/data/gm4/tags/block/grass.json
+++ b/base/data/gm4/tags/block/grass.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:short_grass",
+    "minecraft:tall_grass",
+    "minecraft:short_dry_grass",
+    "minecraft:tall_dry_grass",
+    "minecraft:bush",
+    "minecraft:dead_bush",
+    "minecraft:fern",
+    "minecraft:large_fern"
+  ]
+}

--- a/gm4_desire_lines/data/gm4_desire_lines/function/config.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/config.mcfunction
@@ -1,0 +1,12 @@
+tellraw @s {text:"          "}
+tellraw @s {text:"----------------------", color:"#4AA0C7"}
+tellraw @s {text:" Desire Lines Config ",color:"#a0dcf7",bold:true}
+
+execute if score ?break_flowers gm4_desire_lines matches 1 run tellraw @s ["Destroy Flowers: ",{"bold":true,"click_event":{"action":"run_command","command":"function gm4_desire_lines:config/set {'id':1}"},"color":"green","hover_event":{"action":"show_text","value":[{"text":"Toggle OFF","color":"red"}]},"text":"ON"}]
+execute if score ?break_flowers gm4_desire_lines matches 0 run tellraw @s ["Destroy Flowers: ",{"bold":true,"click_event":{"action":"run_command","command":"function gm4_desire_lines:config/set {'id':2}"},"color":"red","hover_event":{"action":"show_text","value":[{"text":"Toggle ON","color":"green"}]},"text":"OFF"}]
+
+execute if score ?break_grass gm4_desire_lines matches 1 run tellraw @s ["Destroy Grass: ",{"bold":true,"click_event":{"action":"run_command","command":"function gm4_desire_lines:config/set {'id':3}"},"color":"green","hover_event":{"action":"show_text","value":[{"text":"Toggle OFF","color":"red"}]},"text":"ON"}]
+execute if score ?break_grass gm4_desire_lines matches 0 run tellraw @s ["Destroy Grass: ",{"bold":true,"click_event":{"action":"run_command","command":"function gm4_desire_lines:config/set {'id':4}"},"color":"red","hover_event":{"action":"show_text","value":[{"text":"Toggle ON","color":"green"}]},"text":"OFF"}]
+
+tellraw @s {text:"----------------------", color:"#4AA0C7"}
+tellraw @s {text:"          "}

--- a/gm4_desire_lines/data/gm4_desire_lines/function/config/set.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/config/set.mcfunction
@@ -1,0 +1,10 @@
+$scoreboard players set #temp gm4_desire_lines $(id)
+
+execute if score #temp gm4_desire_lines matches 1 run scoreboard players set ?break_flowers gm4_desire_lines 0
+execute if score #temp gm4_desire_lines matches 2 run scoreboard players set ?break_flowers gm4_desire_lines 1
+execute if score #temp gm4_desire_lines matches 3 run scoreboard players set ?break_grass gm4_desire_lines 0
+execute if score #temp gm4_desire_lines matches 4 run scoreboard players set ?break_grass gm4_desire_lines 1
+
+function gm4_desire_lines:config
+
+scoreboard players reset #temp gm4_desire_lines

--- a/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/init.mcfunction
@@ -7,6 +7,10 @@ scoreboard players set #sneak_penality gm4_desire_lines -5
 scoreboard players set #sprint_penalty gm4_desire_lines 3
 scoreboard players set #impact_penalty gm4_desire_lines 8
 
+# settings
+scoreboard players add ?break_flowers gm4_desire_lines 0
+scoreboard players add ?break_grass gm4_desire_lines 0
+
 execute unless score desire_lines gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Desire Lines"}
 execute unless score desire_lines gm4_earliest_version < desire_lines gm4_modules run scoreboard players operation desire_lines gm4_earliest_version = desire_lines gm4_modules
 scoreboard players set desire_lines gm4_modules 1

--- a/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
+++ b/gm4_desire_lines/data/gm4_desire_lines/function/path.mcfunction
@@ -14,7 +14,8 @@ fill ~ ~-0.06 ~ ~ ~-0.06 ~ frosted_ice[age=2] replace frosted_ice[age=1]
 fill ~ ~-0.06 ~ ~ ~-0.06 ~ frosted_ice[age=1] replace frosted_ice[age=0]
 
 # remove foliage
-execute if block ~ ~ ~ #gm4:foliage unless block ~ ~ ~ moss_carpet run setblock ~ ~ ~ air destroy
+execute if block ~ ~ ~ #gm4:foliage unless block ~ ~ ~ moss_carpet if block ~ ~ ~ #flowers if score ?break_flowers gm4_desire_lines matches 1 run setblock ~ ~ ~ air destroy
+execute if block ~ ~ ~ #gm4:foliage unless block ~ ~ ~ moss_carpet if block ~ ~ ~ #gm4:grass if score ?break_grass gm4_desire_lines matches 1 run setblock ~ ~ ~ air destroy
 
 # advancement check
 execute if block ~ ~-0.07 ~ coarse_dirt run scoreboard players add @s gm4_dl_affcoarse 1


### PR DESCRIPTION
Players can now toggle on and off if flowers & grass blocks break or not using the `/function gm4_desire_lines:config` command
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5c995343-25a6-4a37-9859-e7d196f645e3" />