### PR TITLE
Try the command-limit-tracer mod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,8 +102,8 @@ jobs:
             fabric_api_url: https://cdn.modrinth.com/data/P7dR8mSH/versions/dQ3p80zK/fabric-api-0.138.3%2B1.21.10.jar
             packtest_url: https://cdn.modrinth.com/data/XsKUhp45/versions/11yGLsYO/packtest-2.3-beta1-mc1.21.10.jar
           - version: '1.21.11'
-            fabric_server_url: https://meta.fabricmc.net/v2/versions/loader/1.21.11-rc2/0.18.1/1.1.0/server/jar
-            fabric_api_url: https://cdn.modrinth.com/data/P7dR8mSH/versions/RDb9rvBm/fabric-api-0.139.4%2B1.21.11.jar
+            fabric_server_url: https://meta.fabricmc.net/v2/versions/loader/1.21.11/0.18.4/1.1.1/server/jar
+            fabric_api_url: https://cdn.modrinth.com/data/P7dR8mSH/versions/DdVHbeR1/fabric-api-0.141.1%2B1.21.11.jar
             packtest_url: https://cdn.modrinth.com/data/XsKUhp45/versions/GN6fvTsW/packtest-2.4-beta2-mc1.21.11.jar
             command_limit_tracer_url: https://cdn.modrinth.com/data/Ao12dSbt/versions/UFQB7j6W/command-limit-tracer-0.1.0.jar
     name: 'test-${{ matrix.version }}'


### PR DESCRIPTION
Modrinth: https://modrinth.com/mod/command-limit-tracer. It shows debug lines like this:
```
[21:41:00] [Server thread/INFO]: Command execution stopped due to limit (executed 65536 commands)
[21:41:00] [Server thread/INFO]:   gm4_guidebook:player_db/setup/115016177
[21:41:00] [Server thread/INFO]:   gm4_guidebook:player_db/update/1413179790
[21:41:00] [Server thread/INFO]:   gm4_guidebook:potion_swords/rewards/unlock/usage
[21:41:00] [Server thread/INFO]:   gm4_guidebook:potion_swords/init_player_db
[21:41:00] [Server thread/INFO]:   gm4_guidebook:player_db/setup/115016177
[21:41:00] [Server thread/INFO]:   (20155 hidden calls)
[21:41:00] [Server thread/INFO]:   gm4_guidebook:player_db/setup/115016177
[21:41:00] [Server thread/INFO]:   gm4_guidebook:player_db/update/1413179790
[21:41:00] [Server thread/INFO]:   gm4_guidebook:potion_swords/rewards/unlock/usage
[21:41:00] [Server thread/INFO]:   gm4_guidebook:potion_swords/rewards/usage
[21:41:00] [Server thread/INFO]:   packtest:internal
```