### PR TITLE
New publishing pages linking

### DIFF
--- a/gm4_animi_shamir/beet.yaml
+++ b/gm4_animi_shamir/beet.yaml
@@ -35,6 +35,8 @@ meta:
         - Modifies items right after a player died, and might fight over those items with other Datapacks that do the same.
     modrinth:
       project_id: bPnAELDm
+    smithed:
+      pack_id: gm4_animi_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Animi_Shamir
     credits:
       Creator:

--- a/gm4_audere_shamir/beet.yaml
+++ b/gm4_audere_shamir/beet.yaml
@@ -31,6 +31,8 @@ meta:
       notes: []
     modrinth:
       project_id: 2rSIqoh7
+    smithed:
+      pack_id: gm4_audere_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Audere_Shamir
     credits:
       Creator:

--- a/gm4_balloon_animals/beet.yaml
+++ b/gm4_balloon_animals/beet.yaml
@@ -20,6 +20,8 @@ meta:
       description: Looking for exotic animals? This module makes some Wandering Traders sell cute baby animals!
     modrinth:
       project_id: zKRZZHQ3
+    smithed:
+      pack_id: gm4_balloon_animals
     wiki: https://wiki.gm4.co/wiki/Balloon_Animals
     credits:
       Creator:

--- a/gm4_block_compressors/beet.yaml
+++ b/gm4_block_compressors/beet.yaml
@@ -69,6 +69,8 @@ meta:
       notes: []
     modrinth:
       project_id: TSz8iiMD
+    smithed:
+      pack_id: gm4_block_compressors
     planetminecraft: 
       uid: 4344954
     video: https://www.youtube.com/watch?v=sdrTJYjL8C0

--- a/gm4_book_binders/beet.yaml
+++ b/gm4_book_binders/beet.yaml
@@ -35,12 +35,14 @@ meta:
         template: advancement
 
     website:
-      description: Start printing your own Enchanted Books with Book Binders. Use lecterns to exract singular pages from Enchanted Books and recombine pages with Leather to create your own Enchanted Books -- free of charge!
+      description: Start printing your own Enchanted Books with Book Binders. Use lecterns to extract singular pages from Enchanted Books and recombine pages with Leather to create your own Enchanted Books -- free of charge!
       recommended:
         - gm4_resource_pack
       notes: []
     modrinth:
       project_id: oIqNf2N4
+    smithed:
+      pack_id: gm4_book_binders
     wiki: https://wiki.gm4.co/wiki/Book_Binders
     credits:
       Creators:

--- a/gm4_boots_of_ostara/beet.yaml
+++ b/gm4_boots_of_ostara/beet.yaml
@@ -35,6 +35,8 @@ meta:
       notes: []
     modrinth:
       project_id: YCcs2E01
+    smithed:
+      pack_id: gm4_boots_of_ostara
     video: https://www.youtube.com/watch?v=H4UGM6_wGCE
     wiki: https://wiki.gm4.co/wiki/Boots_of_Ostara
     credits:

--- a/gm4_cement_mixers/beet.yaml
+++ b/gm4_cement_mixers/beet.yaml
@@ -22,6 +22,8 @@ meta:
       notes: []
     modrinth:
       project_id: blBLRC4i
+    smithed:
+      pack_id: gm4_cement_mixers
     video: https://www.youtube.com/watch?v=qa9lcbii1BE
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks/Cement_Mixers
     credits:

--- a/gm4_cooler_caves/beet.yaml
+++ b/gm4_cooler_caves/beet.yaml
@@ -19,6 +19,8 @@ meta:
       notes: []
     modrinth:
       project_id: juqV05HI
+    smithed:
+      pack_id: gm4_cooler_caves
     video: https://www.youtube.com/watch?v=cAsXiwLWHFo
     wiki: https://wiki.gm4.co/wiki/Orbis/Cooler_Caves
     credits:

--- a/gm4_cozy_campfires/beet.yaml
+++ b/gm4_cozy_campfires/beet.yaml
@@ -18,6 +18,8 @@ meta:
       notes: []
     modrinth:
       project_id: BKQjQlSY
