### PR TITLE
26.1 Bump version numbers

### DIFF
--- a/base/beet.yaml
+++ b/base/beet.yaml
@@ -1,4 +1,4 @@
-version: 1.8.0
+version: 1.9.0
 id: gm4
 
 data_pack:

--- a/docs/making-a-module.md
+++ b/docs/making-a-module.md
@@ -58,8 +58,8 @@ meta:
     versioning:
       # A list of minimum-required versions for libraries or other modules
       required:
-        - lib_machines: 1.1.0
-        - gm4_bat_grenades: 1.2.0
+        - lib_machines: 1.5.0
+        - gm4_bat_grenades: 1.7.0
 
       # A list of any functions that create "schedule loop clocks". Necessary to turn off the module in case of a load failure
       schedule_loops:

--- a/gm4_animi_shamir/beet.yaml
+++ b/gm4_animi_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_animi_shamir
 name: Animi Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -18,8 +18,8 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
-        lib_player_death: 1.3.0
+        gm4_metallurgy: 1.8.0
+        lib_player_death: 1.4.0
       schedule_loops: [main]
     model_data:
       - reference: shamir/animi

--- a/gm4_apple_trees/beet.yaml
+++ b/gm4_apple_trees/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_apple_trees
 name: Apple Trees
-version: 2.5.X
+version: 2.6.X
 
 require:
   - bolt
@@ -19,7 +19,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_trees: 1.3.0
+        lib_trees: 1.5.0
       schedule_loops:
         - main
         - slow_clock

--- a/gm4_audere_shamir/beet.yaml
+++ b/gm4_audere_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_audere_shamir
 name: Audere Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
       schedule_loops: [main]
     model_data:
       - item: tools

--- a/gm4_balloon_animals/beet.yaml
+++ b/gm4_balloon_animals/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_balloon_animals
 name: Balloon Animals
-version: 1.3.X
+version: 1.4.X
 
 data_pack:
   load: .

--- a/gm4_bat_grenades/beet.yaml
+++ b/gm4_bat_grenades/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_bat_grenades
 name: Bat Grenades
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_better_armour_stands/beet.yaml
+++ b/gm4_better_armour_stands/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_better_armour_stands
 name: Better Armour Stands
-version: 2.5.X
+version: 2.6.X
 
 data_pack:
   load: .

--- a/gm4_block_compressors/beet.yaml
+++ b/gm4_block_compressors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_block_compressors
 name: Block Compressors
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: [main]
     translation_linter_ignores:
       - text.gm4.block_compressors.compressed

--- a/gm4_blossoming_pots/beet.yaml
+++ b/gm4_blossoming_pots/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_blossoming_pots
 name: Blossoming Pots
-version: 3.4.X
+version: 3.5.X
 
 data_pack:
   load: .

--- a/gm4_book_binders/beet.yaml
+++ b/gm4_book_binders/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_book_binders
 name: Book Binders
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_bookshelf_inspector/beet.yaml
+++ b/gm4_bookshelf_inspector/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_bookshelf_inspector
 name: Bookshelf Inspector
-version: 1.4.X
+version: 1.5.X
 
 data_pack:
   load: .

--- a/gm4_boots_of_ostara/beet.yaml
+++ b/gm4_boots_of_ostara/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_boots_of_ostara
 name: Boots of Ostara
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .

--- a/gm4_calling_bell/beet.yaml
+++ b/gm4_calling_bell/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_calling_bell
 name: Calling Bell
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_calling_bell/beet.yaml
+++ b/gm4_calling_bell/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_calling_bell
 name: Calling Bell
-version: 2.0.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_calling_bell/beet.yaml
+++ b/gm4_calling_bell/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_calling_bell
 name: Calling Bell
-version: 1.6.X
+version: 2.0.X
 
 data_pack:
   load: .

--- a/gm4_cement_mixers/beet.yaml
+++ b/gm4_cement_mixers/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_cement_mixers
 name: Cement Mixers
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -15,7 +15,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_liquid_tanks: 3.0.0
+        gm4_liquid_tanks: 3.1.0
     website:
       description: Allows Liquid Tanks to convert Concrete Powder items into Concrete, at the cost of ⅓ of a Bucket of Water per Concrete Powder.
       recommended: []

