### PR TITLE
Interaction `response:1b` -> `/swing`

### DIFF
--- a/gm4_lively_lily_pads/beet.yaml
+++ b/gm4_lively_lily_pads/beet.yaml
@@ -8,9 +8,6 @@ data_pack:
 pipeline:
   - gm4.plugins.extend.module
 
-require:
-  - bolt
-
 meta:
   gm4:
     versioning:

--- a/gm4_lively_lily_pads/beet.yaml
+++ b/gm4_lively_lily_pads/beet.yaml
@@ -1,12 +1,15 @@
 id: gm4_lively_lily_pads
 name: Lively Lily Pads
-version: 3.2.X
+version: 3.3.X
 
 data_pack:
   load: .
 
 pipeline:
   - gm4.plugins.extend.module
+
+require:
+  - bolt
 
 meta:
   gm4:

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/interact_rcd.mcfunction
@@ -11,6 +11,7 @@ scoreboard players set $offhand gm4_llp.data 0
 scoreboard players set $holding_lighter gm4_llp.data 0
 scoreboard players set $holding_candle gm4_llp.data 0
 scoreboard players set $ignited gm4_llp.data 0
+scoreboard players set $extinguished gm4_llp.data 0
 
 # item information
 execute if items entity @s weapon.mainhand #gm4_lively_lily_pads:candle_interactable run function gm4_lively_lily_pads:mechanics/interactions/candle/get_mainhand_data