+    smithed:
+      pack_id: gm4_cozy_campfires
     video: https://www.youtube.com/watch?v=nvAbzAtDFhw
     wiki: https://wiki.gm4.co/wiki/Cozy_Campfires
     credits:

--- a/gm4_dangerous_dungeons/beet.yaml
+++ b/gm4_dangerous_dungeons/beet.yaml
@@ -22,6 +22,8 @@ meta:
       notes: []
     modrinth:
       project_id: Go9VJGOZ
+    smithed:
+      pack_id: gm4_dangerous_dungeons
     wiki: https://wiki.gm4.co/wiki/Orbis/Dangerous_Dungeons
     credits:
       Creator:

--- a/gm4_disassemblers/beet.yaml
+++ b/gm4_disassemblers/beet.yaml
@@ -71,6 +71,8 @@ meta:
       notes: []
     modrinth:
       project_id: Cg5FQaTk
+    smithed:
+      pack_id: gm4_disassemblers
     wiki: https://wiki.gm4.co/wiki/Disassemblers
     credits:
       Creator:

--- a/gm4_display_frames/beet.yaml
+++ b/gm4_display_frames/beet.yaml
@@ -24,6 +24,8 @@ meta:
       notes: []
     modrinth:
       project_id: u59ticCz
+    smithed:
+      pack_id: gm4_display_frames
     wiki: https://wiki.gm4.co/wiki/Display_Frames
     credits:
       Creators:

--- a/gm4_dripleaf_filters/beet.yaml
+++ b/gm4_dripleaf_filters/beet.yaml
@@ -19,6 +19,8 @@ meta:
       notes: []
     modrinth:
       project_id: WNvo6RJr
+    smithed:
+      pack_id: gm4_dripleaf_filters
     wiki: https://wiki.gm4.co/wiki/Dripleaf_Filters
     credits:
       Creator:

--- a/gm4_end_fishing/beet.yaml
+++ b/gm4_end_fishing/beet.yaml
@@ -60,6 +60,8 @@ meta:
       notes: []
     modrinth:
       project_id: BbEwao9o
+    smithed:
+      pack_id: gm4_end_fishing
     wiki: https://wiki.gm4.co/wiki/End_Fishing
     credits:
       Creator:

--- a/gm4_fulcio_shamir/beet.yaml
+++ b/gm4_fulcio_shamir/beet.yaml
@@ -33,6 +33,8 @@ meta:
       notes: []
     modrinth:
       project_id: N09PsTgz
+    smithed:
+      pack_id: gm4_fulcio_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Fulcio_Shamir
     credits:
       Creators:

--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -45,6 +45,8 @@ meta:
         - gm4_resource_pack
       notes:
         - Experimental Module! Features may be added or removed without an easy upgrade path. You may encounter unintentional behaviour.
+    modrinth:
+      project_id: aHcF2nVP
     smithed:
       pack_id: gm4_guidebook
     wiki: https://wiki.gm4.co/wiki/Guidebook

--- a/gm4_guidebook/beet.yaml
+++ b/gm4_guidebook/beet.yaml
@@ -45,6 +45,8 @@ meta:
         - gm4_resource_pack
       notes:
         - Experimental Module! Features may be added or removed without an easy upgrade path. You may encounter unintentional behaviour.
+    smithed:
+      pack_id: gm4_guidebook
     wiki: https://wiki.gm4.co/wiki/Guidebook
     credits:
       Creators:

--- a/gm4_iacio_shamir/beet.yaml
+++ b/gm4_iacio_shamir/beet.yaml
@@ -30,6 +30,8 @@ meta:
       notes: []
     modrinth:
       project_id: DTk79ZcR
+    smithed:
+      pack_id: gm4_iacio_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Iacio_Shamir
     credits:
       Creator:

--- a/gm4_ink_spitting_squid/beet.yaml
+++ b/gm4_ink_spitting_squid/beet.yaml
@@ -25,6 +25,8 @@ meta:
       notes: []
     modrinth:
       project_id: ljOfYHJv
+    smithed:
+      pack_id: gm4_ink_spitting_squid
     planetminecraft:
       uid: 4581763
     video: https://www.youtube.com/watch?v=68LMYEhueZ0