--- a/gm4_chairs/beet.yaml
+++ b/gm4_chairs/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_chairs
 name: Chairs
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_cooler_caves/beet.yaml
+++ b/gm4_cooler_caves/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_cooler_caves
 name: Cooler Caves
-version: 2.5.X
+version: 2.6.X
 
 data_pack:
   load: .

--- a/gm4_cozy_campfires/beet.yaml
+++ b/gm4_cozy_campfires/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_cozy_campfires
 name: Cozy Campfires
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_crossbow_cartridges/beet.yaml
+++ b/gm4_crossbow_cartridges/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_crossbow_cartridges
 name: Crossbow Cartridges
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .

--- a/gm4_dangerous_dungeons/beet.yaml
+++ b/gm4_dangerous_dungeons/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_dangerous_dungeons
 name: Dangerous Dungeons
-version: 2.5.X
+version: 2.6.X
 
 data_pack:
   load: .

--- a/gm4_desire_lines/beet.yaml
+++ b/gm4_desire_lines/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_desire_lines
 name: Desire Lines
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_disassemblers/beet.yaml
+++ b/gm4_disassemblers/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_disassemblers
 name: Disassemblers
-version: 2.5.X
+version: 2.6.X
 
 data_pack:
   load: .
@@ -17,8 +17,8 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
-        lib_forceload: 1.5.0
+        lib_machines: 1.5.0
+        lib_forceload: 1.6.0
       schedule_loops: [main]
     model_data:
       - item: player_head

--- a/gm4_display_frames/beet.yaml
+++ b/gm4_display_frames/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_display_frames
 name: Display Frames
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -13,7 +13,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_potion_tracking: 1.3.0
+        lib_potion_tracking: 1.4.0
       schedule_loops: [main]
     website:
       description: Splash item frames with invisibilty to make invisible item frames! Great for interior decor!

--- a/gm4_double_doors/beet.yaml
+++ b/gm4_double_doors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_double_doors
 name: Double Doors
-version: 1.3.X
+version: 1.4.X
 
 data_pack:
   load: .

--- a/gm4_dripleaf_filters/beet.yaml
+++ b/gm4_dripleaf_filters/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_dripleaf_filters
 name: Dripleaf Filters
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_dripleaf_launchers/beet.yaml
+++ b/gm4_dripleaf_launchers/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_dripleaf_launchers
 name: Dripleaf Launchers
-version: 1.4.X
+version: 1.5.X
 
 data_pack:
   load: .

--- a/gm4_end_fishing/beet.yaml
+++ b/gm4_end_fishing/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_end_fishing
 name: End Fishing
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_ender_hoppers/beet.yaml
+++ b/gm4_ender_hoppers/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_ender_hoppers
 name: Ender Hoppers
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: [main]
     model_data:
       - item: hopper_minecart

--- a/gm4_everstone/beet.yaml
+++ b/gm4_everstone/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_everstone
 name: Everstone
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_fulcio_shamir/beet.yaml
+++ b/gm4_fulcio_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_fulcio_shamir
 name: Fulcio Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
       schedule_loops:
         - main
         - 4_tick

--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_guidebook
 name: Guidebook
-version: 3.2.X
+version: 3.3.X
 
 data_pack:
   load: .
@@ -20,7 +20,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.5.0
+        lib_forceload: 1.6.0
       schedule_loops: 
         - main
         - tick

--- a/gm4_holographic_tags/beet.yaml
+++ b/gm4_holographic_tags/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_holographic_tags
 name: Holographic Tags
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_iacio_shamir/beet.yaml
+++ b/gm4_iacio_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_iacio_shamir
 name: Iacio Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
     model_data:
       - item: chestplates
         reference: shamir/iacio

--- a/gm4_ink_spitting_squid/beet.yaml
+++ b/gm4_ink_spitting_squid/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_ink_spitting_squid
 name: Ink Spitting Squid
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_lavish_livestock/beet.yaml
+++ b/gm4_lavish_livestock/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_lavish_livestock
 name: Lavish Livestock
-version: 1.0.0
+version: 1.1.0
 
 data_pack:
   load: .

