### PR TITLE
Add Hozz to contributors.json

### DIFF
--- a/gm4/contributors.json
+++ b/gm4/contributors.json
@@ -44,12 +44,12 @@
         "links":[]
     },
     {
-        "name":"Hozz",
-        "links":[]
-    },
-    {
         "name": "Fyid",
         "links": ["https://twitter.com/FyidRants"]
+    },
+    {
+        "name":"Hozz",
+        "links":[]
     },
     {
         "name": "JP12",


### PR DESCRIPTION
This has no visual effect anywhere since the website will display it without a link, but the contributors file should contain the name of every contributor.