--- a/gm4_lavish_livestock/beet.yaml
+++ b/gm4_lavish_livestock/beet.yaml
@@ -35,8 +35,8 @@ meta:
     video: null
     #modrinth: 
     #  project_id: 
-    #smithed:
-    #  pack_id: 
+    smithed:
+      pack_id: gm4_lavish_livestock
     #planetminecraft: 
     #  uid: 
     wiki: https://wiki.gm4.co/wiki/Lavish_Livestock

--- a/gm4_lavish_livestock/beet.yaml
+++ b/gm4_lavish_livestock/beet.yaml
@@ -33,8 +33,8 @@ meta:
         - gm4_pig_tractors
         - metallurgy
     video: null
-    #modrinth: 
-    #  project_id: 
+    modrinth:
+      project_id: 9K6xigHH
     smithed:
       pack_id: gm4_lavish_livestock
     #planetminecraft: 

--- a/gm4_lightning_in_a_bottle/beet.yaml
+++ b/gm4_lightning_in_a_bottle/beet.yaml
@@ -57,6 +57,8 @@ meta:
         - Brewing Stands may need to be broken and replaced to be able to craft Lightning in a Bottle when the module is first installed.
     modrinth:
       project_id: GVqJxowR
+    smithed:
+      pack_id: gm4_lightning_in_a_bottle
     wiki: https://wiki.gm4.co/wiki/Lightning_in_a_Bottle
     credits:
       Creator:

--- a/gm4_liquid_minecarts/beet.yaml
+++ b/gm4_liquid_minecarts/beet.yaml
@@ -35,6 +35,8 @@ meta:
       notes: []
     modrinth:
       project_id: Ymtg3OOc
+    smithed:
+      pack_id: gm4_liquid_minecarts
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks/Liquid_Minecarts
     credits:
       Creator:

--- a/gm4_liquid_tanks/beet.yaml
+++ b/gm4_liquid_tanks/beet.yaml
@@ -72,6 +72,8 @@ meta:
       notes: []
     modrinth:
       project_id: h4BcuD3C
+    smithed:
+      pack_id: gm4_liquid_tanks
     video: https://www.youtube.com/watch?v=qa9lcbii1BE
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks
     credits:

--- a/gm4_live_catch/beet.yaml
+++ b/gm4_live_catch/beet.yaml
@@ -24,6 +24,8 @@ meta:
         - fishing
     modrinth:
       project_id: uSXn7pVW
+    smithed:
+      pack_id: gm4_live_catch
     wiki: https://wiki.gm4.co/wiki/Live_Catch
     credits:
       Creator:

--- a/gm4_lumos_shamir/beet.yaml
+++ b/gm4_lumos_shamir/beet.yaml
@@ -31,6 +31,8 @@ meta:
       notes: []
     modrinth:
       project_id: vYbLApXc
+    smithed:
+      pack_id: gm4_lumos_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Lumos_Shamir
     credits:
       Creators:

--- a/gm4_mending_tanks/beet.yaml
+++ b/gm4_mending_tanks/beet.yaml
@@ -19,6 +19,8 @@ meta:
       notes: []
     modrinth:
       project_id: DPYixL7Y
+    smithed:
+      pack_id: gm4_mending_tanks
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks/Mending_Tanks
     credits:
       Creator:

--- a/gm4_metallurgy/beet.yaml
+++ b/gm4_metallurgy/beet.yaml
@@ -49,6 +49,8 @@ meta:
         - shamir
     modrinth:
       project_id: raWyrHxi
+    smithed:
+      pack_id: gm4_metallurgy
     wiki: https://wiki.gm4.co/wiki/Metallurgy
     credits:
       Creators:

--- a/gm4_midnight_menaces/beet.yaml
+++ b/gm4_midnight_menaces/beet.yaml
@@ -20,6 +20,8 @@ meta:
       notes: []
     modrinth:
       project_id: 9aTlLrlw
+    smithed:
+      pack_id: gm4_midnight_menaces
     wiki: https://wiki.gm4.co/wiki/Mysterious_Midnights/Midnight_Menaces
     credits:
       Creator:

