### PR TITLE
Improve Guidebook Item Resolver

### DIFF
--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -888,10 +888,10 @@ def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla) -> str:
   # prepare item tag for searching
   if ":" in item_tag:
     prefix, tag_target = item_tag.split(":")
+    prefix = prefix.removeprefix("#")
   else:
     prefix = ""
     tag_target = item_tag.removeprefix("#")
-  prefix = prefix.removeprefix("#")
 
   # open item tag
   if prefix == "minecraft" or prefix == "":

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -890,7 +890,11 @@ def get_item_from_tag(ctx: Context, item_tag: str|dict[str, Any], vanilla: Vanil
     target: str = item_tag["id"]
   else:
     target = item_tag
-  prefix, tag_target = target.split(":")
+  if ":" in target:
+    prefix, tag_target = target.split(":")
+  else:
+    prefix = ""
+    tag_target = target.removeprefix("#")
   prefix = prefix.removeprefix("#")
 
   # open item tag
@@ -944,7 +948,7 @@ def generate_recipe_display(recipe: str, ctx: Context) -> list[TextComponent]:
           elif ingr.startswith("#"):
             vanilla = ctx.inject(Vanilla)
             vanilla.minecraft_version = '1.21.11'
-            ingr = get_item_from_tag(ingr, vanilla)
+            ingr = get_item_from_tag(ctx, ingr, vanilla)
           ingredients.append(ingr)
 
   elif r["type"].removeprefix("minecraft:") == "crafting_shapeless":

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -887,7 +887,7 @@ Recursively reads item tags to find a single item to use
 def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla, searched: list[str] = []) -> str:
   # prepare item tag for searching
   if ":" in item_tag:
-    prefix, tag_target = item_tag.split(":")
+    prefix, tag_target = item_tag.split(":", maxsplit=1)
     prefix = prefix.removeprefix("#")
   else:
     prefix = ""

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -977,7 +977,7 @@ def generate_recipe_display(recipe: str, ctx: Context) -> list[TextComponent]:
       elif ingr.startswith("#"):
         vanilla = ctx.inject(Vanilla)
         vanilla.minecraft_version = '1.21.11'
-        ingr = get_item_from_tag(ingr, vanilla)
+        ingr = get_item_from_tag(ctx, ingr, vanilla)
       ingredients.append(ingr)
     while len(ingredients) < 9:
       ingredients.append("air")

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -884,17 +884,13 @@ def item_to_display(item: str, components: dict[str, Any] | None, ctx: Context) 
 """
 Recursively reads item tags to find a single item to use
 """
-def get_item_from_tag(ctx: Context, item_tag: str|dict[str, Any], vanilla: Vanilla) -> str:
+def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla) -> str:
   # prepare item tag for searching
-  if isinstance(item_tag, dict):
-    target: str = item_tag["id"]
-  else:
-    target = item_tag
-  if ":" in target:
-    prefix, tag_target = target.split(":")
+  if ":" in item_tag:
+    prefix, tag_target = item_tag.split(":")
   else:
     prefix = ""
-    tag_target = target.removeprefix("#")
+    tag_target = item_tag.removeprefix("#")
   prefix = prefix.removeprefix("#")
 
   # open item tag

--- a/gm4_guidebook/generate_guidebooks.py
+++ b/gm4_guidebook/generate_guidebooks.py
@@ -884,7 +884,7 @@ def item_to_display(item: str, components: dict[str, Any] | None, ctx: Context) 
 """
 Recursively reads item tags to find a single item to use
 """
-def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla) -> str:
+def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla, searched: list[str] = []) -> str:
   # prepare item tag for searching
   if ":" in item_tag:
     prefix, tag_target = item_tag.split(":")
@@ -909,7 +909,10 @@ def get_item_from_tag(ctx: Context, item_tag: str, vanilla: Vanilla) -> str:
   # if first value is another tag, recursively search until an item is found
   if "#" not in res:
     return res
-  return get_item_from_tag(ctx, res, vanilla)
+  if res in searched:
+    raise ValueError("Cycle found in item tag")
+  searched.append(res)
+  return get_item_from_tag(ctx, res, vanilla, searched)
 
 
 

--- a/gm4_standard_crafting/data/gm4_standard_crafting/recipe/string.json
+++ b/gm4_standard_crafting/data/gm4_standard_crafting/recipe/string.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "category": "misc",
   "ingredients": [
-    "#wool"
+    "#minecraft:wool"
   ],
   "result": {
     "id": "minecraft:string",

--- a/gm4_standard_crafting/data/gm4_standard_crafting/recipe/string.json
+++ b/gm4_standard_crafting/data/gm4_standard_crafting/recipe/string.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "category": "misc",
   "ingredients": [
-    "#minecraft:wool"
+    "#wool"
   ],
   "result": {
     "id": "minecraft:string",


### PR DESCRIPTION
This PR adds the following changes to the guidebook item tag resolution (getting a single item from an item tag)
- supports non-vanilla tags
- supports {"id": "...", "required": false} entries in item tags (previously assumed strings)

Required for #1138 to build properly.