@@ -20,9 +21,15 @@ execute unless score $mainhand gm4_llp.data matches 1 if items entity @s weapon.
 execute as @e[type=interaction,tag=gm4_llp_candle_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/candle/process_interaction
 
 # player effects
+# TODO: remove raw and bolt require when mecha is updated
+raw execute if score $extinguished gm4_llp.data matches 1 run swing @s mainhand
+
 execute if score $ignited gm4_llp.data matches 1 run function gm4_lively_lily_pads:mechanics/interactions/candle/find_igniter
+
 execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
 
 # reset
 scoreboard players reset $placement_success gm4_llp.data

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/interact_rcd.mcfunction
@@ -21,15 +21,14 @@ execute unless score $mainhand gm4_llp.data matches 1 if items entity @s weapon.
 execute as @e[type=interaction,tag=gm4_llp_candle_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/candle/process_interaction
 
 # player effects
-# TODO: remove raw and bolt require when mecha is updated
-raw execute if score $extinguished gm4_llp.data matches 1 run swing @s mainhand
+execute if score $extinguished gm4_llp.data matches 1 run swing @s mainhand
 
 execute if score $ignited gm4_llp.data matches 1 run function gm4_lively_lily_pads:mechanics/interactions/candle/find_igniter
 
 execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
+execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
+execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
 
 # reset
 scoreboard players reset $placement_success gm4_llp.data

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_fire_charge.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_fire_charge.mcfunction
@@ -3,8 +3,7 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
-# TODO: remove raw and bolt require when mecha is updated
-raw swing @s mainhand
+swing @s mainhand
 # sound
 playsound minecraft:item.firecharge.use player @a[distance=..16]
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_fire_charge.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_fire_charge.mcfunction
@@ -3,6 +3,8 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
+# TODO: remove raw and bolt require when mecha is updated
+raw swing @s mainhand
 # sound
 playsound minecraft:item.firecharge.use player @a[distance=..16]
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_flint_and_steel.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_flint_and_steel.mcfunction
@@ -3,8 +3,7 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
-# TODO: remove raw and bolt require when mecha is updated
-raw swing @s mainhand
+swing @s mainhand
 # sound
 playsound minecraft:item.flintandsteel.use player @a[distance=..16] ~ ~ ~
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_flint_and_steel.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_mainhand_flint_and_steel.mcfunction
@@ -3,6 +3,8 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
+# TODO: remove raw and bolt require when mecha is updated
+raw swing @s mainhand
 # sound
 playsound minecraft:item.flintandsteel.use player @a[distance=..16] ~ ~ ~
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_fire_charge.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_fire_charge.mcfunction
@@ -3,8 +3,7 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
-# TODO: remove raw and bolt require when mecha is updated
-raw swing @s offhand
+swing @s offhand
 # sound
 playsound minecraft:item.firecharge.use player @a[distance=..16]
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_fire_charge.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_fire_charge.mcfunction
@@ -3,6 +3,8 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
+# TODO: remove raw and bolt require when mecha is updated
+raw swing @s offhand
 # sound
 playsound minecraft:item.firecharge.use player @a[distance=..16]
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_flint_and_steel.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_flint_and_steel.mcfunction
@@ -3,6 +3,8 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
+# TODO: remove raw and bolt require when mecha is updated
+raw swing @s offhand
 # sound
 playsound minecraft:item.flintandsteel.use player @a[distance=..16] ~ ~ ~
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_flint_and_steel.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/candle/used_offhand_flint_and_steel.mcfunction
@@ -3,8 +3,7 @@
 # at @s
 # run from mechanics/interactions/candle/find_igniter
 
-# TODO: remove raw and bolt require when mecha is updated
-raw swing @s offhand
+swing @s offhand
 # sound
 playsound minecraft:item.flintandsteel.use player @a[distance=..16] ~ ~ ~
 

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/candles.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/candles.mcfunction
@@ -19,7 +19,7 @@ $summon minecraft:block_display ~ ~ ~ {\
     right_rotation:[0f,0f,0f,1f]\
   }\
 }
-summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,response:1b,Tags:["gm4_llp_candle_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
+summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,Tags:["gm4_llp_candle_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
 
 # sound
 playsound minecraft:block.candle.place block @a[distance=..16] ~ ~ ~

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/copper_lantern.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/copper_lantern.mcfunction
@@ -16,7 +16,7 @@ $summon minecraft:block_display ~ ~ ~ {\
     right_rotation:[0f,0f,0f,1f]\
   }\
 }
-summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,response:1b,Tags:["gm4_llp_unwaxed_copper_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
+summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,Tags:["gm4_llp_unwaxed_copper_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
 
 # light block
 setblock ~ ~1 ~ light[level=14] keep

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/interact_rcd.mcfunction
@@ -20,8 +20,11 @@ execute unless score $mainhand gm4_llp.data matches 1 if predicate gm4_lively_li
 execute as @e[type=interaction,tag=gm4_llp_placement_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/placement/process_interaction
 
 # remove item if successful
+# TODO: remove raw and bolt require when mecha is updated
 execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
 
 # reset
 scoreboard players reset $placement_success gm4_llp.data

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/interact_rcd.mcfunction
@@ -20,11 +20,10 @@ execute unless score $mainhand gm4_llp.data matches 1 if predicate gm4_lively_li
 execute as @e[type=interaction,tag=gm4_llp_placement_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/placement/process_interaction
 
 # remove item if successful
-# TODO: remove raw and bolt require when mecha is updated
 execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
+execute if score $placement_success gm4_llp.data matches 1 if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
+execute if score $placement_success gm4_llp.data matches 1 if score $offhand gm4_llp.data matches 1 run swing @s offhand
 
 # reset
 scoreboard players reset $placement_success gm4_llp.data

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/waxed_copper_lantern.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/placement/waxed_copper_lantern.mcfunction
@@ -16,7 +16,7 @@ $summon minecraft:block_display ~ ~ ~ {\
     right_rotation:[0f,0f,0f,1f]\
   }\
 }
-summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,response:1b,Tags:["gm4_llp_waxed_copper_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
+summon minecraft:interaction ~ ~ ~ {width:0.4f,height:0.4f,Tags:["gm4_llp_waxed_copper_rcd","gm4_llp_perma_rcd","smithed.entity","smithed.strict"]}
 
 # light block
 setblock ~ ~1 ~ light[level=14] keep

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/unwaxed_copper_lantern/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/unwaxed_copper_lantern/interact_rcd.mcfunction
@@ -21,13 +21,12 @@ execute if items entity @s weapon.offhand honeycomb run scoreboard players set $
 execute as @e[type=interaction,tag=gm4_llp_unwaxed_copper_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/unwaxed_copper_lantern/process_interaction
 
 # item usage
-# TODO: remove raw and bolt require when mecha is updated
 execute if score $wax_used gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $wax_used gm4_llp.data matches 1 run swing @s mainhand
+execute if score $wax_used gm4_llp.data matches 1 run swing @s mainhand
 execute if score $wax_used gm4_llp.data matches 2 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
-raw execute if score $wax_used gm4_llp.data matches 2 run swing @s offhand
+execute if score $wax_used gm4_llp.data matches 2 run swing @s offhand
 
 execute if score $axe_used gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_mainhand_axe
-raw execute if score $axe_used gm4_llp.data matches 1 run swing @s mainhand
+execute if score $axe_used gm4_llp.data matches 1 run swing @s mainhand
 execute if score $axe_used gm4_llp.data matches 2 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_offhand_axe
-raw execute if score $axe_used gm4_llp.data matches 2 run swing @s offhand
+execute if score $axe_used gm4_llp.data matches 2 run swing @s offhand

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/unwaxed_copper_lantern/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/unwaxed_copper_lantern/interact_rcd.mcfunction
@@ -21,7 +21,13 @@ execute if items entity @s weapon.offhand honeycomb run scoreboard players set $
 execute as @e[type=interaction,tag=gm4_llp_unwaxed_copper_rcd,distance=..8] if data entity @s interaction at @s run function gm4_lively_lily_pads:mechanics/interactions/unwaxed_copper_lantern/process_interaction
 
 # item usage
+# TODO: remove raw and bolt require when mecha is updated
 execute if score $wax_used gm4_llp.data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $wax_used gm4_llp.data matches 1 run swing @s mainhand
 execute if score $wax_used gm4_llp.data matches 2 run item modify entity @s[gamemode=!creative] weapon.offhand {function:"minecraft:set_count",count:-1,add:1b}
+raw execute if score $wax_used gm4_llp.data matches 2 run swing @s offhand
+
 execute if score $axe_used gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_mainhand_axe
+raw execute if score $axe_used gm4_llp.data matches 1 run swing @s mainhand
 execute if score $axe_used gm4_llp.data matches 2 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_offhand_axe
+raw execute if score $axe_used gm4_llp.data matches 2 run swing @s offhand

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/waxed_copper_lantern/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/waxed_copper_lantern/interact_rcd.mcfunction
@@ -22,8 +22,7 @@ execute as @e[type=interaction,tag=gm4_llp_waxed_copper_rcd,distance=..8] if dat
 execute if score $scraped gm4_llp.data matches 0 run return fail
 
 # update axe durability
-# TODO: remove raw and bolt require when mecha is updated
 execute if score $mainhand gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_mainhand_axe
-raw execute if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
+execute if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $offhand gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_offhand_axe
-raw execute if score $offhand gm4_llp.data matches 1 run swing @s offhand
+execute if score $offhand gm4_llp.data matches 1 run swing @s offhand

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/waxed_copper_lantern/interact_rcd.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/interactions/waxed_copper_lantern/interact_rcd.mcfunction
@@ -22,5 +22,8 @@ execute as @e[type=interaction,tag=gm4_llp_waxed_copper_rcd,distance=..8] if dat
 execute if score $scraped gm4_llp.data matches 0 run return fail
 
 # update axe durability
+# TODO: remove raw and bolt require when mecha is updated
 execute if score $mainhand gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_mainhand_axe
+raw execute if score $mainhand gm4_llp.data matches 1 run swing @s mainhand
 execute if score $offhand gm4_llp.data matches 1 if entity @s[gamemode=!creative] run function gm4_lively_lily_pads:mechanics/interactions/waxed_copper_lantern/used_offhand_axe
+raw execute if score $offhand gm4_llp.data matches 1 run swing @s offhand

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/right_click_detection/create.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/mechanics/right_click_detection/create.mcfunction
@@ -3,5 +3,5 @@
 # at @s
 # run from mechanics/right_click_detection/found
 
-data merge entity @s {width:0.4f,height:0.3f,response:1b,Tags:["gm4_llp_placement_rcd","smithed.entity","smithed.strict"]}
+data merge entity @s {width:0.4f,height:0.3f,Tags:["gm4_llp_placement_rcd","smithed.entity","smithed.strict"]}
 scoreboard players operation @s gm4_llp.id = $player gm4_llp.id

--- a/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/upgrade_paths/3.3.mcfunction
+++ b/gm4_lively_lily_pads/data/gm4_lively_lily_pads/function/upgrade_paths/3.3.mcfunction
@@ -1,0 +1,6 @@
+# remove `response:1b` from gm4_llp_perma_rcd interactions
+# @s = player
+# at @s
+# run via upgrade paths util
+
+execute as @e[type=interaction,tag=gm4_llp_perma_rcd,nbt={response:1b}] run data modify entity @s response set value 0b

--- a/gm4_rope_ladders/beet.yaml
+++ b/gm4_rope_ladders/beet.yaml
@@ -8,9 +8,6 @@ data_pack:
 pipeline:
   - gm4.plugins.extend.module
 
-require:
-  - bolt
-
 meta:
   gm4:
     versioning:

--- a/gm4_rope_ladders/beet.yaml
+++ b/gm4_rope_ladders/beet.yaml
@@ -8,6 +8,9 @@ data_pack:
 pipeline:
   - gm4.plugins.extend.module
 
+require:
+  - bolt
+
 meta:
   gm4:
     versioning:

--- a/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/ladder_placement/successful_place.mcfunction
+++ b/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/ladder_placement/successful_place.mcfunction
@@ -7,9 +7,12 @@
 playsound minecraft:block.ladder.place ambient @a[distance=..15] ~ ~ ~
 
 # remove 1 ladder from players hand
+# TODO: remove raw and bolt require when mecha is updated
 execute store success score $mainhand gm4_rol_data if items entity @s weapon.mainhand ladder
 execute if score $mainhand gm4_rol_data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {"function": "minecraft:set_count","count": -1,"add": true}
+raw execute if score $mainhand gm4_rol_data matches 1 run swing @s mainhand
 execute if score $mainhand gm4_rol_data matches 0 run item modify entity @s[gamemode=!creative] weapon.offhand {"function": "minecraft:set_count","count": -1,"add": true}
+raw execute if score $mainhand gm4_rol_data matches 0 run swing @s offhand
 
 # grant advancement
 advancement grant @s only gm4:rope_ladders

--- a/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/ladder_placement/successful_place.mcfunction
+++ b/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/ladder_placement/successful_place.mcfunction
@@ -7,12 +7,11 @@
 playsound minecraft:block.ladder.place ambient @a[distance=..15] ~ ~ ~
 
 # remove 1 ladder from players hand
-# TODO: remove raw and bolt require when mecha is updated
 execute store success score $mainhand gm4_rol_data if items entity @s weapon.mainhand ladder
 execute if score $mainhand gm4_rol_data matches 1 run item modify entity @s[gamemode=!creative] weapon.mainhand {"function": "minecraft:set_count","count": -1,"add": true}
-raw execute if score $mainhand gm4_rol_data matches 1 run swing @s mainhand
+execute if score $mainhand gm4_rol_data matches 1 run swing @s mainhand
 execute if score $mainhand gm4_rol_data matches 0 run item modify entity @s[gamemode=!creative] weapon.offhand {"function": "minecraft:set_count","count": -1,"add": true}
-raw execute if score $mainhand gm4_rol_data matches 0 run swing @s offhand
+execute if score $mainhand gm4_rol_data matches 0 run swing @s offhand
 
 # grant advancement
 advancement grant @s only gm4:rope_ladders

--- a/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/right_click_detection/rcd_manager/create_rcd.mcfunction
+++ b/gm4_rope_ladders/data/gm4_rope_ladders/function/mechanics/right_click_detection/rcd_manager/create_rcd.mcfunction
@@ -4,7 +4,7 @@
 # run from function: gm4_rope_ladders:mechanics/right_click_detection/detect_ladder_raycast/found
 
 # init
-data merge entity @s {width:0.2f,height:1.05f,response:1b,Tags:["gm4_rol_rcd_ladder","smithed.entity","smithed.strict"]}
+data merge entity @s {width:0.2f,height:1.05f,Tags:["gm4_rol_rcd_ladder","smithed.entity","smithed.strict"]}
 scoreboard players operation @s gm4_rol_id = $player gm4_rol_id
 
 # start loop


### PR DESCRIPTION
For the interaction entities in Rope Ladders and Lively Lily Pads (`response` isn't used anywhere else), switches them to use the new `/swing` command.
This fixes a visual bug where using the offhand would still play a mainhand arm swing.

For Lively Lily Pads, this has meant upping the minor version (again💀) for an upgrade path to remove `response:1b` from existing interactions.

##### I'm not super happy with the number of repeated score checks here, but i was feeling lazy and didnt want to make ~10 new functions, each with just 2 commands....