### PR TITLE
Add a stick equivalent to the log chests recipe

### DIFF
--- a/gm4_standard_crafting/data/gm4_standard_crafting/advancement/recipes/log_sticks.json
+++ b/gm4_standard_crafting/data/gm4_standard_crafting/advancement/recipes/log_sticks.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "criteria": {
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "gm4_standard_crafting:log_sticks"
+            }
+        },
+        "has_materials": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": "#minecraft:logs"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_recipe",
+            "has_materials"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "gm4_standard_crafting:log_sticks"
+        ]
+    }
+}

--- a/gm4_standard_crafting/data/gm4_standard_crafting/recipe/log_sticks.json
+++ b/gm4_standard_crafting/data/gm4_standard_crafting/recipe/log_sticks.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "group": "sticks",
+  "key": {
+    "#": "#minecraft:logs"
+  },
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "result": {
+    "id": "minecraft:stick",
+    "count": 16
+  }
+}


### PR DESCRIPTION
This adds another qol crafting recipe that enables the player to craft sticks directly from logs.