### PR TITLE
26.1 time query day repetition

### DIFF
--- a/gm4_mysterious_midnights/beet.yaml
+++ b/gm4_mysterious_midnights/beet.yaml
@@ -9,6 +9,9 @@ pipeline:
   - gm4.plugins.extend.module
   - gm4.plugins.include.lib_forceload
 
+require:
+  - bolt
+
 meta:
   gm4:
     versioning:

--- a/gm4_mysterious_midnights/data/gm4_mysterious_midnights/function/calculate_difficulty.mcfunction
+++ b/gm4_mysterious_midnights/data/gm4_mysterious_midnights/function/calculate_difficulty.mcfunction
@@ -2,6 +2,7 @@
 # at 29999998 1 7134 (forceloaded chunk)
 # run from gm4_mysterious_midnights:start_midnight
 
+# TODO: remove raw and bolt require later
 # generate random number from 0 to 15
 raw execute store result storage gm4_mysterious_midnights:temp day int 1 run time query day repetition
 function gm4_mysterious_midnights:roll_difficulty with storage gm4_mysterious_midnights:temp

--- a/gm4_mysterious_midnights/data/gm4_mysterious_midnights/function/calculate_difficulty.mcfunction
+++ b/gm4_mysterious_midnights/data/gm4_mysterious_midnights/function/calculate_difficulty.mcfunction
@@ -3,7 +3,7 @@
 # run from gm4_mysterious_midnights:start_midnight
 
 # generate random number from 0 to 15
-execute store result storage gm4_mysterious_midnights:temp day int 1 run time query day
+raw execute store result storage gm4_mysterious_midnights:temp day int 1 run time query day repetition
 function gm4_mysterious_midnights:roll_difficulty with storage gm4_mysterious_midnights:temp
 scoreboard players set 16 gm4_mm_data 16
 scoreboard players operation difficulty gm4_mm_data %= 16 gm4_mm_data

--- a/gm4_survival_refightalized/beet.yaml
+++ b/gm4_survival_refightalized/beet.yaml
@@ -8,6 +8,9 @@ data_pack:
 resource_pack:
   load: .
 
+require:
+  - bolt
+
 pipeline:
   - gm4.plugins.extend.module
   - gm4.plugins.include.lib_forceload

--- a/gm4_survival_refightalized/data/gm4_survival_refightalized/function/slow_clock.mcfunction
+++ b/gm4_survival_refightalized/data/gm4_survival_refightalized/function/slow_clock.mcfunction
@@ -1,5 +1,6 @@
 schedule function gm4_survival_refightalized:slow_clock 30s
 
+# TODO: remove raw and bolt require later
 # get moon cycle (0 = new moon, 4 = full moon)
 raw execute store result score $moon gm4_sr_data run time query day repetition
 scoreboard players operation $moon gm4_sr_data %= #8 gm4_sr_data

--- a/gm4_survival_refightalized/data/gm4_survival_refightalized/function/slow_clock.mcfunction
+++ b/gm4_survival_refightalized/data/gm4_survival_refightalized/function/slow_clock.mcfunction
@@ -1,7 +1,7 @@
 schedule function gm4_survival_refightalized:slow_clock 30s
 
 # get moon cycle (0 = new moon, 4 = full moon)
-execute store result score $moon gm4_sr_data run time query day
+raw execute store result score $moon gm4_sr_data run time query day repetition
 scoreboard players operation $moon gm4_sr_data %= #8 gm4_sr_data
 scoreboard players set $8 gm4_sr_data 8
 execute if score $moon gm4_sr_data matches ..3 store result score $moon gm4_sr_data run scoreboard players operation $8 gm4_sr_data -= $moon gm4_sr_data


### PR DESCRIPTION
With 26.1, `time query day` no longer gets the day count, but the ticks elapsed each day. The new format is `time query day repetition`, which this PR updates the modules untouched by #1274 to use. (This PR does NOT touch Calling Bell)

Currently, Mecha doesn't support this command structure, so this PR also prefixes the relevant commands with `raw ` and requires bolt. We can remove this later, once Mecha is updated; I've added a TODO comment to remind us.