### PR TITLE
Teleportation Anchors: replace display armor stand with item display

### DIFF
--- a/gm4_teleportation_anchors/beet.yaml
+++ b/gm4_teleportation_anchors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_teleportation_anchors
 name: Teleportation Anchors
-version: 1.7.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_teleportation_anchors/beet.yaml
+++ b/gm4_teleportation_anchors/beet.yaml
@@ -64,5 +64,7 @@ meta:
     credits:
       Creator:
         - BPR
+      Updated By:
+        - runcows
       Icon Design:
         - Hozz

--- a/gm4_teleportation_anchors/beet.yaml
+++ b/gm4_teleportation_anchors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_teleportation_anchors
 name: Teleportation Anchors
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_anchor.mcfunction
@@ -6,12 +6,20 @@
 # place dropper
 setblock ~ ~ ~ lodestone
 
-# summon display armor stand and marker entity
-summon armor_stand ~ ~-0.4 ~ {Small:1b,NoGravity:1b,Marker:1b,Invulnerable:1b,Invisible:1b,DisabledSlots:2039552,Tags:["gm4_no_edit","gm4_teleportation_anchor_stand","gm4_machine_stand","smithed.entity","smithed.strict","gm4_new_machine"],HasVisualFire:1b,CustomName:"gm4_teleportation_anchor_stand",equipment:{head:{id:"end_portal_frame",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_anchor"]}}}},Rotation:[0.0f,0.0f]}
+# summon display and marker entity
+summon minecraft:item_display ~ ~0.5 ~ {\
+  CustomName:"gm4_teleportation_anchor_display",\
+  Tags:["gm4_no_edit","gm4_teleportation_anchor_display","gm4_machine_display","smithed.entity","smithed.strict","gm4_new_machine"],\
+  item:{id:"end_portal_frame",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_anchor"]}}},\
+  item_display:head,\
+  brightness:{sky:15,block:15},\
+  Rotation:[0.0f,0.0f],\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+}
 summon marker ~ ~ ~ {Tags:["gm4_teleportation_anchor","gm4_machine_marker","smithed.block","smithed.entity","smithed.strict","gm4_new_machine"],CustomName:"gm4_teleportation_anchor",Rotation:[0.0f,0.0f]}
 
 # mark block as placed
 playsound minecraft:block.end_portal.spawn block @a[distance=..8] ~ ~ ~ 0.3 1.8
 scoreboard players set $placed_block gm4_machine_data 1
-scoreboard players set @e[distance=..2,tag=gm4_new_machine] gm4_entity_version 1
+scoreboard players set @e[distance=..2,tag=gm4_new_machine] gm4_entity_version 2
 tag @e[distance=..2] remove gm4_new_machine

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_anchor.mcfunction
@@ -3,18 +3,18 @@
 # located at the center of the placed block
 # run from gm4_teleportation_anchors:machine/verify_place_down
 
-# place dropper
+# place lodestone
 setblock ~ ~ ~ lodestone
 
 # summon display and marker entity
-summon minecraft:item_display ~ ~0.5 ~ {\
+summon minecraft:item_display ~ ~ ~ {\
   CustomName:"gm4_teleportation_anchor_display",\
   Tags:["gm4_no_edit","gm4_teleportation_anchor_display","gm4_machine_display","smithed.entity","smithed.strict","gm4_new_machine"],\
   item:{id:"end_portal_frame",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_anchor"]}}},\
   item_display:head,\
   brightness:{sky:15,block:15},\
   Rotation:[0.0f,0.0f],\
-  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.501f,0f],scale:[0.438,0.438,0.438]}\
 }
 summon marker ~ ~ ~ {Tags:["gm4_teleportation_anchor","gm4_machine_marker","smithed.block","smithed.entity","smithed.strict","gm4_new_machine"],CustomName:"gm4_teleportation_anchor",Rotation:[0.0f,0.0f]}
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_jammer.mcfunction
@@ -6,8 +6,16 @@
 # place dropper
 setblock ~ ~ ~ dropper[facing=up]{CustomName:{"translate":"gm4.second","fallback":"%1$s","with":[{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer"},[{"text":" ","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:offscreen"},{"translate":"gui.gm4.teleportation_jammer","fallback":"","font":"gm4:container_gui","color":"white"},{"text":" ","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:default","color":"#404040"}]]}}
 
-# summon display armor stand and marker entity
-summon armor_stand ~ ~-0.4 ~ {Small:1b,NoGravity:1b,Marker:1b,Invulnerable:1b,Invisible:1b,DisabledSlots:2039552,Tags:["gm4_no_edit","gm4_teleportation_jammer_stand","gm4_machine_stand","smithed.entity","smithed.strict","gm4_new_machine"],HasVisualFire:1b,CustomName:"gm4_teleportation_jammer_stand",equipment:{head:{id:"purpur_pillar",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_jammer"]}}}},Rotation:[0.0f,0.0f]}
+# summon display and marker entity
+summon minecraft:item_display ~ ~0.5 ~ {\
+  CustomName:"gm4_teleportation_jammer_display",\
+  Tags:["gm4_no_edit","gm4_teleportation_jammer_display","gm4_machine_display","smithed.entity","smithed.strict","gm4_new_machine"],\
+  item:{id:"purpur_pillar",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_jammer"]}}},\
+  item_display:head,\
+  brightness:{sky:15,block:15},\
+  Rotation:[0.0f,0.0f],\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+}
 summon marker ~ ~ ~ {Tags:["gm4_teleportation_jammer","gm4_machine_marker","smithed.block","smithed.entity","smithed.strict","gm4_new_machine"],CustomName:"gm4_teleportation_jammer",Rotation:[0.0f,0.0f]}
 
 # set id
@@ -17,5 +25,5 @@ execute store result score @e[type=marker,tag=gm4_new_machine,limit=1,distance=.
 playsound minecraft:block.chorus_flower.death block @a[distance=..8] ~ ~ ~ 100 1.3
 playsound minecraft:block.beacon.power_select block @a[distance=..8] ~ ~ ~ 0.3 0.3
 scoreboard players set $placed_block gm4_machine_data 1
-scoreboard players set @e[distance=..2,tag=gm4_new_machine] gm4_entity_version 1
+scoreboard players set @e[distance=..2,tag=gm4_new_machine] gm4_entity_version 2
 tag @e[distance=..2] remove gm4_new_machine

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/create_jammer.mcfunction
@@ -7,14 +7,14 @@
 setblock ~ ~ ~ dropper[facing=up]{CustomName:{"translate":"gm4.second","fallback":"%1$s","with":[{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer"},[{"text":" ","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:offscreen"},{"translate":"gui.gm4.teleportation_jammer","fallback":"","font":"gm4:container_gui","color":"white"},{"text":" ","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:half_invert"},{"translate":"container.gm4.teleportation_jammer","fallback":"Teleportation Jammer","font":"gm4:default","color":"#404040"}]]}}
 
 # summon display and marker entity
-summon minecraft:item_display ~ ~0.5 ~ {\
+summon minecraft:item_display ~ ~ ~ {\
   CustomName:"gm4_teleportation_jammer_display",\
   Tags:["gm4_no_edit","gm4_teleportation_jammer_display","gm4_machine_display","smithed.entity","smithed.strict","gm4_new_machine"],\
   item:{id:"purpur_pillar",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_jammer"]}}},\
   item_display:head,\
   brightness:{sky:15,block:15},\
   Rotation:[0.0f,0.0f],\
-  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.501f,0f],scale:[0.438,0.438,0.438]}\
 }
 summon marker ~ ~ ~ {Tags:["gm4_teleportation_jammer","gm4_machine_marker","smithed.block","smithed.entity","smithed.strict","gm4_new_machine"],CustomName:"gm4_teleportation_jammer",Rotation:[0.0f,0.0f]}
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
@@ -3,8 +3,9 @@
 # located at @s
 # run from gm4_teleportation_anchors:machine/verify_destroy
 
-# kill entities related to machine block
+# kill entities related to machine block (armor stand kill needed for legacy compat)
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_anchor_stand,limit=1,distance=..0.01]
+execute positioned ~ ~0.5 ~ run kill @e[type=item_display,tag=gm4_teleportation_anchor_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:lodestone",count:1}},nbt=!{Item:{components:{}}},limit=1,sort=nearest]
 kill @s
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
@@ -3,8 +3,9 @@
 # located at @s
 # run from gm4_teleportation_anchors:machine/verify_destroy
 
-# kill entities related to machine block (armor stand kill needed for legacy compat)
+# legacy armor stand clean up - TODO: remove this when we stop supporting the upgrade path
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_anchor_stand,limit=1,distance=..0.01]
+# kill entities related to machine block
 kill @e[type=item_display,tag=gm4_teleportation_anchor_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:lodestone",count:1}},nbt=!{Item:{components:{}}},limit=1,sort=nearest]
 kill @s

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_anchor.mcfunction
@@ -5,7 +5,7 @@
 
 # kill entities related to machine block (armor stand kill needed for legacy compat)
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_anchor_stand,limit=1,distance=..0.01]
-execute positioned ~ ~0.5 ~ run kill @e[type=item_display,tag=gm4_teleportation_anchor_display,limit=1,distance=..0.01]
+kill @e[type=item_display,tag=gm4_teleportation_anchor_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:lodestone",count:1}},nbt=!{Item:{components:{}}},limit=1,sort=nearest]
 kill @s
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
@@ -3,8 +3,9 @@
 # located at @s
 # run from gm4_teleportation_anchors:machine/verify_destroy
 
-# kill entities related to machine block (armor stand kill needed for legacy compat)
+# legacy armor stand cleanup - TODO: remove this when we stop supporting the upgrade path
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_jammer_stand,limit=1,distance=..0.01]
+# kill entities related to machine block
 kill @e[type=item_display,tag=gm4_teleportation_jammer_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:dropper",count:1,components:{}}},limit=1,sort=nearest]
 kill @s

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
@@ -3,8 +3,9 @@
 # located at @s
 # run from gm4_teleportation_anchors:machine/verify_destroy
 
-# kill entities related to machine block
+# kill entities related to machine block (armor stand kill needed for legacy compat)
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_jammer_stand,limit=1,distance=..0.01]
+execute positioned ~ ~0.5 ~ run kill @e[type=item_display,tag=gm4_teleportation_jammer_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:dropper",count:1,components:{}}},limit=1,sort=nearest]
 kill @s
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/machine/destroy_jammer.mcfunction
@@ -5,7 +5,7 @@
 
 # kill entities related to machine block (armor stand kill needed for legacy compat)
 execute positioned ~ ~-0.4 ~ run kill @e[type=armor_stand,tag=gm4_teleportation_jammer_stand,limit=1,distance=..0.01]
-execute positioned ~ ~0.5 ~ run kill @e[type=item_display,tag=gm4_teleportation_jammer_display,limit=1,distance=..0.01]
+kill @e[type=item_display,tag=gm4_teleportation_jammer_display,limit=1,distance=..0.01]
 execute store result score $dropped_item gm4_machine_data run kill @e[type=item,distance=..1,nbt={Age:0s,Item:{id:"minecraft:dropper",count:1,components:{}}},limit=1,sort=nearest]
 kill @s
 

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7.mcfunction
@@ -1,0 +1,9 @@
+# @s = player
+# at @s
+# run via upgrade paths util
+
+execute as @e[type=minecraft:armor_stand,tag=gm4_teleportation_anchor_stand] at @s positioned ~ ~0.4 ~ \
+  run function gm4_teleportation_anchors:upgrade_paths/1.7/create_item_display_anchor
+
+execute as @e[type=minecraft:armor_stand,tag=gm4_teleportation_jammer_stand] at @s positioned ~ ~0.4 ~ \
+  run function gm4_teleportation_anchors:upgrade_paths/1.7/create_item_display_jammer

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_anchor.mcfunction
@@ -1,0 +1,19 @@
+# @s = gm4_teleportation_anchor_stand armor stand
+# at center of block
+# run from upgrade_paths/1.7
+
+summon minecraft:item_display ~ ~0.5 ~ {\
+  CustomName:"gm4_teleportation_anchor_display",\
+  Tags:["gm4_no_edit","gm4_teleportation_anchor_display","gm4_machine_display","smithed.entity","smithed.strict"],\
+  item:{id:"end_portal_frame",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_anchor"]}}},\
+  item_display:head,\
+  brightness:{sky:15,block:15},\
+  Rotation:[0.0f,0.0f],\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+}
+
+# entity version
+execute positioned ~ ~0.5 ~ run scoreboard players set @e[type=item_display,tag=gm4_teleportation_anchor_display,distance=..0.01,limit=1] gm4_entity_version 2
+scoreboard players set @e[type=marker,tag=gm4_teleportation_anchor,distance=..0.01,limit=1] gm4_entity_version 2
+
+kill @s

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_anchor.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_anchor.mcfunction
@@ -2,18 +2,18 @@
 # at center of block
 # run from upgrade_paths/1.7
 
-summon minecraft:item_display ~ ~0.5 ~ {\
+summon minecraft:item_display ~ ~ ~ {\
   CustomName:"gm4_teleportation_anchor_display",\
   Tags:["gm4_no_edit","gm4_teleportation_anchor_display","gm4_machine_display","smithed.entity","smithed.strict"],\
   item:{id:"end_portal_frame",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_anchor"]}}},\
   item_display:head,\
   brightness:{sky:15,block:15},\
   Rotation:[0.0f,0.0f],\
-  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.501f,0f],scale:[0.438,0.438,0.438]}\
 }
 
 # entity version
-execute positioned ~ ~0.5 ~ run scoreboard players set @e[type=item_display,tag=gm4_teleportation_anchor_display,distance=..0.01,limit=1] gm4_entity_version 2
+scoreboard players set @e[type=item_display,tag=gm4_teleportation_anchor_display,distance=..0.01,limit=1] gm4_entity_version 2
 scoreboard players set @e[type=marker,tag=gm4_teleportation_anchor,distance=..0.01,limit=1] gm4_entity_version 2
 
 kill @s

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_jammer.mcfunction
@@ -2,18 +2,18 @@
 # at center of block
 # run from upgrade_paths/1.7
 
-summon minecraft:item_display ~ ~0.5 ~ {\
+summon minecraft:item_display ~ ~ ~ {\
   CustomName:"gm4_teleportation_jammer_display",\
   Tags:["gm4_no_edit","gm4_teleportation_jammer_display","gm4_machine_display","smithed.entity","smithed.strict"],\
   item:{id:"purpur_pillar",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_jammer"]}}},\
   item_display:head,\
   brightness:{sky:15,block:15},\
   Rotation:[0.0f,0.0f],\
-  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.501f,0f],scale:[0.438,0.438,0.438]}\
 }
 
 # entity version
-execute positioned ~ ~0.5 ~ run scoreboard players set @e[type=item_display,tag=gm4_teleportation_jammer_display,distance=..0.01,limit=1] gm4_entity_version 2
+scoreboard players set @e[type=item_display,tag=gm4_teleportation_jammer_display,distance=..0.01,limit=1] gm4_entity_version 2
 scoreboard players set @e[type=marker,tag=gm4_teleportation_jammer,distance=..0.01,limit=1] gm4_entity_version 2
 
 kill @s

--- a/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_jammer.mcfunction
+++ b/gm4_teleportation_anchors/data/gm4_teleportation_anchors/function/upgrade_paths/1.7/create_item_display_jammer.mcfunction
@@ -1,0 +1,19 @@
+# @s = gm4_teleportation_jammer_stand armor stand
+# at center of block
+# run from upgrade_paths/1.7
+
+summon minecraft:item_display ~ ~0.5 ~ {\
+  CustomName:"gm4_teleportation_jammer_display",\
+  Tags:["gm4_no_edit","gm4_teleportation_jammer_display","gm4_machine_display","smithed.entity","smithed.strict"],\
+  item:{id:"purpur_pillar",count:1,components:{"minecraft:custom_model_data":{"strings":["gm4_teleportation_anchors:block/teleportation_jammer"]}}},\
+  item_display:head,\
+  brightness:{sky:15,block:15},\
+  Rotation:[0.0f,0.0f],\
+  transformation:{left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],translation:[0f,0.001f,0f],scale:[0.438,0.438,0.438]}\
+}
+
+# entity version
+execute positioned ~ ~0.5 ~ run scoreboard players set @e[type=item_display,tag=gm4_teleportation_jammer_display,distance=..0.01,limit=1] gm4_entity_version 2
+scoreboard players set @e[type=marker,tag=gm4_teleportation_jammer,distance=..0.01,limit=1] gm4_entity_version 2
+
+kill @s


### PR DESCRIPTION
Replaces display armor stand with item display for Teleportation Anchors and Jammers.
Item displays are located at the center of the blocks, same place as the markers.

Aside from modernizing, this also fixes an issue with the resource pack that cropped up last version, where the small armor stand heads started rendering bigger. This meant that the places we used this had their models inflated a bit and no longer fit the block. This issue affects other modules too, just addressing this per module.

~~Due to the needed upgrade path, the minor version has been bumped. This is of note for https://github.com/Gamemode4Dev/GM4_Datapacks/pull/1256 where we want to bump all minor versions anyway.~~

I have tested the item display in game and it works as expected. I have not yet tested the upgrade path, but after combing over it for a while, I see no reason it shouldn't work. Will test soon though.