--- a/gm4_monsters_unbound/beet.yaml
+++ b/gm4_monsters_unbound/beet.yaml
@@ -27,6 +27,8 @@ meta:
       description: Mobs gain special effects based on their biome.
       recommended:
         - gm4_survival_refightalized
+    smithed:
+      pack_id: gm4_monsters_unbound
     wiki: https://wiki.gm4.co/wiki/Monsters_Unbound
     credits:
       Creator:

--- a/gm4_monsters_unbound/beet.yaml
+++ b/gm4_monsters_unbound/beet.yaml
@@ -27,6 +27,8 @@ meta:
       description: Mobs gain special effects based on their biome.
       recommended:
         - gm4_survival_refightalized
+    modrinth:
+      project_id: 6EGin6pC
     smithed:
       pack_id: gm4_monsters_unbound
     wiki: https://wiki.gm4.co/wiki/Monsters_Unbound

--- a/gm4_mysterious_midnights/beet.yaml
+++ b/gm4_mysterious_midnights/beet.yaml
@@ -26,6 +26,8 @@ meta:
       notes: []
     modrinth:
       project_id: 9skST20d
+    smithed:
+      pack_id: gm4_mysterious_midnights
     wiki: https://wiki.gm4.co/wiki/Mysterious_Midnights
     credits:
       Creator:

--- a/gm4_orb_of_ankou/beet.yaml
+++ b/gm4_orb_of_ankou/beet.yaml
@@ -32,6 +32,8 @@ meta:
       notes: []
     modrinth:
       project_id: rRP5afZM
+    smithed:
+      pack_id: gm4_orb_of_ankou
     wiki: https://wiki.gm4.co/wiki/Orb_of_Ankou
     credits:
       Creator:

--- a/gm4_particles_pack/beet.yaml
+++ b/gm4_particles_pack/beet.yaml
@@ -21,6 +21,8 @@ meta:
       notes: []
     modrinth:
       project_id: hqLgWYiS
+    smithed:
+      pack_id: gm4_particles_pack
     video: https://www.youtube.com/watch?v=ZBqmGpAXqmw&t=238s
     wiki: https://wiki.gm4.co/wiki/Particles_Pack
     credits:

--- a/gm4_percurro_shamir/beet.yaml
+++ b/gm4_percurro_shamir/beet.yaml
@@ -30,6 +30,8 @@ meta:
       notes: []
     modrinth:
       project_id: MrSTch8u
+    smithed:
+      pack_id: gm4_percurro_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Percurro_Shamir
     credits:
       Creator:

--- a/gm4_phantom_scarecrows/beet.yaml
+++ b/gm4_phantom_scarecrows/beet.yaml
@@ -24,6 +24,8 @@ meta:
       notes: []
     modrinth:
       project_id: OQYrrgEP
+    smithed:
+      pack_id: gm4_phantom_scarecrows
     wiki: https://wiki.gm4.co/wiki/Phantom_Scarecrows
     credits:
       Creator:

--- a/gm4_pig_tractors/beet.yaml
+++ b/gm4_pig_tractors/beet.yaml
@@ -16,6 +16,8 @@ meta:
       notes: []
     modrinth:
       project_id: 8lN3MtcQ
+    smithed:
+      pack_id: gm4_pig_tractors
     model_data:
       - item: saddle
         reference: gui/advancement/pig_tractors

--- a/gm4_podzol_rooting_soil/beet.yaml
+++ b/gm4_podzol_rooting_soil/beet.yaml
@@ -17,6 +17,8 @@ meta:
       notes: []
     modrinth:
       project_id: keFbZ5iO
+    smithed:
+      pack_id: gm4_podzol_rooting_soil
     wiki: https://wiki.gm4.co/wiki/Podzol_Rooting_Soil
     credits:
       Creator:

--- a/gm4_potion_liquids/beet.yaml
+++ b/gm4_potion_liquids/beet.yaml
@@ -33,6 +33,8 @@ meta:
       notes: []
     modrinth:
       project_id: Z08l0oKH
+    smithed:
+      pack_id: gm4_potion_liquids
     video: https://www.youtube.com/watch?v=qa9lcbii1BE
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks/Potion_Liquids
     credits:

--- a/gm4_scuba_gear/beet.yaml
+++ b/gm4_scuba_gear/beet.yaml
@@ -23,6 +23,8 @@ meta:
         - This data pack requires you to use the Gamemode 4 resource pack! Restart the server/world after adding this data pack!
     modrinth:
       project_id: 6AVYWZgD
+    smithed:
+      pack_id: gm4_scuba_gear
     wiki: https://wiki.gm4.co/wiki/SCUBA_Gear
     credits:
       Creator:

--- a/gm4_shroomites/beet.yaml
+++ b/gm4_shroomites/beet.yaml
@@ -20,6 +20,8 @@ meta:
       notes: []
     modrinth:
       project_id: 7Rcai2W4
+    smithed:
+      pack_id: gm4_shroomites
     wiki: https://wiki.gm4.co/wiki/Shroomites
     credits:
       Creators:

--- a/gm4_smelteries/beet.yaml
+++ b/gm4_smelteries/beet.yaml
@@ -30,6 +30,8 @@ meta:
       notes: []
     modrinth:
       project_id: AHj8RSHk
+    smithed:
+      pack_id: gm4_smelteries
     wiki: https://wiki.gm4.co/wiki/smelteries
     credits:
       Creator:

--- a/gm4_soul_glass/beet.yaml
+++ b/gm4_soul_glass/beet.yaml
@@ -34,6 +34,8 @@ meta:
         - On versions <1.21, Blast Furnaces may need to be broken and replaced to be able to craft Soul Glass when the module is first installed.
     modrinth:
       project_id: Hi8fkYoI
+    smithed:
+      pack_id: gm4_soul_glass
     wiki: https://wiki.gm4.co/wiki/Soul_Glass
     credits:
       Creators:

--- a/gm4_spawner_minecarts/beet.yaml
+++ b/gm4_spawner_minecarts/beet.yaml
@@ -22,6 +22,8 @@ meta:
       notes: []
     modrinth:
       project_id: j4qeIaSW
+    smithed:
+      pack_id: gm4_spawner_minecarts
     wiki: https://wiki.gm4.co/wiki/Spawner_Minecarts
     credits:
       Creators:

--- a/gm4_speed_paths/beet.yaml
+++ b/gm4_speed_paths/beet.yaml
@@ -18,6 +18,8 @@ meta:
       notes: []
     modrinth:
       project_id: vRH8BKZ7
+    smithed:
+      pack_id: gm4_speed_paths
     video: https://www.youtube.com/watch?v=99VFSW1ORzU
     wiki: https://wiki.gm4.co/wiki/Speed_Paths
     credits:

--- a/gm4_standard_crafting/beet.yaml
+++ b/gm4_standard_crafting/beet.yaml
@@ -17,6 +17,8 @@ meta:
       notes: []
     modrinth:
       project_id: KIxK9MA7
+    smithed:
+      pack_id: gm4_standard_crafting
     video: https://www.youtube.com/watch?v=_GekIoefncg
     wiki: https://wiki.gm4.co/wiki/Standard_Crafting
     credits:

--- a/gm4_sunken_treasure/beet.yaml
+++ b/gm4_sunken_treasure/beet.yaml
@@ -40,6 +40,8 @@ meta:
       notes: []
     modrinth:
       project_id: drjgVlzU
+    smithed:
+      pack_id: gm4_sunken_treasure
     video: https://www.youtube.com/watch?v=VV7ZIyIzKV0
     wiki: https://wiki.gm4.co/wiki/Sunken_Treasure
     credits:

--- a/gm4_survival_refightalized/beet.yaml
+++ b/gm4_survival_refightalized/beet.yaml
@@ -27,6 +27,8 @@ meta:
       description: A reworked survival experience with more varied mobs and new armor and shield mechanics.
       recommended:
         - gm4_monsters_unbound
+    modrinth:
+      project_id: AyXb56yt
     smithed:
       pack_id: gm4_survival_refightalized
     wiki: https://wiki.gm4.co/wiki/Survival_Refightalized

--- a/gm4_survival_refightalized/beet.yaml
+++ b/gm4_survival_refightalized/beet.yaml
@@ -27,6 +27,8 @@ meta:
       description: A reworked survival experience with more varied mobs and new armor and shield mechanics.
       recommended:
         - gm4_monsters_unbound