--- a/gm4_lightning_in_a_bottle/beet.yaml
+++ b/gm4_lightning_in_a_bottle/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_lightning_in_a_bottle
 name: Lightning in a Bottle
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .
@@ -24,8 +24,8 @@ meta:
   gm4:
     versioning:
       required:
-        lib_potion_tracking: 1.3.0
-        lib_brewing: 1.4.0
+        lib_potion_tracking: 1.4.0
+        lib_brewing: 1.5.0
       schedule_loops:
         - main
         - brewing_stand/texture_connector/process

--- a/gm4_liquid_minecarts/beet.yaml
+++ b/gm4_liquid_minecarts/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_liquid_minecarts
 name: Liquid Minecarts
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .
@@ -16,8 +16,8 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_liquid_tanks: 3.0.0
-        lib_machines: 1.4.0
+        gm4_liquid_tanks: 3.1.0
+        lib_machines: 1.5.0
       schedule_loops: [main]
     model_data:
       - item: hopper_minecart

--- a/gm4_liquid_tanks/beet.yaml
+++ b/gm4_liquid_tanks/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_liquid_tanks
 name: Liquid Tanks
-version: 3.0.X
+version: 3.1.X
 
 data_pack:
   load: .
@@ -23,7 +23,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: [main]
     model_data:
       - item: player_head

--- a/gm4_live_catch/beet.yaml
+++ b/gm4_live_catch/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_live_catch
 name: Live Catch
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_lively_lily_pads/beet.yaml
+++ b/gm4_lively_lily_pads/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_lively_lily_pads
 name: Lively Lily Pads
-version: 3.1.X
+version: 3.2.X
 
 data_pack:
   load: .

--- a/gm4_lumos_shamir/beet.yaml
+++ b/gm4_lumos_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_lumos_shamir
 name: Lumos Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
       schedule_loops: [main]
     model_data:
       - item: [pickaxes, shovels]

--- a/gm4_mending_tanks/beet.yaml
+++ b/gm4_mending_tanks/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_mending_tanks
 name: Mending Tanks
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -12,7 +12,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_liquid_tanks: 3.0.0
+        gm4_liquid_tanks: 3.1.0
     website:
       description: Enables Liquid Tanks filled with Experience to repair tools with the mending enchant on them.
       recommended: []

--- a/gm4_metallurgy/beet.yaml
+++ b/gm4_metallurgy/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_metallurgy
 name: Metallurgy
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .
@@ -17,7 +17,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_lore: 1.3.0
+        lib_lore: 1.4.0
       schedule_loops:
         - main
         - tick

--- a/gm4_midnight_menaces/beet.yaml
+++ b/gm4_midnight_menaces/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_midnight_menaces
 name: Midnight Menaces
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -12,7 +12,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_mysterious_midnights: 1.7.0
+        gm4_mysterious_midnights: 1.8.0
       schedule_loops: [main]
     website:
       description: Adds 7 new events to Mysterious Midnights! From nights with merging Slimes to scary Illusioners -- this is a variety pack you shouldn't miss out on!

--- a/gm4_monsters_unbound/beet.yaml
+++ b/gm4_monsters_unbound/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_monsters_unbound
 name: Monsters Unbound
-version: 1.1.X
+version: 1.2.X
 
 data_pack:
   load: .
@@ -17,8 +17,8 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.3.0
-        lib_lore: 1.1.0
+        lib_forceload: 1.6.0
+        lib_lore: 1.4.0
       schedule_loops: 
         - tick
         - main

--- a/gm4_mysterious_midnights/beet.yaml
+++ b/gm4_mysterious_midnights/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_mysterious_midnights
 name: Mysterious Midnights
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.5.0
+        lib_forceload: 1.6.0
       schedule_loops: [main]
     model_data:
       - item: end_stone

--- a/gm4_note_block_interface/beet.yaml
+++ b/gm4_note_block_interface/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_note_block_interface
 name: Note Block Interface
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_orb_of_ankou/beet.yaml
+++ b/gm4_orb_of_ankou/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_orb_of_ankou
 name: Orb of Ankou
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .
@@ -21,8 +21,8 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
-        lib_player_motion: 1.0.0
+        gm4_metallurgy: 1.8.0
+        lib_player_motion: 1.1.0
       schedule_loops:
         - main
         - tick

