### PR TITLE
fix guidebook infinite loop

### DIFF
--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_guidebook
 name: Guidebook
-version: 3.1.X
+version: 3.2.X
 
 data_pack:
   load: .

--- a/gm4_guidebook/data/gm4_guidebook/function/init.mcfunction
+++ b/gm4_guidebook/data/gm4_guidebook/function/init.mcfunction
@@ -19,7 +19,9 @@ scoreboard players reset $module_count gm4_guide
 #declare storage gm4_guidebook:pages
 schedule function gm4_guidebook:update_storage/setup_markers 1t
 
+scoreboard players set $ready gm4_guide 0
 schedule function #gm4_guidebook:setup_storage 5t
+schedule function gm4_guidebook:update_storage/mark_ready 6t
 
 data modify storage gm4_guidebook:register front_matter set value [{raw:["",{"translate":"gui.gm4.guidebook.page.intro","fallback": "","color": "white","font": "gm4:guidebook"},{"translate":"text.gm4.guidebook.introduction","fallback":"Introduction","underlined":true},{"text":"\n\n"},{"translate":"text.gm4.guidebook.letter","fallback":"This is a world unlike others. It appears that certain things work...differently to say the least.\n\nThis book will document discoveries regarding these new mechanics."},{"text":"\n\n> ","color":"#4AA0C7"},{"translate":"text.gm4.guidebook.refresh_findings","fallback":"Refresh Findings","color":"#4AA0C7","hover_event":{"action":"show_text","value":[{"translate":"text.gm4.guidebook.refresh_toc","fallback":"Refresh Table of Contents","color":"gold"}]},"click_event":{"action":"run_command","command":"/trigger gm4_guide set 1"}}]}]
 

--- a/gm4_guidebook/data/gm4_guidebook/function/update_storage/mark_ready.mcfunction
+++ b/gm4_guidebook/data/gm4_guidebook/function/update_storage/mark_ready.mcfunction
@@ -1,0 +1,6 @@
+# marks the module ready for advancements to be granted
+# @s = none
+# located at world spawn
+# run from gm4_guidebook:init
+
+scoreboard players set $ready gm4_guide 1

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -1499,6 +1499,18 @@ def generate_advancement(book: Book, section_index: int) -> Advancement | None:
         "score": "load.status"
       },
       "range": {"min": 1}
+    },
+    {
+      "condition": "minecraft:value_check",
+      "value": {
+        "type": "minecraft:score",
+        "target": {
+          "type": "minecraft:fixed",
+          "name": "$ready"
+        },
+        "score": "gm4_guide"
+      },
+      "range": {"min": 1}
     }
   ]
 


### PR DESCRIPTION
This adds a flag to let modules know when it's okay to start granting guidebook pages (via advancements). In addition to updating guidebook, all modules need to built and updated to have the fix applied, but this technically does not break old modules (those modules just keep the bug until it is updated), and thus is not a breaking change. 