+    smithed:
+      pack_id: gm4_survival_refightalized
     wiki: https://wiki.gm4.co/wiki/Survival_Refightalized
     credits:
       Creator:

--- a/gm4_sweethearts/beet.yaml
+++ b/gm4_sweethearts/beet.yaml
@@ -22,6 +22,8 @@ meta:
       notes: []
     modrinth:
       project_id: z33oiJCd
+    smithed:
+      pack_id: gm4_sweethearts
     planetminecraft: 
       uid: 5484554
     video: https://www.youtube.com/watch?v=mcopNZzY2dA

--- a/gm4_teleportation_anchors/beet.yaml
+++ b/gm4_teleportation_anchors/beet.yaml
@@ -60,6 +60,8 @@ meta:
       notes: []
     modrinth:
       project_id: CQkaELVA
+    smithed:
+      pack_id: gm4_teleportation_anchors
     wiki: https://wiki.gm4.co/wiki/Teleportation_Anchors
     credits:
       Creator:

--- a/gm4_tower_structures/beet.yaml
+++ b/gm4_tower_structures/beet.yaml
@@ -35,6 +35,8 @@ meta:
       notes: []
     modrinth:
       project_id: FvGL10DQ
+    smithed:
+      pack_id: gm4_tower_structures
     wiki: https://wiki.gm4.co/wiki/Orbis/Tower_Structures
     credits:
       Creator:

--- a/gm4_towering_trees/beet.yaml
+++ b/gm4_towering_trees/beet.yaml
@@ -19,6 +19,8 @@ meta:
       description: Adds mega and small tree variants to any sapling that is missing one!
       recommended:
         - gm4_metallurgy
+    modrinth:
+      project_id: ghmlkCsY
     smithed:
       pack_id: gm4_towering_trees
     wiki: https://wiki.gm4.co/wiki/Towering_Trees

--- a/gm4_towering_trees/beet.yaml
+++ b/gm4_towering_trees/beet.yaml
@@ -19,6 +19,8 @@ meta:
       description: Adds mega and small tree variants to any sapling that is missing one!
       recommended:
         - gm4_metallurgy
+    smithed:
+      pack_id: gm4_towering_trees
     wiki: https://wiki.gm4.co/wiki/Towering_Trees
     credits:
       Creator:

--- a/gm4_tunnel_bores/beet.yaml
+++ b/gm4_tunnel_bores/beet.yaml
@@ -35,6 +35,8 @@ meta:
       notes: []
     modrinth:
       project_id: L32wQVcn
+    smithed:
+      pack_id: gm4_tunnel_bores
     wiki: https://wiki.gm4.co/wiki/Tunnel_Bores
     credits:
       Creator:

--- a/gm4_undead_players/beet.yaml
+++ b/gm4_undead_players/beet.yaml
@@ -26,6 +26,8 @@ meta:
         - Modifies items right after a player died, and might fight over those items with other Datapacks that do the same.
     modrinth:
       project_id: jx6D06Q4
+    smithed:
+      pack_id: gm4_undead_players
     planetminecraft:
       uid: 4294228
     video: https://www.youtube.com/watch?v=dD8nChP8t9A

--- a/gm4_vecto_shamir/beet.yaml
+++ b/gm4_vecto_shamir/beet.yaml
@@ -31,6 +31,8 @@ meta:
       notes: []
     modrinth:
       project_id: wwe9xfEp
+    smithed:
+      pack_id: gm4_vecto_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Vecto_Shamir
     credits:
       Creator:

--- a/gm4_vertical_rails/beet.yaml
+++ b/gm4_vertical_rails/beet.yaml
@@ -24,6 +24,8 @@ meta:
       notes: []
     modrinth:
       project_id: PL3P0wBS
+    smithed:
+      pack_id: gm4_vertical_rails
     video: https://www.youtube.com/watch?v=LJoN7CmJL4Q
     wiki: https://wiki.gm4.co/wiki/Vertical_Rails
     credits:

--- a/gm4_vigere_shamir/beet.yaml
+++ b/gm4_vigere_shamir/beet.yaml
@@ -31,6 +31,8 @@ meta:
       notes: []
     modrinth:
       project_id: 9QdXJeGc
