### PR TITLE
Disable Balloon Animals

### DIFF
--- a/gm4_balloon_animals/beet.yaml
+++ b/gm4_balloon_animals/beet.yaml
@@ -14,6 +14,7 @@ require:
 
 meta:
   gm4:
+    minecraft: []
     versioning:
       schedule_loops: [main]
     website:


### PR DESCRIPTION
Balloon Animals broke with 26.2

With 26.2, now Wandering Traders (and assumedly villagers as well) only generate trades on first conversation if there are no existing trade. Previously they would spawn with trades.

This complicates appending trades manually quite a lot. Realistically, Balloon Animals needs a design change to be in a non-broken and non-jank place.