--- a/gm4_particles_pack/beet.yaml
+++ b/gm4_particles_pack/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_particles_pack
 name: Particles Pack
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .
@@ -13,7 +13,7 @@ meta:
     versioning:
       schedule_loops: [main]
       required:
-        gm4_better_armour_stands: 2.5.0
+        gm4_better_armour_stands: 2.6.0
     website:
       description: Fireflies to flames, add some pezazz to your projects! Allows you to turn Armour Stands into particle sources that you control!
       recommended:

--- a/gm4_percurro_shamir/beet.yaml
+++ b/gm4_percurro_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_percurro_shamir
 name: Percurro Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
     model_data:
       - item: weapons
         reference: shamir/percurro

--- a/gm4_phantom_scarecrows/beet.yaml
+++ b/gm4_phantom_scarecrows/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_phantom_scarecrows
 name: Phantom Scarecrows
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_pig_tractors/beet.yaml
+++ b/gm4_pig_tractors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_pig_tractors
 name: Pig Tractors
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .

--- a/gm4_podzol_rooting_soil/beet.yaml
+++ b/gm4_podzol_rooting_soil/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_podzol_rooting_soil
 name: Podzol Rooting Soil
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_potion_liquids/beet.yaml
+++ b/gm4_potion_liquids/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_potion_liquids
 name: Potion Liquids
-version: 1.9.X
+version: 1.10.X
 
 data_pack:
   load: .
@@ -21,8 +21,8 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_liquid_tanks: 3.0.0
-        lib_brewing: 1.4.0
+        gm4_liquid_tanks: 3.1.0
+        lib_brewing: 1.5.0
     model_data:
       - item: potion
         reference: gui/advancement/potion_liquids

--- a/gm4_reeling_rods/beet.yaml
+++ b/gm4_reeling_rods/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_reeling_rods
 name: Reeling Rods
-version: 1.0.X
+version: 1.1.X
 
 data_pack:
   load: .

--- a/gm4_rope_ladders/beet.yaml
+++ b/gm4_rope_ladders/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_rope_ladders
 name: Rope Ladders
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .

--- a/gm4_scuba_gear/beet.yaml
+++ b/gm4_scuba_gear/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_scuba_gear
 name: SCUBA Gear
-version: 2.0.X
+version: 2.1.X
 
 data_pack:
   load: .

--- a/gm4_shapeless_portals/beet.yaml
+++ b/gm4_shapeless_portals/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_shapeless_portals
 name: Shapeless Portals
-version: 1.3.X
+version: 1.4.X
 
 data_pack:
   load: .

--- a/gm4_shroomites/beet.yaml
+++ b/gm4_shroomites/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_shroomites
 name: Shroomites
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_smelteries/beet.yaml
+++ b/gm4_smelteries/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_smelteries
 name: Smelteries
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .
@@ -17,7 +17,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: [main]
     
     gui_fonts:

--- a/gm4_soul_glass/beet.yaml
+++ b/gm4_soul_glass/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_soul_glass
 name: Soul Glass
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -13,7 +13,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: 
         - main
         - beacon_clock

--- a/gm4_spawner_minecarts/beet.yaml
+++ b/gm4_spawner_minecarts/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_spawner_minecarts
 name: Spawner Minecarts
-version: 3.0.X
+version: 3.1.X
 
 data_pack:
   load: .

--- a/gm4_speed_paths/beet.yaml
+++ b/gm4_speed_paths/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_speed_paths
 name: Speed Paths
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_standard_crafting/beet.yaml
+++ b/gm4_standard_crafting/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_standard_crafting
 name: Standard Crafting
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .

--- a/gm4_standard_crafting/beet.yaml
+++ b/gm4_standard_crafting/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_standard_crafting
 name: Standard Crafting
-version: 1.8.X
+version: 2.0.X
 
 data_pack:
   load: .

--- a/gm4_sunken_treasure/beet.yaml
+++ b/gm4_sunken_treasure/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_sunken_treasure
 name: Sunken Treasure
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .

--- a/gm4_survival_refightalized/beet.yaml
+++ b/gm4_survival_refightalized/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_survival_refightalized
 name: Survival Refightalized
-version: 1.1.X
+version: 1.2.X
 
 data_pack:
   load: .
@@ -20,8 +20,8 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.3.0
-        lib_lore: 1.1.0
+        lib_forceload: 1.6.0
+        lib_lore: 1.4.0
       schedule_loops: 
         - tick
         - main

--- a/gm4_sweethearts/beet.yaml
+++ b/gm4_sweethearts/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_sweethearts
 name: Sweethearts
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_teleportation_anchors/beet.yaml
+++ b/gm4_teleportation_anchors/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_teleportation_anchors
 name: Teleportation Anchors
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops:
         - main
         - tick

--- a/gm4_tower_structures/beet.yaml
+++ b/gm4_tower_structures/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_tower_structures
 name: Tower Structures
-version: 3.5.X
+version: 3.6.X
 
 data_pack:
   load: .

--- a/gm4_towering_trees/beet.yaml
+++ b/gm4_towering_trees/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_towering_trees
 name: Towering Trees
-version: 1.0.X
+version: 1.1.X
 
 data_pack:
   load: .
@@ -14,7 +14,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_trees: 1.4.0
+        lib_trees: 1.5.0
     website:
       description: Adds mega and small tree variants to any sapling that is missing one!
       recommended:

--- a/gm4_tunnel_bores/beet.yaml
+++ b/gm4_tunnel_bores/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_tunnel_bores
 name: Tunnel Bores
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_machines: 1.4.0
+        lib_machines: 1.5.0
       schedule_loops: [pulse_check]
     model_data:
       - item: furnace_minecart

--- a/gm4_undead_players/beet.yaml
+++ b/gm4_undead_players/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_undead_players
 name: Undead Players
-version: 1.7.X
+version: 1.8.X
 
 data_pack:
   load: .
@@ -13,7 +13,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_player_death: 1.3.0
+        lib_player_death: 1.4.0
       schedule_loops: [main]
     model_data:
       - item: zombie_head

--- a/gm4_vecto_shamir/beet.yaml
+++ b/gm4_vecto_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_vecto_shamir
 name: Vecto Shamir
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
       schedule_loops: [main]
     model_data:
       - item: boots

--- a/gm4_vertical_rails/beet.yaml
+++ b/gm4_vertical_rails/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_vertical_rails
 name: Vertical Rails
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/gm4_vigere_shamir/beet.yaml
+++ b/gm4_vigere_shamir/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_vigere_shamir
 name: Vigere Shamir
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -16,7 +16,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_metallurgy: 1.5.0
+        gm4_metallurgy: 1.8.0
       schedule_loops: [main]
     model_data:
       - item: shield

--- a/gm4_washing_tanks/beet.yaml
+++ b/gm4_washing_tanks/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_washing_tanks
 name: Washing Tanks
-version: 1.5.X
+version: 1.6.X
 
 data_pack:
   load: .
@@ -15,7 +15,7 @@ meta:
   gm4:
     versioning:
       required:
-        gm4_liquid_tanks: 3.0.0
+        gm4_liquid_tanks: 3.1.0
     website:
       description: Die! Dye! Remove die from items in a Liquid Tank filled with Water, at the cost of ⅓ of a bucket.
       recommended: []

--- a/gm4_weighted_armour/beet.yaml
+++ b/gm4_weighted_armour/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_weighted_armour
 name: Weighted Armour
-version: 1.8.X
+version: 1.9.X
 
 data_pack:
   load: .

--- a/gm4_zauber_cauldrons/beet.yaml
+++ b/gm4_zauber_cauldrons/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_zauber_cauldrons
 name: Zauber Cauldrons
-version: 1.14.X
+version: 2.0.X
 
 data_pack:
   load: .

--- a/gm4_zauber_cauldrons/beet.yaml
+++ b/gm4_zauber_cauldrons/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_zauber_cauldrons
 name: Zauber Cauldrons
-version: 1.13.X
+version: 1.14.X
 
 data_pack:
   load: .
@@ -23,9 +23,9 @@ meta:
     minecraft: []
     versioning:
       required:
-        lib_forceload: 1.5.0
-        lib_brewing: 1.4.0
-        lib_potion_tracking: 1.3.0
+        lib_forceload: 1.6.0
+        lib_brewing: 1.5.0
+        lib_potion_tracking: 1.4.0
       schedule_loops:
         - main
         - cauldron/extra_items/process_bottled_vex_items

--- a/gm4_ziprails/beet.yaml
+++ b/gm4_ziprails/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_ziprails
 name: Ziprails
-version: 1.6.X
+version: 1.7.X
 
 data_pack:
   load: .

--- a/lib_brewing/beet.yaml
+++ b/lib_brewing/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_brewing
 name: Gamemode 4 Brewing
-version: 1.4.X
+version: 1.5.X
 description: Allows datapacks to replace custom potions with splash and lingering potions when brewed in a brewing stand.
 
 data_pack:

--- a/lib_forceload/beet.yaml
+++ b/lib_forceload/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_forceload
 name: Gamemode 4 Forceload
-version: 1.5.X
+version: 1.6.X
 description: lib_forceload is a mcfunction library adding a forceloaded chunk with common utlities.
 
 data_pack:

--- a/lib_lore/beet.yaml
+++ b/lib_lore/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_lore
 name: Gamemode 4 Lore
-version: 1.3.X
+version: 1.4.X
 description: Allows other datapacks to easily search, remove, insert, and replace lines of lore on items.
 
 data_pack:

--- a/lib_machines/beet.yaml
+++ b/lib_machines/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_machines
 name: Gamemode 4 Machines
-version: 1.4.X
+version: 1.5.X
 description: lib_machines is a mcfunction library that adds logic for placing and breaking custom blocks. 
 
 data_pack:
@@ -15,7 +15,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.5.0
+        lib_forceload: 1.6.0
       schedule_loops: [main]
       extra_version_injections:
         functions:

--- a/lib_player_death/beet.yaml
+++ b/lib_player_death/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_player_death
 name: Gamemode 4 Player Death
-version: 1.3.X
+version: 1.4.X
 
 data_pack:
   load: 

--- a/lib_player_motion/beet.yaml
+++ b/lib_player_motion/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_player_motion
 name: Gamemode 4 Player Motion
-version: 1.0.X
+version: 1.1.X
 
 data_pack:
   load: 
@@ -14,7 +14,7 @@ meta:
   gm4:
     versioning:
       required:
-        lib_forceload: 1.5.0
+        lib_forceload: 1.6.0
       schedule_loops: [internal/technical/tick]
     credits:
       Original Creator:

--- a/lib_potion_tracking/beet.yaml
+++ b/lib_potion_tracking/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_potion_tracking
 name: Gamemode 4 Potion Tracking
-version: 1.3.X
+version: 1.4.X
 description: Allows other datapacks to track thrown splash or lingering potions.
 
 data_pack:
@@ -15,7 +15,7 @@ meta:
   gm4:
     versioning:
       required: 
-        lib_forceload: 1.5.0
+        lib_forceload: 1.6.0
       extra_version_injections: 
         functions: [resolve_tick]
     smithed:

--- a/lib_trees/beet.yaml
+++ b/lib_trees/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_trees
 name: Gamemode 4 Trees
-version: 1.4.X
+version: 1.5.X
 description: A mcfunction library that facilitates the creation of custom trees.
 
 data_pack:

--- a/resource_pack/beet.yaml
+++ b/resource_pack/beet.yaml
@@ -1,6 +1,6 @@
 id: gm4_resource_pack
 name: Resource Pack
-version: 1.4.X
+version: 1.5.X
 
 resource_pack:
   load:


### PR DESCRIPTION
Bump all minor version numbers, excluding:
- Zauber Liquids, as even with #1262, it will remain in limbo, unless misode wants to update that too
- Lib Hooked Entity, since it's new

Bump specific major version numbers
- Zauber Cauldrons, since #1262 is significant
- ~~Calling Bell, since its basically a full rewrite, even if the module is quite small~~
- Standard Crafting, we're in a post-custom-crafters world 🎉

Also went through all beet.yaml `required:` fields and updated those to match current version numbers