+    smithed:
+      pack_id: gm4_vigere_shamir
     wiki: https://wiki.gm4.co/wiki/Metallurgy/Vigere_Shamir
     credits:
       Creator:

--- a/gm4_washing_tanks/beet.yaml
+++ b/gm4_washing_tanks/beet.yaml
@@ -22,6 +22,8 @@ meta:
       notes: []
     modrinth:
       project_id: ipiZnkaE
+    smithed:
+      pack_id: gm4_washing_tanks
     wiki: https://wiki.gm4.co/wiki/Liquid_Tanks/Washing_Tanks
     credits:
       Creators:

--- a/gm4_weighted_armour/beet.yaml
+++ b/gm4_weighted_armour/beet.yaml
@@ -29,6 +29,8 @@ meta:
       notes: []
     modrinth:
       project_id: ReZCIa6j
+    smithed:
+      pack_id: gm4_weighted_armour
     video: https://www.youtube.com/watch?v=rVRSXTGQPbg
     wiki: https://wiki.gm4.co/wiki/Weighted_Armour
     credits:

--- a/gm4_zauber_cauldrons/beet.yaml
+++ b/gm4_zauber_cauldrons/beet.yaml
@@ -34,6 +34,8 @@ meta:
         - gm4_resource_pack
         - gm4_zauber_liquids
       notes: []
+    modrinth:
+      project_id: 3vluenrD
     smithed:
       pack_id: gm4_zauber_cauldrons
     video: https://www.youtube.com/watch?v=Io1JTFUzyrc

--- a/gm4_zauber_cauldrons/beet.yaml
+++ b/gm4_zauber_cauldrons/beet.yaml
@@ -34,6 +34,8 @@ meta:
         - gm4_resource_pack
         - gm4_zauber_liquids
       notes: []
+    smithed:
+      pack_id: gm4_zauber_cauldrons
     video: https://www.youtube.com/watch?v=Io1JTFUzyrc
     wiki: https://wiki.gm4.co/wiki/Zauber_Cauldrons
     credits:


### PR DESCRIPTION
This PR adds the Modrinth `project_id`s for:
- Guidebook
- Lavish Livestock
- Monsters Unbound
- Survival Refightalized
- Towering Trees
- Zauber Cauldrons

And the Smithed `pack_id`s for:
- gm4_animi_shamir
- gm4_audere_shamir
- gm4_balloon_animals
- gm4_block_compressors
- gm4_book_binders
- gm4_boots_of_ostara
- gm4_cement_mixers
- gm4_cooler_caves
- gm4_cozy_campfires
- gm4_dangerous_dungeons
- gm4_disassemblers
- gm4_display_frames
- ~~gm4_dripleaf_filters~~ (already existed, just connecting)
- gm4_end_fishing
- gm4_fulcio_shamir
- gm4_guidebook
- gm4_iacio_shamir
- gm4_ink_spitting_squid
- gm4_lavish_livestock
- gm4_lightning_in_a_bottle
- gm4_liquid_minecarts
- gm4_liquid_tanks
- gm4_live_catch
- gm4_lumos_shamir
- gm4_mending_tanks
- gm4_metallurgy
- gm4_midnight_menaces
- gm4_monsters_unbound
- gm4_mysterious_midnights
- gm4_orb_of_ankou
- gm4_particles_pack
- gm4_percurro_shamir
- gm4_phantom_scarecrows
- gm4_pig_tractors
- gm4_podzol_rooting_soil
- gm4_potion_liquids
- gm4_scuba_gear
- gm4_shroomites
- gm4_smelteries
- gm4_soul_glass
- gm4_spawner_minecarts
- gm4_speed_paths
- gm4_standard_crafting
- gm4_sunken_treasure
- gm4_survival_refightalized
- gm4_sweethearts
- gm4_teleportation_anchors
- gm4_towering_trees
- gm4_tower_structures
- gm4_tunnel_bores
- gm4_undead_players
- gm4_vecto_shamir
- gm4_vertical_rails
- gm4_vigere_shamir
- gm4_washing_tanks
- gm4_weighted_armour
- gm4_zauber_cauldrons