### PR TITLE
fix mismatched player motion uuid

### DIFF
--- a/lib_player_motion/data/gm4_player_motion/function/internal/launch/exp_pos.mcfunction
+++ b/lib_player_motion/data/gm4_player_motion/function/internal/launch/exp_pos.mcfunction
@@ -1,3 +1,3 @@
 #> gm4_player_motion:internal/launch/exp_pos
-$tp 9a347e6c-1ce5-434a-b717-6707d51f4299f ^ ^ ^$(d)
+$tp 9a347e6c-1ce5-434a-b717-6707d51f4299 ^ ^ ^$(d)
 #   ^ (GM4) changed UUID to prevent potential conflict


### PR DESCRIPTION
very small fix to a function that never gets called, but I figured we might as well fix it in case we use it in the future (idk what the function is meant to be used for, but this keeps it consistent with the player motion library v1.4.2 which we are targeting).